### PR TITLE
Travis: Cache cargo index & packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
   - 1.26.2
   - beta
   - nightly
+cache: cargo
 script:
   - cargo build --verbose $F
   - cargo test --verbose $F


### PR DESCRIPTION
Avoid downloading all the packages from Cargo on every CI job.
Reference: https://docs.travis-ci.com/user/caching/#rust-cargo-cache