### PR TITLE
Parser CallArgs: Allow trailing spacelike sans ","

### DIFF
--- a/src/parser/formalargs.rs
+++ b/src/parser/formalargs.rs
@@ -37,5 +37,5 @@ named!(pub call_args<Input, CallArgs>,
                                      ignore_comments)))),
                 CallArgs::new),
            preceded!(
-               opt!(delimited!(opt_spacelike, tag!(","), opt_spacelike)),
+               opt!(delimited!(opt_spacelike, opt!(tag!(",")), opt_spacelike)),
                tag!(")"))));


### PR DESCRIPTION
Fixes #39 

Not sure if this is the best way to fix the issue but it does fix it.	