### PR TITLE
Update nom to 4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ commandline = ["clap"]
 [dependencies]
 clap = { version = "^2.19", optional = true }
 lazy_static = "1.0"
-nom = "^3.2.0"
+nom = "^4.0.0"
 num-rational = { version = "^0.1", default-features = false }
 num-traits = "^0.2.0"
 rand = "^0.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 use clap;
 use css::Value;
 use nom;
+use nom::types::CompleteByteSlice as Input;
 use std::convert::From;
 use std::path::PathBuf;
 use std::string::FromUtf8Error;
@@ -81,9 +82,9 @@ impl From<nom::ErrorKind> for Error {
         Error::ParseError(e)
     }
 }
-impl<'a> From<nom::Err<&'a [u8]>> for Error {
-    fn from(e: nom::Err<&'a [u8]>) -> Self {
-        Error::S(format!("Parse error: {}", e))
+impl<'a> From<nom::Err<Input<'a>>> for Error {
+    fn from(e: nom::Err<Input<'a>>) -> Self {
+        Error::S(format!("Parse error: {:?}", e))
     }
 }
 

--- a/src/functions/macros.rs
+++ b/src/functions/macros.rs
@@ -3,10 +3,11 @@ macro_rules! one_arg {
         (stringify!($name).into(), $crate::sass::Value::Null)
     };
     ($name:ident = $value:expr) => {{
+        use nom::types::CompleteByteSlice as Input;
         use $crate::parser::value::value_expression;
         (
             stringify!($name).into(),
-            value_expression($value).unwrap().1,
+            value_expression(Input($value)).unwrap().1,
         )
     }};
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -156,6 +156,7 @@ lazy_static! {
 
 #[test]
 fn test_rgb() {
+    use nom::types::CompleteByteSlice as Input;
     use num_rational::Rational;
     use num_traits::{One, Zero};
     use parser::formalargs::call_args;
@@ -167,7 +168,10 @@ fn test_rgb() {
             .unwrap()
             .call(
                 &scope,
-                &call_args(b"(17, 0, 225)").unwrap().1.evaluate(&scope, true)
+                &call_args(Input(b"(17, 0, 225)"))
+                    .unwrap()
+                    .1
+                    .evaluate(&scope, true)
             ).unwrap(),
         css::Value::Color(
             Rational::new(17, 1),

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -1,5 +1,6 @@
 use super::SassFunction;
 use css::Value;
+use nom::types::CompleteByteSlice as Input;
 use parser::selectors::{selector, selectors};
 use selectors::{Selector, Selectors};
 use std::collections::BTreeMap;
@@ -56,15 +57,15 @@ fn parse_selectors(v: Value) -> Selectors {
     if s.is_empty() {
         Selectors::root()
     } else {
-        let (rest, result) = selectors(s.as_bytes()).unwrap();
-        assert!(rest == b"" || rest == b",");
+        let (rest, result) = selectors(Input(s.as_bytes())).unwrap();
+        assert!(rest.is_empty() || rest == Input(b","));
         result
     }
 }
 
 // Note, this helper should probably handle errors and return a Result.
 fn parse_selector(s: &str) -> Selector {
-    let (rest, result) = selector(s.as_bytes()).unwrap();
-    assert!(rest == b"");
+    let (rest, result) = selector(Input(s.as_bytes())).unwrap();
+    assert!(rest.is_empty());
     result
 }

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -1,6 +1,7 @@
 use css::Value;
 use error::Error;
 use file_context::FileContext;
+use nom::types::CompleteByteSlice as Input;
 use parser::parse_scss_file;
 use sass::{FormalArgs, Item};
 use selectors::{Selector, SelectorPart, Selectors};
@@ -651,7 +652,7 @@ fn eval_selectors(s: &Selectors, scope: &Scope) -> Selectors {
     // contain high-level selector separators (i.e. ","), so we need to
     // parse the selectors again, from a string representation.
     use parser::selectors::selectors;
-    selectors(format!("{} ", s).as_bytes()).unwrap().1
+    selectors(Input(format!("{}", s).as_bytes())).unwrap().1
 }
 
 struct CssWriter {

--- a/src/parser/formalargs.rs
+++ b/src/parser/formalargs.rs
@@ -1,8 +1,9 @@
+use nom::types::CompleteByteSlice as Input;
 use parser::util::{ignore_comments, name, opt_spacelike};
 use parser::value::space_list;
 use sass::{CallArgs, FormalArgs, Value};
 
-named!(pub formal_args<FormalArgs>,
+named!(pub formal_args<Input, FormalArgs>,
        do_parse!(tag!("(") >> opt_spacelike >>
                  v: separated_list!(
                      preceded!(tag!(","), opt_spacelike),
@@ -18,7 +19,7 @@ named!(pub formal_args<FormalArgs>,
                  tag!(")") >>
                  (FormalArgs::new(v, va.is_some()))));
 
-named!(pub call_args<CallArgs>,
+named!(pub call_args<Input, CallArgs>,
        delimited!(
            tag!("("),
            map!(separated_list!(

--- a/src/parser/unit.rs
+++ b/src/parser/unit.rs
@@ -1,6 +1,7 @@
+use nom::types::CompleteByteSlice as Input;
 use value::Unit;
 
-named!(pub unit<&[u8], Unit>,
+named!(pub unit<Input, Unit>,
        alt_complete!(
            // Distance units, <length> type
            value!(Unit::Em, tag!("em")) |

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -1,74 +1,76 @@
+use nom::types::CompleteByteSlice as Input;
 use nom::{is_alphanumeric, multispace};
 use std::str::from_utf8;
 
-named!(pub spacelike<()>,
+named!(pub spacelike<Input, ()>,
        fold_many1!(alt_complete!(ignore_space |ignore_lcomment),
                    (),
                    |(), ()| ()));
-named!(pub spacelike2<()>,
+named!(pub spacelike2<Input, ()>,
        terminated!(spacelike,
                    ignore_comments));
 
-named!(pub opt_spacelike<()>,
+named!(pub opt_spacelike<Input, ()>,
        fold_many0!(alt_complete!(ignore_space | ignore_lcomment),
                    (),
                    |(), ()| ()));
 
-named!(pub ignore_comments<()>,
+named!(pub ignore_comments<Input, ()>,
        fold_many0!(alt_complete!(ignore_space |
                                  ignore_lcomment |
                                  map!(comment, |_| ())),
                    (),
                    |(), ()| ()));
 
-named!(pub name<String>,
+named!(pub name<Input, String>,
        map!(verify!(take_while1!(is_name_char),
-                    |n| n != b"-"),
-            |n| from_utf8(n).unwrap().into()));
+                    |n| n != Input(b"-")),
+            |n| from_utf8(&n).unwrap().into()));
 
 pub fn is_name_char(c: u8) -> bool {
     is_alphanumeric(c) || c == b'_' || c == b'-'
 }
 
-named!(pub comment,
+named!(pub comment<Input, Input>,
        delimited!(tag!("/*"),
                   recognize!(many0!(alt_complete!(
-                      is_not!("*") |
-                      preceded!(tag!("*"), not!(tag!("/")))))),
+                      value!((), is_not!("*")) |
+                      preceded!(tag!("*"), not!(tag!("/")))
+                  ))),
                   tag!("*/")));
 
-named!(pub ignore_space<()>, map!(multispace, |_|()));
+named!(pub ignore_space<Input, ()>, map!(multispace, |_|()));
 named!(
-    ignore_lcomment<()>,
+    ignore_lcomment<Input, ()>,
     do_parse!(tag!("//") >> opt!(is_not!("\n")) >> ())
 );
 
 #[cfg(test)]
 mod test {
     use super::comment;
-    use nom::IResult::*;
+    use nom::types::CompleteByteSlice as Input;
 
     #[test]
     fn comment_simple() {
         assert_eq!(
-            comment(b"/* hello */\n"),
-            Done(&b"\n"[..], &b" hello "[..])
+            comment(Input(b"/* hello */\n")),
+            Ok((Input(b"\n"), Input(b" hello ")))
         )
     }
 
     #[test]
     fn comment_with_stars() {
         assert_eq!(
-            comment(b"/**** hello ****/\n"),
-            Done(&b"\n"[..], &b"*** hello ***"[..])
+            comment(Input(b"/**** hello ****/\n")),
+            Ok((Input(b"\n"), Input(b"*** hello ***")))
         )
     }
 
     #[test]
     fn comment_with_stars2() {
         assert_eq!(
-            comment(b"/* / * / * / * hello * \\ * \\ * \\ */\n"),
-            Done(&b"\n"[..], &b" / * / * / * hello * \\ * \\ * \\ "[..])
+            comment(Input(b"/* / * / * / * hello * \\ * \\ * \\ */\n")),
+            Ok((Input(b"\n"), Input(b" / * / * / * hello * \\ * \\ * \\ ")))
         )
     }
 }

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -338,6 +338,7 @@ impl Scope for GlobalScope {
 
 #[cfg(test)]
 pub mod test {
+    use nom::types::CompleteByteSlice as Input;
     use parser::value::value_expression;
     use std::str::from_utf8;
     use variablescope::*;
@@ -669,14 +670,14 @@ pub mod test {
     pub fn do_evaluate(s: &[(&str, &str)], expression: &[u8]) -> String {
         let mut scope = GlobalScope::new();
         for &(name, ref val) in s {
-            let val = format!("{};", val);
-            let (end, value) = value_expression(val.as_bytes()).unwrap();
+            let (end, value) =
+                value_expression(Input(val.as_bytes())).unwrap();
             let value = value.evaluate(&scope);
-            assert_eq!(Ok(";"), from_utf8(end));
+            assert_eq!(Ok(""), from_utf8(&end));
             scope.define(name, &value);
         }
-        let (end, foo) = value_expression(expression).unwrap();
-        assert_eq!(Ok(";"), from_utf8(end));
+        let (end, foo) = value_expression(Input(expression)).unwrap();
+        assert_eq!(Ok(";"), from_utf8(&end));
         format!("{}", foo.evaluate(&mut scope))
     }
 }


### PR DESCRIPTION
Lots of wrapping &[u8] in Input (i.e. nom::types::CompleteByteSlice).

Also, the unfortunate return of some String allocations that should not be needed in string parsing.