### PR TITLE
Refactor scopes

### DIFF
--- a/src/formalargs.rs
+++ b/src/formalargs.rs
@@ -25,20 +25,18 @@ impl FormalArgs {
                    .iter()
                    .find(|&&(ref k, ref _v)| k.as_ref() == Some(name))
                    .map(|&(ref _k, ref v)| v) {
-                argscope.define(name, value, false);
+                argscope.define(name, value);
             } else if self.1 && i + 1 == n && args.0.len() > n {
                 let args =
                     args.0[i..].iter().map(|&(_, ref v)| v.clone()).collect();
                 argscope.define(name,
-                                &Value::List(args, ListSeparator::Comma),
-                                false);
+                                &Value::List(args, ListSeparator::Comma));
             } else {
                 argscope.define(name,
                                 match args.0.get(i) {
                                     Some(&(None, ref v)) => v,
                                     _ => default,
-                                },
-                                false);
+                                });
             }
         }
         argscope

--- a/src/formalargs.rs
+++ b/src/formalargs.rs
@@ -70,7 +70,7 @@ impl CallArgs {
     pub fn xyzzy(&self, scope: &mut Scope) -> Self {
         CallArgs(self.0
                      .iter()
-                     .map(|&(ref n, ref v)| (n.clone(), scope.evaluate(v)))
+                     .map(|&(ref n, ref v)| (n.clone(), v.evaluate(scope)))
                      .collect())
     }
 }

--- a/src/formalargs.rs
+++ b/src/formalargs.rs
@@ -29,8 +29,7 @@ impl FormalArgs {
             } else if self.1 && i + 1 == n && args.0.len() > n {
                 let args =
                     args.0[i..].iter().map(|&(_, ref v)| v.clone()).collect();
-                argscope.define(name,
-                                &Value::List(args, ListSeparator::Comma));
+                argscope.define(name, &Value::List(args, ListSeparator::Comma));
             } else {
                 argscope.define(name,
                                 match args.0.get(i) {

--- a/src/formalargs.rs
+++ b/src/formalargs.rs
@@ -17,10 +17,7 @@ impl FormalArgs {
         FormalArgs(a, is_varargs)
     }
 
-    pub fn eval<'a>(&self,
-                    scope: &'a mut Scope,
-                    args: &CallArgs)
-                    -> ScopeImpl<'a> {
+    pub fn eval<'a>(&self, scope: &'a Scope, args: &CallArgs) -> ScopeImpl<'a> {
         let mut argscope = ScopeImpl::sub(scope);
         let n = self.0.len();
         for (i, &(ref name, ref default)) in self.0.iter().enumerate() {
@@ -67,7 +64,7 @@ impl CallArgs {
         CallArgs(v)
     }
 
-    pub fn xyzzy(&self, scope: &mut Scope) -> Self {
+    pub fn xyzzy(&self, scope: &Scope) -> Self {
         CallArgs(self.0
                      .iter()
                      .map(|&(ref n, ref v)| (n.clone(), v.evaluate(scope)))

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -130,7 +130,7 @@ fn test_rgb() {
     use formalargs::call_args;
     use num_rational::Rational;
     use num_traits::{One, Zero};
-    use variablescope::ScopeImpl;
+    use variablescope::GlobalScope;
     assert_eq!(Ok(Value::Color(Rational::new(17, 1),
                                Rational::zero(),
                                Rational::new(225, 1),
@@ -139,7 +139,7 @@ fn test_rgb() {
                FUNCTIONS
                    .get("rgb")
                    .unwrap()
-                   .call(&mut ScopeImpl::new(),
+                   .call(&mut GlobalScope::new(),
                          &call_args(b"(17, 0, 225)").unwrap().1))
 }
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -73,10 +73,7 @@ impl SassFunction {
         SassFunction { args: args, body: FuncImpl::UserDefined(body) }
     }
 
-    pub fn call(&self,
-                scope: &mut Scope,
-                args: &CallArgs)
-                -> Result<Value, Error> {
+    pub fn call(&self, scope: &Scope, args: &CallArgs) -> Result<Value, Error> {
         let mut s = self.args.eval(scope, args);
         match self.body {
             FuncImpl::Builtin(ref body) => body(&s),

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -75,7 +75,11 @@ impl OutputStyle {
                 if *default {
                     globals.define_default(name, val, *global);
                 } else {
-                    globals.define(name, val, *global);
+                    if *global {
+                        globals.define_global(name, val);
+                    } else {
+                        globals.define(name, val);
+                    }
                 }
             }
             &SassItem::MixinDeclaration { ref name, ref args, ref body } => {
@@ -181,7 +185,7 @@ impl OutputStyle {
                     v => vec![v],
                 };
                 for value in values {
-                    globals.define(name, &value, false);
+                    globals.define(name, &value);
                     for item in body {
                         self.handle_root_item(item,
                                               globals,
@@ -203,7 +207,7 @@ impl OutputStyle {
                 let to = if inclusive { to + 1 } else { to };
                 for value in from..to {
                     let mut scope = ScopeImpl::sub(globals);
-                    scope.define(name, &Value::scalar(value), false);
+                    scope.define(name, &Value::scalar(value));
                     for item in body {
                         self.handle_root_item(item,
                                               &mut scope,
@@ -355,7 +359,11 @@ impl OutputStyle {
                     if default {
                         scope.define_default(name, val, global);
                     } else {
-                        scope.define(name, val, global);
+                        if global {
+                            scope.define_global(name, val);
+                        } else {
+                            scope.define(name, val);
+                        }
                     }
                 }
                 &SassItem::MixinDeclaration {
@@ -452,7 +460,7 @@ impl OutputStyle {
                     };
                     for value in values {
                         let mut scope = ScopeImpl::sub(scope);
-                        scope.define(name, &value, false);
+                        scope.define(name, &value);
                         self.handle_body(direct,
                                          sub,
                                          &mut scope,
@@ -474,7 +482,7 @@ impl OutputStyle {
                     let to = if inclusive { to + 1 } else { to };
                     for value in from..to {
                         let mut scope = ScopeImpl::sub(scope);
-                        scope.define(name, &Value::scalar(value), false);
+                        scope.define(name, &Value::scalar(value));
                         self.handle_body(direct,
                                          sub,
                                          &mut scope,

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -5,7 +5,7 @@ use std::ascii::AsciiExt;
 use std::fmt;
 use std::io::Write;
 use valueexpression::Value;
-use variablescope::{Scope, ScopeImpl};
+use variablescope::{GlobalScope, Scope, ScopeImpl};
 
 /// Selected target format.
 /// Only formats that are variants of this type are supported by rsass.
@@ -23,7 +23,7 @@ impl OutputStyle {
                       items: &[SassItem],
                       file_context: FileContext)
                       -> Result<Vec<u8>, Error> {
-        let mut globals = ScopeImpl::new();
+        let mut globals = GlobalScope::new();
         let mut result = Vec::new();
         let mut separate = false;
         for item in items {

--- a/src/valueexpression.rs
+++ b/src/valueexpression.rs
@@ -113,11 +113,11 @@ impl Value {
         }
     }
 
-    pub fn evaluate(&self, scope: &mut Scope) -> Value {
+    pub fn evaluate(&self, scope: &Scope) -> Value {
         self.do_evaluate(scope, false)
     }
     // TODO Maybe this should be private?
-    pub fn do_evaluate(&self, scope: &mut Scope, arithmetic: bool) -> Value {
+    pub fn do_evaluate(&self, scope: &Scope, arithmetic: bool) -> Value {
         match self {
             &Value::Literal(ref v, ref q) => {
                 Value::Literal(v.clone(), q.clone())

--- a/src/valueexpression.rs
+++ b/src/valueexpression.rs
@@ -116,7 +116,8 @@ impl Value {
     pub fn evaluate(&self, scope: &mut Scope) -> Value {
         self.do_evaluate(scope, false)
     }
-    fn do_evaluate(&self, scope: &mut Scope, arithmetic: bool) -> Value {
+    // TODO Maybe this should be private?
+    pub fn do_evaluate(&self, scope: &mut Scope, arithmetic: bool) -> Value {
         match self {
             &Value::Literal(ref v, ref q) => {
                 Value::Literal(v.clone(), q.clone())


### PR DESCRIPTION
Try to use less mutable references to Scopes.  Mainly, there should be no need for a mutable parent from a scope, as I want to be able to let a user-defined function capture the scope it is defined in as a parent, which means multiple scopes must be able to exist with the same parent.

Since `!global` definitions exists in sass, the global scope must still be internally mutable.  I aim to fix this with a `Mutex`.