### PR TITLE
Report file position of parse errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ spectest = ["yaml-rust", "deunicode", "hrx-get", "regex"]
 [dependencies]
 bytecount = "0.5.0"
 lazy_static = "1.0"
-nom = "4.2.0"
+nom = { version = "4.2.0", features = ["verbose-errors"] }
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "^0.2.0"
 rand = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ commandline = ["clap"]
 spectest = ["yaml-rust", "deunicode", "hrx-get", "regex"]
 
 [dependencies]
+bytecount = "0.5.0"
 lazy_static = "1.0"
-nom = "^4.0.0"
+nom = "4.2.0"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "^0.2.0"
 rand = "0.6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub mod selectors;
 mod value;
 mod variablescope;
 
-pub use crate::error::Error;
+pub use crate::error::{ErrPos, Error};
 pub use crate::file_context::FileContext;
 pub use crate::functions::SassFunction;
 pub use crate::output_style::OutputStyle;
@@ -97,7 +97,12 @@ pub fn compile_scss(
     style: OutputStyle,
 ) -> Result<Vec<u8>, Error> {
     let file_context = FileContext::new();
-    let items = parse_scss_data(input)?;
+    let items =
+        parse_scss_data(input).map_err(|(pos, kind)| Error::ParseError {
+            file: "-".into(),
+            pos: ErrPos::pos_of(pos, input),
+            kind,
+        })?;
     style.write_root(&items, &mut GlobalScope::new(), &file_context)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
     match run(&args) {
         Ok(()) => (),
         Err(err) => {
-            eprintln!("Error: {}!", err);
+            eprintln!("{}", err);
             exit(1);
         }
     }

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -59,12 +59,15 @@ pub fn is_name_char(c: char) -> bool {
 }
 
 named!(pub comment<Input, Input>,
-       delimited!(tag!("/*"),
-                  recognize!(many0!(alt_complete!(
-                      value!((), is_not!("*")) |
-                      preceded!(tag!("*"), not!(tag!("/")))
-                  ))),
-                  tag!("*/")));
+       preceded!(tag!("/*"), comment2)
+);
+named!(pub comment2<Input, Input>,
+       terminated!(
+           recognize!(many0!(alt_complete!(
+               value!((), is_not!("*")) |
+               preceded!(tag!("*"), not!(tag!("/")))
+           ))),
+           tag!("*/")));
 
 named!(pub ignore_space<Input, ()>, map!(multispace, |_|()));
 named!(


### PR DESCRIPTION
As requested in #46.

There are several steps to report errors in a way that is actually helpful to users.

- [x] Actually report line and position for parse errors.
- [x] Get parse errors inside the block that contains the error, rather than at the start of the outmost rule or block that contains the error.
- [x] Get value parse errors in the value, or at least at the start of the value, instead of at the start of the property.
- [ ] Get more helpfull error messages, not just "parse error expecting Alt" or some other nom-internal name.
