### PR TITLE
The url function is special.

### DIFF
--- a/src/functions/strings.rs
+++ b/src/functions/strings.rs
@@ -134,6 +134,12 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
             Quotes::None,
         ))
     });
+    def!(f, url(string), |s| {
+        Ok(Value::Literal(
+            format!("url({})", s.get("string")?),
+            Quotes::None,
+        ))
+    });
 }
 
 fn intvalue(n: usize) -> Value {

--- a/src/output_style.rs
+++ b/src/output_style.rs
@@ -74,7 +74,9 @@ impl OutputStyle {
                             )?;
                         }
                     } else {
-                        if x.starts_with('/') {
+                        if (x.starts_with("url(") && x.ends_with(")"))
+                            || x.starts_with('/')
+                        {
                             write!(
                                 result.to_imports(),
                                 "@import {};{}",

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -1,7 +1,7 @@
 use super::formalargs::call_args;
 use super::strings::{
     name, sass_string_dq, sass_string_ext, sass_string_sq, selector_string,
-    special_args,
+    special_args, special_url,
 };
 use super::unit::unit;
 use super::util::{opt_spacelike, spacelike2};
@@ -199,6 +199,7 @@ fn simple_value(input: &[u8]) -> IResult<&[u8], Value> {
         variable,
         hex_color,
         value(Value::Null, tag("null")),
+        map(special_url, Value::Literal),
         special_function,
         // Really ugly special case ... sorry.
         value(Value::Literal("-null".into()), tag("-null")),

--- a/tests/css/main.rs
+++ b/tests/css/main.rs
@@ -383,7 +383,6 @@ mod url {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // failing
         fn middle() {
             assert_eq!(
                 rsass(
@@ -398,7 +397,6 @@ mod url {
             );
         }
         #[test]
-        #[ignore] // failing
         fn only() {
             assert_eq!(
                 rsass(


### PR DESCRIPTION
Handle `url(foo)` as simply a string if possible.  Sometimes, such as `url("foo" + $bar)`, it must be a function returning a string instead.

Partially adresses #42.  Fixes #41.