### PR TITLE
Manually specify `rg` input will be STDIN for `check_specs stats`

### DIFF
--- a/check_spec
+++ b/check_spec
@@ -68,7 +68,7 @@ case "$1" in
     "stats")
 	check \
             | rg --no-line-number '^([0-9]+) runs, ([0-9]+) assertions.*' \
-                 --replace 'Progress: ![$2](http://progressed.io/bar/$2?scale=$1&suffix=+) of $1 tests passed'
+                 --replace 'Progress: ![$2](http://progressed.io/bar/$2?scale=$1&suffix=+) of $1 tests passed' -
         ;;
     *)
         check $1 | list_fails


### PR DESCRIPTION
This fixes a broken pipe in Ruby on Windows when using MSYS2. :)