### PR TITLE
Redirect check_spec setup commands to stderr

### DIFF
--- a/check_spec
+++ b/check_spec
@@ -10,12 +10,12 @@
 #     ./check-spec stats
 #
 cd `dirname $0`
-cargo build --release --features=commandline
+cargo build --release --features=commandline >&2
 
 if [ -d sass-spec ]; then
-   (cd sass-spec && git fetch && git rebase origin/master --autostash)
+   (cd sass-spec && git fetch >&2 && git rebase origin/master --autostash >&2)
 else
-   git clone https://github.com/sass/sass-spec.git
+   git clone https://github.com/sass/sass-spec.git >&2
 fi
 
 cat > sass-spec/spec/output_styles/options.yml <<EOF


### PR DESCRIPTION
I've been doing some hacking here, and would really like a `diff` flow to make sure I don't introduce regressions. This is technically possible already, but the current setup commands for `check_spec` (i.e., `cargo` and `git` invocations to build the project and ensure that `sass-spec` is pulled down) print to `stdout` (which they normally should, of course). This PR merely redirects the output of those commands to `stderr` so one can get a more "clean" test failure report for `list_fails`.

```bash
$ git checkout master && ./check_spec > failed_tests_before.txt
$ git checkout my_crazy_experiments && ./check_spec > failed_tests_after.txt
$ diff -u failed_tests_before.txt