### PR TITLE
Pin the rustfmt version to 0.8.4, closes #11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ matrix:
   include:
    - rust: stable
      env: TASK=rustfmt
-     script: cargo install -f rustfmt && PATH=${HOME}/.cargo/bin:$PATH cargo fmt
+     script: cargo install -f rustfmt --vers 0.8.4 && PATH=${HOME}/.cargo/bin:$PATH cargo fmt
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Choose the easy solution to #11 for now, resulting in less churn.