### PR TITLE
 Raise on accessing an undefined variable

### DIFF
--- a/check_spec
+++ b/check_spec
@@ -40,13 +40,13 @@ cat > sass-spec/spec/output_styles/nested/options.yml <<EOF
 EOF
 
 IMPL=rsass
-function check() {
+check() {
     cargo build --release --features=commandline >&2
     LC_ALL=C sass-spec/sass-spec.rb -c target/release/rsass \
 	  --impl $IMPL -V 4.0 sass-spec/spec/$1
 }
 
-function list_fails() {
+list_fails() {
     grep ^SassSpec:: | sed -e 's#.*test__##' -e 's# .*##' | sort
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ pub enum Error {
     BadArguments(String),
     ParseError(nom::ErrorKind),
     S(String),
+    UndefinedVariable(String),
 }
 
 impl Error {
@@ -50,6 +51,10 @@ impl Error {
             expected, actual
         ))
     }
+
+    pub fn undefined_variable(name: &str) -> Self {
+        Error::UndefinedVariable(name.to_string())
+    }
 }
 
 impl fmt::Display for Error {
@@ -58,6 +63,9 @@ impl fmt::Display for Error {
             Error::S(ref s) => write!(out, "{}", s),
             Error::Input(ref p, ref e) => {
                 write!(out, "Failed to read {:?}: {}", p, e)
+            }
+            Error::UndefinedVariable(ref name) => {
+                write!(out, "Undefined variable: \"${}\"", name)
             }
             // fallback
             ref x => write!(out, "{:?}", x),

--- a/src/functions/colors_other.rs
+++ b/src/functions/colors_other.rs
@@ -12,15 +12,15 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         adjust_color(
             color, red, green, blue, hue, saturation, lightness, alpha
         ),
-        |s: &Scope| match &s.get("color") {
+        |s: &Scope| match &s.get("color")? {
             &Value::Color(ref rgba, _) => {
-                let c_add = |orig: Rational, name: &str| match s.get(name) {
+                let c_add = |orig: Rational, name: &str| match s.get(name)? {
                     Value::Null => Ok(orig),
                     x => to_rational(x).map(|x| orig + x),
                 };
-                let h_adj = s.get("hue");
-                let s_adj = s.get("saturation");
-                let l_adj = s.get("lightness");
+                let h_adj = s.get("hue")?;
+                let s_adj = s.get("saturation")?;
+                let l_adj = s.get("lightness")?;
                 if h_adj.is_null() && s_adj.is_null() && l_adj.is_null() {
                     Ok(Value::rgba(
                         c_add(rgba.red, "red")?,
@@ -50,12 +50,12 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         scale_color(
             color, red, green, blue, hue, saturation, lightness, alpha
         ),
-        |s: &Scope| match &s.get("color") {
+        |s: &Scope| match &s.get("color")? {
             &Value::Color(ref rgba, _) => {
-                let h_adj = s.get("hue");
-                let s_adj = s.get("saturation");
-                let l_adj = s.get("lightness");
-                let a_adj = s.get("alpha");
+                let h_adj = s.get("hue")?;
+                let s_adj = s.get("saturation")?;
+                let l_adj = s.get("lightness")?;
+                let a_adj = s.get("alpha")?;
 
                 let comb = |orig: Rational, x: Value, max: Rational| match x {
                     Value::Null => Ok(orig),
@@ -71,9 +71,9 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
                 let ff = Rational::from_integer(255);
                 if h_adj.is_null() && s_adj.is_null() && l_adj.is_null() {
                     Ok(Value::rgba(
-                        comb(rgba.red, s.get("red"), ff)?,
-                        comb(rgba.green, s.get("green"), ff)?,
-                        comb(rgba.blue, s.get("blue"), ff)?,
+                        comb(rgba.red, s.get("red")?, ff)?,
+                        comb(rgba.green, s.get("green")?, ff)?,
+                        comb(rgba.blue, s.get("blue")?, ff)?,
                         comb(rgba.alpha, a_adj, one)?,
                     ))
                 } else {
@@ -130,17 +130,17 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         change_color(
             color, red, green, blue, hue, saturation, lightness, alpha
         ),
-        |s: &Scope| match s.get("color") {
+        |s: &Scope| match s.get("color")? {
             Value::Color(rgba, _) => {
-                let h_adj = s.get("hue");
-                let s_adj = s.get("saturation");
-                let l_adj = s.get("lightness");
+                let h_adj = s.get("hue")?;
+                let s_adj = s.get("saturation")?;
+                let l_adj = s.get("lightness")?;
 
-                let c_or = |name: &str, orig: Rational| match s.get(name) {
+                let c_or = |name: &str, orig: Rational| match s.get(name)? {
                     Value::Null => Ok(orig),
                     x => to_rational(x),
                 };
-                let a_or = |name: &str, orig: Rational| match s.get(name) {
+                let a_or = |name: &str, orig: Rational| match s.get(name)? {
                     Value::Null => Ok(orig),
                     x => to_rational(x),
                 };
@@ -168,7 +168,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
             v => Err(Error::badarg("color", &v)),
         }
     );
-    def!(f, ie_hex_str(color), |s| match s.get("color") {
+    def!(f, ie_hex_str(color), |s| match s.get("color")? {
         Value::Color(rgba, _) => {
             let (r, g, b, a) = rgba.to_bytes();
             Ok(Value::Literal(

--- a/src/functions/colors_rgb.rs
+++ b/src/functions/colors_rgb.rs
@@ -7,17 +7,17 @@ use value::{ListSeparator, Number, Unit};
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     def!(f, rgb(red, green, blue), |s| Ok(Value::rgba(
-        to_int(s.get("red"))?,
-        to_int(s.get("green"))?,
-        to_int(s.get("blue"))?,
+        to_int(s.get("red")?)?,
+        to_int(s.get("green")?)?,
+        to_int(s.get("blue")?)?,
         Rational::one()
     )));
     def!(f, rgba(red, green, blue, alpha, color), |s| {
-        let a = s.get("alpha");
-        let red = s.get("red");
-        let red = if red.is_null() { s.get("color") } else { red };
+        let a = s.get("alpha")?;
+        let red = s.get("red")?;
+        let red = if red.is_null() { s.get("color")? } else { red };
         if let Value::Color(rgba, _) = red {
-            let a = if a.is_null() { s.get("green") } else { a };
+            let a = if a.is_null() { s.get("green")? } else { a };
             match a {
                 Value::Numeric(a, ..) => {
                     Ok(Value::rgba(rgba.red, rgba.green, rgba.blue, a.value))
@@ -39,8 +39,8 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         } else {
             Ok(Value::rgba(
                 to_int(red)?,
-                to_int(s.get("green"))?,
-                to_int(s.get("blue"))?,
+                to_int(s.get("green")?)?,
+                to_int(s.get("blue")?)?,
                 to_rational(a)?,
             ))
         }
@@ -48,22 +48,22 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     fn num(v: &Rational) -> Result<Value, Error> {
         Ok(Value::Numeric(Number::from(*v), Unit::None, true))
     }
-    def!(f, red(color), |s| match &s.get("color") {
+    def!(f, red(color), |s| match &s.get("color")? {
         &Value::Color(ref rgba, _) => num(&rgba.red),
         value => Err(Error::badarg("color", value)),
     });
-    def!(f, green(color), |s| match &s.get("color") {
+    def!(f, green(color), |s| match &s.get("color")? {
         &Value::Color(ref rgba, _) => num(&rgba.green),
         value => Err(Error::badarg("color", value)),
     });
-    def!(f, blue(color), |s| match &s.get("color") {
+    def!(f, blue(color), |s| match &s.get("color")? {
         &Value::Color(ref rgba, _) => num(&rgba.blue),
         value => Err(Error::badarg("color", value)),
     });
     def!(f, mix(color1, color2, weight = b"50%"), |s| match (
-        s.get("color1"),
-        s.get("color2"),
-        s.get("weight"),
+        s.get("color1")?,
+        s.get("color2")?,
+        s.get("weight")?,
     ) {
         (
             Value::Color(a, _),
@@ -92,8 +92,8 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         )),
     });
     def!(f, invert(color, weight = b"100%"), |s| match (
-        s.get("color"),
-        s.get("weight"),
+        s.get("color")?,
+        s.get("weight")?,
     ) {
         (Value::Color(rgba, _), Value::Numeric(w, wu, ..)) => {
             let w = if wu == Unit::Percent {

--- a/src/functions/macros.rs
+++ b/src/functions/macros.rs
@@ -46,7 +46,7 @@ macro_rules! def_va {
 macro_rules! func2 {
     ($name:ident( $($arg:ident $( = $value:expr )* ),* )) => {
         func!(($($arg $( = $value )* ),*),
-              |s: &Scope| $name($(s.get(stringify!($arg))),*))
+              |s: &Scope| $name($(s.get(stringify!($arg))?),*))
     };
 }
 

--- a/src/functions/maps.rs
+++ b/src/functions/maps.rs
@@ -5,21 +5,21 @@ use std::collections::BTreeMap;
 use value::ListSeparator;
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
-    def!(f, map_get(map, key), |s| Ok(get_map(s.get("map"))?
-        .get(&s.get("key"))
+    def!(f, map_get(map, key), |s| Ok(get_map(s.get("map")?)?
+        .get(&s.get("key")?)
         .cloned()
         .unwrap_or(Value::Null)));
     def!(f, map_merge(map1, map2), |s| {
-        let mut map1 = get_map(s.get("map1"))?;
-        let map2 = get_map(s.get("map2"))?;
+        let mut map1 = get_map(s.get("map1")?)?;
+        let map2 = get_map(s.get("map2")?)?;
         for (key, value) in map2 {
             map1.insert(key, value);
         }
         Ok(Value::Map(map1))
     });
     def_va!(f, map_remove(map, keys), |s| {
-        let mut map = get_map(s.get("map"))?;
-        match s.get("keys") {
+        let mut map = get_map(s.get("map")?)?;
+        match s.get("keys")? {
             Value::List(keys, ..) => {
                 for key in keys {
                     map.remove(&key);
@@ -32,16 +32,16 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         Ok(Value::Map(map))
     });
     def!(f, map_keys(map), |s| {
-        let map = get_map(s.get("map"))?;
+        let map = get_map(s.get("map")?)?;
         Ok(Value::List(map.keys(), ListSeparator::Comma, false))
     });
     def!(f, map_values(map), |s| {
-        let map = get_map(s.get("map"))?;
+        let map = get_map(s.get("map")?)?;
         Ok(Value::List(map.values(), ListSeparator::Comma, false))
     });
     def!(f, map_has_key(map, key), |s| {
-        let map = get_map(s.get("map"))?;
-        Ok(Value::bool(map.contains_key(&s.get("key"))))
+        let map = get_map(s.get("map")?)?;
+        Ok(Value::bool(map.contains_key(&s.get("key")?)))
     });
 }
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -121,11 +121,11 @@ impl SassFunction {
         scope: &Scope,
         args: &css::CallArgs,
     ) -> Result<css::Value, Error> {
-        let mut s = self.args.eval(scope, args);
+        let mut s = self.args.eval(scope, args)?;
         match self.body {
             FuncImpl::Builtin(ref body) => body(&s),
             FuncImpl::UserDefined(ref body) => {
-                Ok(s.eval_body(body).unwrap_or(css::Value::Null))
+                Ok(s.eval_body(body)?.unwrap_or(css::Value::Null))
             }
         }
     }
@@ -135,10 +135,10 @@ lazy_static! {
     static ref FUNCTIONS: BTreeMap<&'static str, SassFunction> = {
         let mut f = BTreeMap::new();
         def!(f, if(condition, if_true, if_false), |s| {
-            if s.get("condition").is_true() {
-                Ok(s.get("if_true"))
+            if s.get("condition")?.is_true() {
+                Ok(s.get("if_true")?)
             } else {
-                Ok(s.get("if_false"))
+                Ok(s.get("if_false")?)
             }
         });
         colors_hsl::register(&mut f);
@@ -171,6 +171,7 @@ fn test_rgb() {
                     .unwrap()
                     .1
                     .evaluate(&scope, true)
+                    .unwrap()
             )
             .unwrap(),
         css::Value::Color(Rgba::from_rgb(17, 0, 225), None)

--- a/src/functions/numbers.rs
+++ b/src/functions/numbers.rs
@@ -8,39 +8,39 @@ use std::collections::BTreeMap;
 use value::{Number, Unit};
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
-    def!(f, abs(number), |s| match s.get("number") {
+    def!(f, abs(number), |s| match s.get("number")? {
         Value::Numeric(v, u, ..) => Ok(number(v.value.abs(), u)),
         v => Err(Error::badarg("number", &v)),
     });
-    def!(f, ceil(number), |s| match s.get("number") {
+    def!(f, ceil(number), |s| match s.get("number")? {
         Value::Numeric(v, u, ..) => Ok(number(v.value.ceil(), u)),
         v => Err(Error::badarg("number", &v)),
     });
-    def!(f, floor(number), |s| match s.get("number") {
+    def!(f, floor(number), |s| match s.get("number")? {
         Value::Numeric(v, u, ..) => Ok(number(v.value.floor(), u)),
         v => Err(Error::badarg("number", &v)),
     });
-    def!(f, percentage(number), |s| match s.get("number") {
+    def!(f, percentage(number), |s| match s.get("number")? {
         Value::Numeric(val, Unit::None, _) => {
             Ok(number(val.value * 100, Unit::Percent))
         }
         v => Err(Error::badarg("number", &v)),
     });
-    def!(f, round(number), |s| match s.get("number") {
+    def!(f, round(number), |s| match s.get("number")? {
         Value::Numeric(val, unit, _) => Ok(number(val.value.round(), unit)),
         v => Err(Error::badarg("number", &v)),
     });
-    def_va!(f, max(numbers), |s| match s.get("numbers") {
+    def_va!(f, max(numbers), |s| match s.get("numbers")? {
         Value::List(v, _, _) => {
             Ok(find_extreme(&v, Ordering::Greater).clone())
         }
         single_value => Ok(single_value),
     });
-    def_va!(f, min(numbers), |s| match s.get("numbers") {
+    def_va!(f, min(numbers), |s| match s.get("numbers")? {
         Value::List(v, _, _) => Ok(find_extreme(&v, Ordering::Less).clone()),
         single_value => Ok(single_value),
     });
-    def!(f, random(limit), |s| match s.get("limit") {
+    def!(f, random(limit), |s| match s.get("limit")? {
         Value::Null => {
             let rez = 1_000_000;
             Ok(number(Rational::new(intrand(rez), rez), Unit::None))

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use value::Quotes;
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
-    def_va!(f, selector_nest(selectors), |s| match s.get("selectors") {
+    def_va!(f, selector_nest(selectors), |s| match s.get("selectors")? {
         Value::List(v, _, _) => Ok(Value::Literal(
             format!(
                 "{}",
@@ -25,7 +25,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     def_va!(
         f,
         selector_append(selectors),
-        |s| match s.get("selectors") {
+        |s| match s.get("selectors")? {
             Value::List(v, _, _) => Ok(Value::Literal(
                 format!(
                     "{}",
@@ -50,7 +50,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         }
     );
     def!(f, selector_parse(selector), |s| Ok(parse_selectors(
-        s.get("selector")
+        s.get("selector")?
     )
     .to_value()));
 }

--- a/src/functions/strings.rs
+++ b/src/functions/strings.rs
@@ -5,11 +5,11 @@ use std::collections::BTreeMap;
 use value::{Number, Quotes, Unit};
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
-    def!(f, quote(contents), |s| match s.get("contents") {
+    def!(f, quote(contents), |s| match s.get("contents")? {
         Value::Literal(v, _) => Ok(Value::Literal(v, Quotes::Double)),
         v => Ok(Value::Literal(format!("{}", v), Quotes::Double)),
     });
-    def!(f, unquote(contents), |s| match s.get("contents") {
+    def!(f, unquote(contents), |s| match s.get("contents")? {
         Value::Literal(v, _) => Ok(Value::Literal(v, Quotes::None)),
         v => {
             dep_warn!("Passing {}, a non-string value, to unquote()", v);
@@ -17,9 +17,9 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         }
     });
     def!(f, str_insert(string, insert, index), |s| match (
-        s.get("string"),
-        s.get("insert"),
-        s.get("index"),
+        s.get("string")?,
+        s.get("insert")?,
+        s.get("index")?,
     ) {
         (
             Value::Literal(s, q),
@@ -44,9 +44,9 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         )),
     });
     def!(f, str_slice(string, start_at, end_at = b"-1;"), |s| match (
-        s.get("string"),
-        s.get("start_at"),
-        s.get("end_at")
+        s.get("string")?,
+        s.get("start_at")?,
+        s.get("end_at")?
     ) {
         (
             Value::Literal(s, q),
@@ -68,13 +68,13 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
             &[&v, &s, &e]
         )),
     });
-    def!(f, str_length(string), |s| match &s.get("string") {
+    def!(f, str_length(string), |s| match &s.get("string")? {
         &Value::Literal(ref v, _) => Ok(intvalue(v.chars().count())),
         v => Err(Error::badarg("string", v)),
     });
     def!(f, str_index(string, substring), |s| match (
-        s.get("string"),
-        s.get("substring"),
+        s.get("string")?,
+        s.get("substring")?,
     ) {
         (Value::Literal(s, _), Value::Literal(sub, _)) => {
             Ok(match s.find(&sub) {
@@ -86,11 +86,11 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
             Err(Error::badargs(&["string", "string"], &[&full, &sub]))
         }
     });
-    def!(f, to_upper_case(string), |s| match s.get("string") {
+    def!(f, to_upper_case(string), |s| match s.get("string")? {
         Value::Literal(v, q) => Ok(Value::Literal(v.to_uppercase(), q)),
         v => Ok(v),
     });
-    def!(f, to_lower_case(string), |s| match s.get("string") {
+    def!(f, to_lower_case(string), |s| match s.get("string")? {
         Value::Literal(v, q) => Ok(Value::Literal(v.to_lowercase(), q)),
         v => Ok(v),
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use variablescope::{GlobalScope, Scope};
 pub fn compile_value(input: &[u8]) -> Result<Vec<u8>, Error> {
     let scope = GlobalScope::new();
     let value = parse_value_data(input)?;
-    let buffer = format!("{}", value.evaluate(&scope)).into_bytes();
+    let buffer = format!("{}", value.evaluate(&scope)?).into_bytes();
     Ok(buffer)
 }
 

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -736,7 +736,13 @@ mod test {
         let t = value_expression_eof(Input(b"http://#{\")\"}.com/"));
         if let &Ok((rest, ref result)) = &t {
             assert_eq!(
-                (format!("{}", result.evaluate(&GlobalScope::new())), rest),
+                (
+                    format!(
+                        "{}",
+                        result.evaluate(&GlobalScope::new()).unwrap()
+                    ),
+                    rest
+                ),
                 ("http://).com/".to_string(), Input(b""))
             );
         } else {
@@ -748,7 +754,13 @@ mod test {
         let t = value_expression_eof(Input(b"url(http://#{\")\"}.com/)"));
         if let &Ok((rest, ref result)) = &t {
             assert_eq!(
-                (format!("{}", result.evaluate(&GlobalScope::new())), rest),
+                (
+                    format!(
+                        "{}",
+                        result.evaluate(&GlobalScope::new()).unwrap()
+                    ),
+                    rest
+                ),
                 ("url(http://).com/)".to_string(), Input(b""))
             );
         } else {
@@ -760,7 +772,13 @@ mod test {
         let t = value_expression_eof(Input(b"url(//#{\")\"}.com/)"));
         if let &Ok((rest, ref result)) = &t {
             assert_eq!(
-                (format!("{}", result.evaluate(&GlobalScope::new())), rest),
+                (
+                    format!(
+                        "{}",
+                        result.evaluate(&GlobalScope::new()).unwrap()
+                    ),
+                    rest
+                ),
                 ("url(//).com/)".to_string(), Input(b""))
             );
         } else {

--- a/src/sass/call_args.rs
+++ b/src/sass/call_args.rs
@@ -1,4 +1,5 @@
 use css;
+use error::Error;
 use sass::Value;
 use std::default::Default;
 use variablescope::Scope;
@@ -40,15 +41,18 @@ impl CallArgs {
         self.0.get(index)
     }
 
-    pub fn evaluate(&self, scope: &Scope, arithmetic: bool) -> css::CallArgs {
-        css::CallArgs(
-            self.0
+    pub fn evaluate(
+        &self,
+        scope: &Scope,
+        arithmetic: bool,
+    ) -> Result<css::CallArgs, Error> {
+        let args = self.0
                 .iter()
-                .map(|&(ref n, ref v)| {
-                    (n.clone(), v.do_evaluate(scope, arithmetic))
+                .map(|&(ref n, ref v)| -> Result<(Option<String>, css::Value), Error> {
+                    Ok((n.clone(), v.do_evaluate(scope, arithmetic)?))
                 })
-                .collect(),
-        )
+                .collect::<Result<Vec<_>, Error>>()?;
+        Ok(css::CallArgs(args))
     }
 }
 

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -1,4 +1,5 @@
 use css;
+use error::Error;
 use sass::Value;
 use std::default::Default;
 use value::ListSeparator;
@@ -20,7 +21,7 @@ impl FormalArgs {
         &self,
         scope: &'a Scope,
         args: &css::CallArgs,
-    ) -> ScopeImpl<'a> {
+    ) -> Result<ScopeImpl<'a>, Error> {
         let mut argscope = ScopeImpl::sub(scope);
         let n = self.0.len();
         for (i, &(ref name, ref default)) in self.0.iter().enumerate() {
@@ -44,13 +45,13 @@ impl FormalArgs {
                 match args.get(i) {
                     Some(&(None, ref v)) => argscope.define(name, v),
                     _ => {
-                        let v = default.do_evaluate(&argscope, true);
+                        let v = default.do_evaluate(&argscope, true)?;
                         argscope.define(name, &v)
                     }
                 };
             }
         }
-        argscope
+        Ok(argscope)
     }
 }
 

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -57,7 +57,7 @@ fn function_with_args() {
                 ("b".into(), sass::Value::scalar(0)),
             ],
             false,
-            Arc::new(|s| match (s.get("a"), s.get("b")) {
+            Arc::new(|s| match (s.get("a")?, s.get("b")?) {
                 (
                     css::Value::Numeric(a, au, ..),
                     css::Value::Numeric(b, bu, ..),


### PR DESCRIPTION
Adds a new error type and changes `Scope#get` to return a `Result`.

`variable-exists` now correctly returns `null` for a defined `null` variable.

Fixes #34 
