### PR TITLE
Support `@at-root`

### DIFF
--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -27,12 +27,12 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
             Value::List(v, _, _) => Ok(Value::Literal(
                 format!(
                     "{}",
-                    v.into_iter().map(parse_selectors,).fold(
+                    v.into_iter().map(parse_selectors).fold(
                         Selectors::root(),
-                        |base, ext| Selectors(
-                            base.0
+                        |base, ext| Selectors::new(
+                            base.s
                                 .into_iter()
-                                .flat_map(|b| ext.0.iter().map(move |e| {
+                                .flat_map(|b| ext.s.iter().map(move |e| {
                                     parse_selector(&format!("{}{}", b, e))
                                 })).collect()
                         ),

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -13,7 +13,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
                 "{}",
                 v.into_iter()
                     .map(parse_selectors)
-                    .fold(Selectors::root(), |b, e| e.inside(Some(&b))),
+                    .fold(Selectors::root(), |b, e| e.inside(&b)),
             ),
             Quotes::None,
         )),

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -110,7 +110,8 @@ impl OutputStyle {
                 ref selectors,
                 ref body,
             } => {
-                let selectors = eval_selectors(selectors, scope);
+                let selectors = eval_selectors(selectors, scope)
+                    .with_backref(scope.get_selectors().one());
                 let mut s1 = vec![];
                 let mut s2 = vec![];
                 self.handle_body(
@@ -381,7 +382,8 @@ impl OutputStyle {
                     ref selectors,
                     ref body,
                 } => {
-                    let selectors = eval_selectors(selectors, scope);
+                    let selectors = eval_selectors(selectors, scope)
+                        .with_backref(scope.get_selectors().one());
                     let mut s1 = vec![];
                     let mut s2 = vec![];
                     self.handle_body(
@@ -456,6 +458,7 @@ impl OutputStyle {
                             sub.write_all(&s2)?;
                         }
                         write!(sub, "}}")?;
+                        self.do_indent(sub, 0)?;
                     } else {
                         write!(sub, ";")?;
                     }
@@ -681,8 +684,8 @@ impl OutputStyle {
 }
 
 fn eval_selectors(s: &Selectors, scope: &Scope) -> Selectors {
-    let s = Selectors(
-        s.0.iter()
+    let s = Selectors::new(
+        s.s.iter()
             .map(|s| {
                 Selector(
                     s.0.iter()
@@ -725,7 +728,7 @@ fn eval_selectors(s: &Selectors, scope: &Scope) -> Selectors {
     // contain high-level selector separators (i.e. ","), so we need to
     // parse the selectors again, from a string representation.
     use parser::selectors::selectors;
-    selectors(Input(format!("{}", s).as_bytes())).unwrap().1
+    selectors(Input(format!("{} ", s).as_bytes())).unwrap().1
 }
 
 struct CssWriter {

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -116,10 +116,7 @@ impl OutputStyle {
                 self.handle_body(
                     &mut s1,
                     &mut s2,
-                    &mut ScopeImpl::sub_selectors(
-                        scope,
-                        selectors.clone(),
-                    ),
+                    &mut ScopeImpl::sub_selectors(scope, selectors.clone()),
                     body,
                     file_context,
                     0,
@@ -309,8 +306,8 @@ impl OutputStyle {
         file_context: &FileContext,
         indent: usize,
     ) -> Result<(), Error> {
-        let selectors = eval_selectors(selectors, scope)
-            .inside(Some(scope.get_selectors()));
+        let selectors =
+            eval_selectors(selectors, scope).inside(scope.get_selectors());
         let mut direct = Vec::new();
         let mut sub = Vec::new();
         self.handle_body(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,6 +21,7 @@ use parser::util::{comment, ignore_space, name, opt_spacelike, spacelike};
 #[cfg(test)]
 use sass::{CallArgs, FormalArgs};
 use sass::{Item, Value};
+use selectors::Selectors;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -114,6 +115,7 @@ named!(
             | function_declaration
             | mixin_call
             | import
+            | at_root
             | if_statement
             | return_stmt
             | content_stmt
@@ -131,6 +133,22 @@ named!(
     map!(
         delimited!(tag!("@import "), value_expression, tag!(";")),
         Item::Import
+    )
+);
+
+named!(
+    at_root<Input, Item>,
+    preceded!(
+        terminated!(tag!("@at-root"), opt_spacelike),
+        map!(
+            pair!(
+                map!(opt!(selectors), |s| {
+                    s.unwrap_or_else(|| Selectors::root())
+                }),
+                body_block
+            ),
+            |(selectors, body)| Item::AtRoot { selectors, body }
+        )
     )
 );
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -142,9 +142,8 @@ named!(
         terminated!(tag!("@at-root"), opt_spacelike),
         map!(
             pair!(
-                map!(opt!(selectors), |s| {
-                    s.unwrap_or_else(|| Selectors::root())
-                }),
+                map!(opt!(selectors), |s| s
+                    .unwrap_or_else(|| Selectors::root())),
                 body_block
             ),
             |(selectors, body)| Item::AtRoot { selectors, body }

--- a/src/parser/selectors.rs
+++ b/src/parser/selectors.rs
@@ -8,7 +8,7 @@ named!(pub selectors<Input, Selectors>,
        map!(separated_nonempty_list!(
            complete!(do_parse!(tag!(",") >> opt!(is_a!(", \t\n")) >> ())),
            selector),
-            Selectors));
+            Selectors::new));
 
 named!(pub selector<Input, Selector>,
        map!(many1!(selector_part),
@@ -178,11 +178,15 @@ mod test {
 
     #[test]
     fn selectors_simple() {
-        let foo = Selector(vec![SelectorPart::Simple("foo".into())]);
-        let bar = Selector(vec![SelectorPart::Simple("bar".into())]);
         assert_eq!(
             selectors(Input(b"foo, bar ")),
-            Ok((Input(b""), Selectors(vec![foo, bar])))
+            Ok((
+                Input(b""),
+                Selectors::new(vec![
+                    Selector(vec![SelectorPart::Simple("foo".into())]),
+                    Selector(vec![SelectorPart::Simple("bar".into())]),
+                ])
+            ))
         )
     }
 

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -13,6 +13,10 @@ pub enum Item {
         default: bool,
         global: bool,
     },
+    AtRoot {
+        selectors: Selectors,
+        body: Vec<Item>,
+    },
     AtRule {
         name: String,
         args: Value,

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -11,18 +11,14 @@ impl Selectors {
     pub fn root() -> Self {
         Selectors(vec![Selector::root()])
     }
-    pub fn inside(&self, parent: Option<&Self>) -> Self {
-        if let Some(parent) = parent {
-            let mut result = Vec::new();
-            for p in &parent.0 {
-                for s in &self.0 {
-                    result.push(p.join(s));
-                }
+    pub fn inside(&self, parent: &Self) -> Self {
+        let mut result = Vec::new();
+        for p in &parent.0 {
+            for s in &self.0 {
+                result.push(p.join(s));
             }
-            Selectors(result)
-        } else {
-            self.clone()
         }
+        Selectors(result)
     }
     pub fn to_value(&self) -> Value {
         let content = self

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -5,24 +5,45 @@ use std::io::Write;
 use value::{ListSeparator, Quotes};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Selectors(pub Vec<Selector>);
+pub struct Selectors {
+    pub s: Vec<Selector>,
+    backref: Selector,
+}
 
 impl Selectors {
     pub fn root() -> Self {
-        Selectors(vec![Selector::root()])
+        Selectors::new(vec![Selector::root()])
+    }
+    pub fn new(s: Vec<Selector>) -> Self {
+        Selectors {
+            s,
+            backref: Selector::root(),
+        }
+    }
+    pub fn one(&self) -> Selector {
+        self.s.first().cloned().unwrap_or_else(|| Selector::root())
     }
     pub fn inside(&self, parent: &Self) -> Self {
         let mut result = Vec::new();
-        for p in &parent.0 {
-            for s in &self.0 {
-                result.push(p.join(s));
+        for p in &parent.s {
+            for s in &self.s {
+                result.push(p.join(s, &parent.backref));
             }
         }
-        Selectors(result)
+        Selectors {
+            s: result,
+            backref: parent.backref.clone(),
+        }
+    }
+    pub fn with_backref(self, context: Selector) -> Self {
+        self.inside(&Selectors {
+            s: vec![Selector::root()],
+            backref: context,
+        })
     }
     pub fn to_value(&self) -> Value {
         let content = self
-            .0
+            .s
             .iter()
             .map(|s: &Selector| {
                 Value::List(
@@ -51,12 +72,16 @@ impl Selector {
         Selector(vec![])
     }
 
-    pub fn join(&self, other: &Selector) -> Selector {
+    fn join(&self, other: &Selector, alt_context: &Selector) -> Selector {
         let mut split = other.0.splitn(2, |p| p == &SelectorPart::BackRef);
         let o1 = split.next().unwrap();
         if let Some(o2) = split.next() {
             let mut result = o1.to_vec();
-            result.extend(self.0.iter().cloned());
+            if self.0.is_empty() {
+                result.extend(alt_context.0.iter().cloned());
+            } else {
+                result.extend(self.0.iter().cloned());
+            }
             result.extend(o2.iter().cloned());
             Selector(result)
         } else {
@@ -111,7 +136,7 @@ impl SelectorPart {
 
 impl fmt::Display for Selectors {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        if let Some((first, rest)) = self.0.split_first() {
+        if let Some((first, rest)) = self.s.split_first() {
             first.fmt(out)?;
             let separator = if out.alternate() { "," } else { ", " };
             for item in rest {
@@ -205,13 +230,15 @@ mod test {
     #[test]
     fn root_join() {
         let s = Selector(vec![SelectorPart::Simple("foo".into())]);
-        assert_eq!(Selector::root().join(&s), s)
+        assert_eq!(Selector::root().join(&s, &Selector::root()), s)
     }
 
     #[test]
     fn simple_join() {
-        let s = Selector(vec![SelectorPart::Simple("foo".into())])
-            .join(&Selector(vec![SelectorPart::Simple(".bar".into())]));
+        let s = Selector(vec![SelectorPart::Simple("foo".into())]).join(
+            &Selector(vec![SelectorPart::Simple(".bar".into())]),
+            &Selector::root(),
+        );
         assert_eq!(format!("{}", s), "foo .bar")
     }
 
@@ -222,6 +249,7 @@ mod test {
                 SelectorPart::BackRef,
                 SelectorPart::Simple(".bar".into()),
             ]),
+            &Selector::root(),
         );
         assert_eq!(format!("{}", s), "foo.bar")
     }

--- a/tests/libsass.rs
+++ b/tests/libsass.rs
@@ -75,6 +75,24 @@ fn keyframes() {
     )
 }
 
+mod at_root {
+    use super::check;
+
+    #[test]
+    fn basic() {
+        check(
+            "foo {\n  color: blue;\n\n  \
+             @at-root {\n    bar {\n      color: red;\n    }\n  }\n}\n\n\
+             foo {\n  color: blue;\n\n  \
+             @at-root bar {\n    color: red;\n  }\n}\n",
+            "foo {\n  color: blue;\n}\n\
+             bar {\n  color: red;\n}\n\n\
+             foo {\n  color: blue;\n}\n\
+             bar {\n  color: red;\n}\n",
+        )
+    }
+}
+
 fn check(input: &str, expected: &str) {
     assert_eq!(
         compile_scss(input.as_ref(), OutputStyle::Expanded)

--- a/tests/libsass.rs
+++ b/tests/libsass.rs
@@ -91,13 +91,80 @@ mod at_root {
              bar {\n  color: red;\n}\n",
         )
     }
+
+    #[test]
+    fn ampersand() {
+        check(
+            "foo {\
+             \n  @at-root {\
+             \n    & {\n      color: blue;\n    }\n\
+             \n    &--modifier {\n      color: red;\n    }\
+             \n  }\
+             \n}\n",
+            "foo {\n  color: blue;\n}\n\
+             foo--modifier {\n  color: red;\n}\n",
+        )
+    }
+
+    #[test]
+    fn nested() {
+        check(
+            "foo {\
+             \n  color: blue;\n\
+             \n  baz {\
+             \n    color: purple;\n\
+             \n    @at-root {\
+             \n      bar {\n        color: red;\n      }\
+             \n    }\n  }\n}\n\
+             \nfoo {\
+             \n  color: blue;\n\
+             \n  baz {\
+             \n    color: purple;\n\
+             \n    @at-root bar {\n      color: red;\n    }\
+             \n  }\n}\n",
+            "foo {\n  color: blue;\n}\
+             \nfoo baz {\n  color: purple;\n}\
+             \nbar {\n  color: red;\n}\n\
+             \nfoo {\n  color: blue;\n}\
+             \nfoo baz {\n  color: purple;\n}\
+             \nbar {\n  color: red;\n}\n",
+        )
+    }
+
+    #[test]
+    fn media() {
+        check(
+            "foo {\n  @at-root {\
+             \n    @media print {\
+             \n      bar {\n        color: red;\n      }\
+             \n    }\n\
+             \n    baz {\
+             \n      @media speech {\n        color: blue;\n      }\
+             \n    }\
+             \n  }\n}\n",
+            "@media print {\
+             \n  bar {\n    color: red;\n  }\
+             \n}\
+             \n@media speech {\
+             \n  baz {\n    color: blue;\n  }\
+             \n}\n",
+        )
+    }
+
+    #[test]
+    fn t141_test_at_root_with_parent_ref() {
+        check(
+            ".foo {\n  @at-root & {\n    a: b;\n  }\n}\n",
+            ".foo {\n  a: b;\n}\n",
+        )
+    }
 }
 
 fn check(input: &str, expected: &str) {
     assert_eq!(
         compile_scss(input.as_ref(), OutputStyle::Expanded)
             .and_then(|s| Ok(String::from_utf8(s)?))
-            .unwrap(),
+            .expect("Compile scss"),
         expected
     );
 }


### PR DESCRIPTION
- [x] Basic `@at-root` support
- [ ] Implement the `with` and `without` arguments.
- [x] Handle `&` back-refs in selectors, that sometimes should give access to the outer selector.