### PR TITLE
Parser: Basic @media support

### DIFF
--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -22,7 +22,10 @@ pub enum Item {
         args: Value,
         body: Option<Vec<Item>>,
     },
-
+    MediaRule {
+        queries: Vec<MediaQuery>, // Never empty.
+        body: Vec<Item>,
+    },
     MixinDeclaration {
         name: String,
         args: FormalArgs,
@@ -58,4 +61,16 @@ pub enum Item {
     Property(SassString, Value),
     Comment(String),
     None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MediaQuery {
+    // The modifier, such as "not" or "only".
+    pub modifier: Option<String>,
+
+    // The media type, such as "screen" or "print".
+    pub media_type: Option<String>,
+
+    // Feature queries, including parenthesis.
+    pub features: Vec<String>,
 }

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -6,6 +6,6 @@ mod value;
 
 pub use self::call_args::CallArgs;
 pub use self::formal_args::FormalArgs;
-pub use self::item::Item;
+pub use self::item::{Item, MediaQuery};
 pub use self::string::{SassString, StringPart};
 pub use self::value::Value;


### PR DESCRIPTION
Introduces a new Item, `MediaRule`, and custom parser rules for it based on the dart-sass parser.

I have no idea what I'm doing when it comes to `nom` and the architecture of `rsass`. :see_no_evil: :hear_no_evil: :speak_no_evil: 

Hopefully this provides a starting point for you to implement better support in the future (for variables in media queries, and nested media query intersection).

What is the command to check / update newly passing sass-spec tests?

Fixes #37 