### PR TITLE
Support user-defined functions in rust

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::string::FromUtf8Error;
 use valueexpression::Value;
 
+/// Most functions in rsass that returns a Result uses this Error type.
 #[derive(Debug)]
 pub enum Error {
     Input(PathBuf, io::Error),
@@ -22,6 +23,9 @@ impl Error {
                                 actual))
     }
 
+    /// Wrong kind of argument to a sass function.
+    /// `expected` is a string describing what the parameter should
+    /// have been, `actual` is the argument.
     pub fn badarg(expected: &str, actual: &Value) -> Error {
         Error::BadArguments(format!("expected {}, got {} = {}",
                                     expected,
@@ -29,6 +33,7 @@ impl Error {
                                     actual))
     }
 
+    /// Multiple-argument variant of `badarg`.
     pub fn badargs(expected: &[&str], actual: &[&Value]) -> Error {
         // TODO Better message!
         Error::BadArguments(format!("expected {:?}, got {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod unit;
 
 pub use error::Error;
 use formalargs::{CallArgs, FormalArgs, call_args, formal_args};
-use functions::SassFunction;
+pub use functions::SassFunction;
 pub use output_style::OutputStyle;
 use parseutil::{comment, name, opt_spacelike, spacelike};
 use selectors::{Selector, selector};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,11 @@ use functions::SassFunction;
 pub use output_style::OutputStyle;
 use parseutil::{comment, name, opt_spacelike, spacelike};
 use selectors::{Selector, selector};
-use valueexpression::{Value, single_value, value_expression};
+use valueexpression::{single_value, value_expression};
 #[cfg(test)]
 use valueexpression::ListSeparator;
+pub use valueexpression::Value;
+pub use variablescope::{GlobalScope, Scope};
 
 /// Parse scss data and write css in the given style.
 ///
@@ -87,7 +89,7 @@ pub fn compile_scss(input: &[u8],
                     -> Result<Vec<u8>, Error> {
     let file_context = FileContext::new();
     let items = parse_scss_data(input)?;
-    style.write_root(&items, file_context)
+    style.write_root(&items, &mut GlobalScope::new(), file_context)
 }
 
 /// Parse a file of scss data and write css in the given style.
@@ -110,7 +112,7 @@ pub fn compile_scss_file(file: &Path,
     let file_context = FileContext::new();
     let (sub_context, file) = file_context.file(file);
     let items = parse_scss_file(&file)?;
-    style.write_root(&items, sub_context)
+    style.write_root(&items, &mut GlobalScope::new(), sub_context)
 }
 
 /// A file context specifies where to find files to load.
@@ -167,7 +169,7 @@ pub fn parse_scss_file(file: &Path) -> Result<Vec<SassItem>, Error> {
     parse_scss_data(&data)
 }
 
-fn parse_scss_data(data: &[u8]) -> Result<Vec<SassItem>, Error> {
+pub fn parse_scss_data(data: &[u8]) -> Result<Vec<SassItem>, Error> {
     match sassfile(data) {
         IResult::Done(b"", items) => Ok(items),
         IResult::Done(rest, _styles) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,11 @@ mod unit;
 pub use error::Error;
 use formalargs::{CallArgs, FormalArgs, call_args, formal_args};
 pub use functions::SassFunction;
+pub use num_rational::Rational;
 pub use output_style::OutputStyle;
 use parseutil::{comment, name, opt_spacelike, spacelike};
 use selectors::{Selector, selector};
+pub use unit::Unit;
 use valueexpression::{single_value, value_expression};
 #[cfg(test)]
 use valueexpression::ListSeparator;
@@ -523,7 +525,6 @@ named!(body_block<Vec<SassItem>>,
 
 #[test]
 fn test_simple_property() {
-    use num_rational::Rational;
     let one = Rational::from_integer(1);
     fn r(v: u8) -> Rational {
         Rational::from_integer(v as isize)
@@ -546,8 +547,6 @@ fn test_property_2() {
 
 #[cfg(test)]
 fn percentage(v: isize) -> Value {
-    use num_rational::Rational;
-    use unit::Unit;
     Value::Numeric(Rational::from_integer(v), Unit::Percent, false)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,7 @@ use parseutil::{comment, name, opt_spacelike, spacelike};
 use selectors::{Selector, selector};
 pub use unit::Unit;
 use valueexpression::{single_value, value_expression};
-#[cfg(test)]
-use valueexpression::ListSeparator;
-pub use valueexpression::Value;
+pub use valueexpression::{ListSeparator, Quotes, Value};
 pub use variablescope::{GlobalScope, Scope};
 
 /// Parse scss data and write css in the given style.
@@ -610,6 +608,5 @@ fn test_variable_declaration_default() {
 
 #[cfg(test)]
 fn string(v: &str) -> Value {
-    use valueexpression::Quotes;
     Value::Literal(v.into(), Quotes::None)
 }

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -6,7 +6,7 @@ use std::ascii::AsciiExt;
 use std::fmt;
 use std::io::Write;
 use valueexpression::Value;
-use variablescope::{GlobalScope, Scope, ScopeImpl};
+use variablescope::{Scope, ScopeImpl};
 
 /// Selected target format.
 /// Only formats that are variants of this type are supported by rsass.
@@ -22,14 +22,14 @@ impl OutputStyle {
     /// in the sass file.
     pub fn write_root(&self,
                       items: &[SassItem],
+                      globals: &mut Scope,
                       file_context: FileContext)
                       -> Result<Vec<u8>, Error> {
-        let mut globals = GlobalScope::new();
         let mut result = Vec::new();
         let mut separate = false;
         for item in items {
             self.handle_root_item(item,
-                                  &mut globals,
+                                  globals,
                                   &mut separate,
                                   &file_context,
                                   &mut result)?;

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -7,10 +7,22 @@ use std::collections::BTreeMap;
 use std::sync::Mutex;
 use valueexpression::Value;
 
+/// Variables, functions and mixins are defined in a `Scope`.
+///
+/// A scope can be a local scope, e.g. in a function, or the global scope.
+/// All scopes except the global scope has a parent.
+/// The global scope is global to a sass document, multiple different
+/// global scopes may exists in the same rust-language process.
 pub trait Scope {
+    /// Define a variable with a value.
+    ///
+    /// The `$` sign is not included in `name`.
     fn define(&mut self, name: &str, val: &Value);
     fn define_default(&mut self, name: &str, val: &Value, global: bool);
+    /// Define a variable in the global scope that is an ultimate
+    /// parent of this scope.
     fn define_global(&self, name: &str, val: &Value);
+    /// Get the Value for a variable.
     fn get(&self, name: &str) -> Value;
     fn get_global(&self, name: &str) -> Value;
 

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -20,12 +20,12 @@ fn simple_value() {
 #[test]
 fn simple_function() {
     let mut scope = GlobalScope::new();
-    scope.define_function("get_answer",
-                          SassFunction::builtin(vec![],
-                                               false,
-                                               Arc::new(|_| {
-                                                   Ok(Value::scalar(42))
-                                               })));
+    scope.define_function(
+        "get_answer",
+        SassFunction::builtin(
+            vec![],
+            false,
+            Arc::new(|_| Ok(Value::scalar(42)))));
     let parsed = parse_scss_data(b"p { x: get_answer(); }").unwrap();
     let style = OutputStyle::Compressed;
     let file_context = FileContext::new();

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,6 +1,5 @@
 extern crate rsass;
-use rsass::{FileContext, GlobalScope, OutputStyle, SassFunction, Scope, Value,
-            parse_scss_data};
+use rsass::*;
 use std::sync::Arc;
 
 #[test]
@@ -34,4 +33,38 @@ fn simple_function() {
                    .and_then(|s| Ok(String::from_utf8(s)?))
                    .unwrap(),
                "p{x:42}\n");
+}
+
+#[test]
+fn function_with_args() {
+    let mut scope = GlobalScope::new();
+    scope.define_function("halfway",
+                          SassFunction::builtin(vec![("a".into(),
+                                                      Value::Null),
+                                                     ("b".into(),
+                                                      Value::scalar(0))],
+                                                false,
+                                                Arc::new(|s| {
+        let half = Rational::new(1, 2);
+        match (s.get("a"), s.get("b")) {
+            (Value::Numeric(a, au, _), Value::Numeric(b, bu, _)) => {
+                if au == bu || bu == Unit::None {
+                    Ok(Value::Numeric((a + b) * half, au, true))
+                } else if au == Unit::None {
+                    Ok(Value::Numeric((a + b) * half, bu, true))
+                } else {
+                    Err(Error::BadArguments("Incopatible args".into()))
+                }
+            }
+            (a, b) => Err(Error::badargs(&["number", "number"], &[&a, &b])),
+        }
+    })));
+    let parsed = parse_scss_data(b"p { x: halfway(10, 18); }").unwrap();
+    let style = OutputStyle::Compressed;
+    let file_context = FileContext::new();
+    assert_eq!(style
+                   .write_root(&parsed, &mut scope, file_context)
+                   .and_then(|s| Ok(String::from_utf8(s)?))
+                   .unwrap(),
+               "p{x:14}\n");
 }

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,0 +1,17 @@
+extern crate rsass;
+use rsass::{FileContext, GlobalScope, OutputStyle, Scope, Value,
+            parse_scss_data};
+
+#[test]
+fn simple_value() {
+    let mut scope = GlobalScope::new();
+    scope.define("color", &Value::black());
+    let parsed = parse_scss_data(b"p { color: $color }").unwrap();
+    let style = OutputStyle::Compressed;
+    let file_context = FileContext::new();
+    assert_eq!(style
+                   .write_root(&parsed, &mut scope, file_context)
+                   .and_then(|s| Ok(String::from_utf8(s)?))
+                   .unwrap(),
+               "p{color:black}\n");
+}

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,6 +1,7 @@
 extern crate rsass;
-use rsass::{FileContext, GlobalScope, OutputStyle, Scope, Value,
+use rsass::{FileContext, GlobalScope, OutputStyle, SassFunction, Scope, Value,
             parse_scss_data};
+use std::sync::Arc;
 
 #[test]
 fn simple_value() {
@@ -14,4 +15,23 @@ fn simple_value() {
                    .and_then(|s| Ok(String::from_utf8(s)?))
                    .unwrap(),
                "p{color:black}\n");
+}
+
+#[test]
+fn simple_function() {
+    let mut scope = GlobalScope::new();
+    scope.define_function("get_answer",
+                          SassFunction::builtin(vec![],
+                                               false,
+                                               Arc::new(|_| {
+                                                   Ok(Value::scalar(42))
+                                               })));
+    let parsed = parse_scss_data(b"p { x: get_answer(); }").unwrap();
+    let style = OutputStyle::Compressed;
+    let file_context = FileContext::new();
+    assert_eq!(style
+                   .write_root(&parsed, &mut scope, file_context)
+                   .and_then(|s| Ok(String::from_utf8(s)?))
+                   .unwrap(),
+               "p{x:42}\n");
 }


### PR DESCRIPTION
A program using rsass as a library should be able to define functions in rust. An example use-case is that [ructe](https://crates.io/crates/ructe) should be able to define a function to get the uniquified url of a static file.

This means that `Scope`s and the `Value` type needs to be public.