### PR TITLE
Add rls.toml so rls doesn’t get confused about bin/lib crates in same project

### DIFF
--- a/rls.toml
+++ b/rls.toml
@@ -1,0 +1,1 @@
+build_lib = true


### PR DESCRIPTION
This is a bug in rls it seems, and the workaround is quite simple, albeit a bit unfortunate.