### PR TITLE
Improve how positions in input is managed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ spectest = ["yaml-rust", "deunicode", "hrx-get", "regex"]
 [dependencies]
 lazy_static = "1.0"
 nom = "5.0.0"
-nom_locate = { git = "https://github.com/fflorent/nom_locate" }
+nom_locate = "2.1.0"
 num-bigint = { version = "0.3.0", default-features = false, features = ["std"] }
 num-integer = "0.1.42"
 num-rational = { version = "0.3.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,9 @@ commandline = ["structopt"]
 spectest = ["yaml-rust", "deunicode", "hrx-get", "regex"]
 
 [dependencies]
-bytecount = "0.6.0"
 lazy_static = "1.0"
 nom = "5.0.0"
-nom_locate = "2.0.0"
+nom_locate = { git = "https://github.com/fflorent/nom_locate" }
 num-bigint = { version = "0.3.0", default-features = false, features = ["std"] }
 num-integer = "0.1.42"
 num-rational = { version = "0.3.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ spectest = ["yaml-rust", "deunicode", "hrx-get", "regex"]
 bytecount = "0.6.0"
 lazy_static = "1.0"
 nom = "5.0.0"
+nom_locate = "2.0.0"
 num-bigint = { version = "0.3.0", default-features = false, features = ["std"] }
 num-integer = "0.1.42"
 num-rational = { version = "0.3.0", default-features = false }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -172,13 +172,16 @@ fn make_call(name: &str, args: Vec<css::Value>) -> css::Value {
 #[test]
 fn test_rgb() -> Result<(), Box<dyn std::error::Error>> {
     use crate::parser::formalargs::call_args;
+    use crate::parser::Span;
     use crate::value::Rgba;
     use crate::variablescope::GlobalScope;
     let scope = GlobalScope::new(Default::default());
     assert_eq!(
         FUNCTIONS.get("rgb").unwrap().call(
             &scope,
-            &call_args(b"(17, 0, 225)")?.1.evaluate(&scope, true)?
+            &call_args(Span::new(b"(17, 0, 225)"))?
+                .1
+                .evaluate(&scope, true)?
         )?,
         css::Value::Color(Rgba::from_rgb(17, 0, 225), None)
     );

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -171,15 +171,15 @@ fn make_call(name: &str, args: Vec<css::Value>) -> css::Value {
 
 #[test]
 fn test_rgb() -> Result<(), Box<dyn std::error::Error>> {
+    use crate::parser::code_span;
     use crate::parser::formalargs::call_args;
-    use crate::test_span;
     use crate::value::Rgba;
     use crate::variablescope::GlobalScope;
     let scope = GlobalScope::new(Default::default());
     assert_eq!(
         FUNCTIONS.get("rgb").unwrap().call(
             &scope,
-            &call_args(test_span!(b"(17, 0, 225)"))?
+            &call_args(code_span(b"(17, 0, 225)"))?
                 .1
                 .evaluate(&scope, true)?
         )?,

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -172,14 +172,14 @@ fn make_call(name: &str, args: Vec<css::Value>) -> css::Value {
 #[test]
 fn test_rgb() -> Result<(), Box<dyn std::error::Error>> {
     use crate::parser::formalargs::call_args;
-    use crate::parser::Span;
+    use crate::test_span;
     use crate::value::Rgba;
     use crate::variablescope::GlobalScope;
     let scope = GlobalScope::new(Default::default());
     assert_eq!(
         FUNCTIONS.get("rgb").unwrap().call(
             &scope,
-            &call_args(Span::new(b"(17, 0, 225)"))?
+            &call_args(test_span!(b"(17, 0, 225)"))?
                 .1
                 .evaluate(&scope, true)?
         )?,

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -1,6 +1,7 @@
 use super::SassFunction;
 use crate::css::Value;
 use crate::parser::selectors::{selector, selectors};
+use crate::parser::Span;
 use crate::selectors::{Selector, Selectors};
 use crate::value::Quotes;
 use crate::{Error, ParseError};
@@ -64,11 +65,11 @@ fn parse_selectors(v: Value) -> Result<Selectors, Error> {
         Ok(Selectors::root())
     } else {
         let bytes = s.as_bytes();
-        Ok(ParseError::check(selectors(bytes), bytes)?)
+        Ok(ParseError::check(selectors(Span::new(bytes)), bytes)?)
     }
 }
 
 fn parse_selector(s: &str) -> Result<Selector, Error> {
     let bytes = s.as_bytes();
-    Ok(ParseError::check(selector(bytes), bytes)?)
+    Ok(ParseError::check(selector(Span::new(bytes)), bytes)?)
 }

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -64,12 +64,11 @@ fn parse_selectors(v: Value) -> Result<Selectors, Error> {
     if s.is_empty() {
         Ok(Selectors::root())
     } else {
-        let bytes = s.as_bytes();
-        Ok(ParseError::check(selectors(Span::new(bytes)), bytes)?)
+        // FIXME: Old code allowd a trailing comma here.  Add back or remove?
+        Ok(ParseError::check(selectors(Span::new(s.as_bytes())))?)
     }
 }
 
 fn parse_selector(s: &str) -> Result<Selector, Error> {
-    let bytes = s.as_bytes();
-    Ok(ParseError::check(selector(Span::new(bytes)), bytes)?)
+    Ok(ParseError::check(selector(Span::new(s.as_bytes())))?)
 }

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -1,7 +1,7 @@
 use super::SassFunction;
 use crate::css::Value;
+use crate::parser::code_span;
 use crate::parser::selectors::{selector, selectors};
-use crate::parser::Span;
 use crate::selectors::{Selector, Selectors};
 use crate::value::Quotes;
 use crate::{Error, ParseError};
@@ -65,10 +65,11 @@ fn parse_selectors(v: Value) -> Result<Selectors, Error> {
         Ok(Selectors::root())
     } else {
         // FIXME: Old code allowd a trailing comma here.  Add back or remove?
-        Ok(ParseError::check(selectors(Span::new(s.as_bytes())))?)
+        Ok(ParseError::check(selectors(code_span(s.as_bytes())))?)
     }
 }
 
 fn parse_selector(s: &str) -> Result<Selector, Error> {
-    Ok(ParseError::check(selector(Span::new(s.as_bytes())))?)
+    // TODO: Use a span from the value rather than claiming its hardcoded.
+    Ok(ParseError::check(selector(code_span(s.as_bytes())))?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! That said, this implementation has reached a version where I find it
 //! usable for my personal projects, and the number of working tests are
 //! improving.
-//#![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 use std::path::Path;
 
 pub mod css;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! That said, this implementation has reached a version where I find it
 //! usable for my personal projects, and the number of working tests are
 //! improving.
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 use std::path::Path;
 
 pub mod css;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::file_context::FileContext;
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_file, parse_value_data, ParseError,
+    parse_scss_data, parse_scss_file, parse_value_data, ParseError, SourcePos,
 };
 pub use crate::sass::Item;
 pub use crate::value::{Dimension, ListSeparator, Number, Quotes, Unit};

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -2,7 +2,7 @@ use super::Format;
 use crate::css::Value;
 use crate::error::Error;
 use crate::file_context::FileContext;
-use crate::parser::parse_scss_file;
+use crate::parser::parse_imported_scss_file;
 use crate::sass::{FormalArgs, Item};
 use crate::selectors::Selectors;
 use crate::variablescope::{Scope, ScopeImpl};
@@ -75,14 +75,16 @@ impl Format {
         result: &mut CssWriter,
     ) -> Result<(), Error> {
         match *item {
-            Item::Import(ref names, ref args) => {
+            Item::Import(ref names, ref args, ref pos) => {
                 if args.is_null() {
                     for name in names {
                         let (x, _q) = name.evaluate(scope)?;
                         if let Some((sub_context, file)) =
                             file_context.find_file(x.as_ref())
                         {
-                            for item in parse_scss_file(&file)? {
+                            for item in
+                                parse_imported_scss_file(&file, pos.clone())?
+                            {
                                 self.handle_root_item(
                                     &item,
                                     scope,
@@ -395,14 +397,17 @@ impl Format {
     ) -> Result<(), Error> {
         for b in body {
             match *b {
-                Item::Import(ref names, ref args) => {
+                Item::Import(ref names, ref args, ref pos) => {
                     if args.is_null() {
                         for name in names {
                             let (x, _q) = name.evaluate(scope)?;
                             if let Some((sub_context, file)) =
                                 file_context.find_file(x.as_ref())
                             {
-                                let items = parse_scss_file(&file)?;
+                                let items = parse_imported_scss_file(
+                                    &file,
+                                    pos.clone(),
+                                )?;
                                 self.handle_body(
                                     direct,
                                     sub,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// This contains an error message (currently just a String, and often
 /// not very descriptive) and informaion on where in the parsed data
 /// the error occured.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseError {
     pub msg: String,
     pub pos: SourcePos,

--- a/src/parser/formalargs.rs
+++ b/src/parser/formalargs.rs
@@ -1,6 +1,7 @@
 use super::strings::name;
 use super::util::{ignore_comments, opt_spacelike};
 use super::value::space_list;
+use super::Span;
 use crate::sass::{CallArgs, FormalArgs, Value};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -9,7 +10,7 @@ use nom::multi::separated_list;
 use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::IResult;
 
-pub fn formal_args(input: &[u8]) -> IResult<&[u8], FormalArgs> {
+pub fn formal_args(input: Span) -> IResult<Span, FormalArgs> {
     let (input, _) = terminated(tag("("), opt_spacelike)(input)?;
     let (input, v) = separated_list(
         preceded(tag(","), opt_spacelike),
@@ -31,7 +32,7 @@ pub fn formal_args(input: &[u8]) -> IResult<&[u8], FormalArgs> {
     Ok((input, FormalArgs::new(v, va.is_some())))
 }
 
-pub fn call_args(input: &[u8]) -> IResult<&[u8], CallArgs> {
+pub fn call_args(input: Span) -> IResult<Span, CallArgs> {
     let (input, _) = tag("(")(input)?;
     let (input, v) = separated_list(
         delimited(opt_spacelike, tag(","), opt_spacelike),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -64,19 +64,6 @@ pub fn code_span(value: &[u8]) -> Span {
     Span::new_extra(value, &SOURCE)
 }
 
-#[cfg(test)]
-#[macro_export]
-macro_rules! test_span {
-    ($value:expr) => {{
-        use crate::parser::{SourceName, Span};
-        use lazy_static::lazy_static;
-        lazy_static! {
-            static ref SOURCE: SourceName = SourceName::root(file!());
-        }
-        Span::new_extra($value, &SOURCE)
-    }};
-}
-
 /// Parse a scss value.
 ///
 /// Returns a single value (or an error).

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -51,10 +51,8 @@ pub type Span<'a> = LocatedSpan<&'a [u8]>;
 ///
 /// Returns a single value (or an error).
 pub fn parse_value_data(data: &[u8]) -> Result<Value, Error> {
-    Ok(ParseError::check(
-        all_consuming(value_expression)(Span::new(data)),
-        data,
-    )?)
+    let data = Span::new(data);
+    Ok(ParseError::check(all_consuming(value_expression)(data))?)
 }
 
 #[test]
@@ -79,14 +77,19 @@ pub fn parse_scss_file(file: &Path) -> Result<Vec<Item>, Error> {
     let mut data = vec![];
     f.read_to_end(&mut data)
         .map_err(|e| Error::Input(file.into(), e))?;
+    /*
     parse_scss_data(&data).map_err(|err| err.in_file(file).into())
+    */
+    // TODO: Include the file info in the Span!
+    let data = Span::new(&data);
+    Ok(ParseError::check(sassfile(data))?)
 }
 
 /// Parse scss data from a buffer.
 ///
 /// Returns a vec of the top level items of the file (or an error message).
 pub fn parse_scss_data(data: &[u8]) -> Result<Vec<Item>, ParseError> {
-    ParseError::check(sassfile(Span::new(data)), data)
+    ParseError::check(sassfile(Span::new(data)))
 }
 
 fn sassfile(input: Span) -> IResult<Span, Vec<Item>> {

--- a/src/parser/pos.rs
+++ b/src/parser/pos.rs
@@ -18,7 +18,7 @@ impl From<Span<'_>> for SourcePos {
                 .to_string(),
             line_no: span.location_line(),
             line_pos: span.get_utf8_column(),
-            file: SourceName::root("-"), // span.extra.clone(),
+            file: span.extra.clone(),
         }
     }
 }

--- a/src/parser/pos.rs
+++ b/src/parser/pos.rs
@@ -25,22 +25,32 @@ impl From<Span<'_>> for SourcePos {
 
 /// The name of a scss source file.
 ///
-/// Currently this is just a String.
-/// In a future version it should also contain the information if this
-/// was the root stylesheet or where it was imported from.
+/// This also contains the information if this was the root stylesheet
+/// or where it was imported from.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SourceName {
     name: String,
+    imported: Option<Box<SourcePos>>,
 }
 
 impl SourceName {
     pub fn root<T: ToString>(name: T) -> Self {
         SourceName {
             name: name.to_string(),
+            imported: None,
+        }
+    }
+    pub fn imported<T: ToString>(name: T, from: SourcePos) -> Self {
+        SourceName {
+            name: name.to_string(),
+            imported: Some(Box::new(from)),
         }
     }
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+    pub fn imported_from(&self) -> Option<&SourcePos> {
+        self.imported.as_ref().map(|b| b.as_ref())
     }
 }

--- a/src/parser/selectors.rs
+++ b/src/parser/selectors.rs
@@ -118,28 +118,27 @@ fn selector_part(input: Span) -> IResult<Span, SelectorPart> {
 mod test {
     use super::*;
     use crate::sass::{SassString, StringPart};
-    use crate::test_span;
     use crate::value::Quotes;
 
     #[test]
     fn simple_selector() {
-        assert_value(
-            selector(test_span!(b"foo ")),
+        assert_eq!(
+            check_parse!(selector, b"foo "),
             Selector(vec![SelectorPart::Simple("foo".into())]),
         )
     }
     #[test]
     fn escaped_simple_selector() {
-        assert_value(
-            selector(test_span!(b"\\E9m ")),
+        assert_eq!(
+            check_parse!(selector, b"\\E9m "),
             Selector(vec![SelectorPart::Simple("ém".into())]),
         )
     }
 
     #[test]
     fn selector2() {
-        assert_value(
-            selector(test_span!(b"foo bar ")),
+        assert_eq!(
+            check_parse!(selector, b"foo bar "),
             Selector(vec![
                 SelectorPart::Simple("foo".into()),
                 SelectorPart::Descendant,
@@ -150,8 +149,8 @@ mod test {
 
     #[test]
     fn child_selector() {
-        assert_value(
-            selector(test_span!(b"foo > bar ")),
+        assert_eq!(
+            check_parse!(selector, b"foo > bar "),
             Selector(vec![
                 SelectorPart::Simple("foo".into()),
                 SelectorPart::RelOp(b'>'),
@@ -162,8 +161,8 @@ mod test {
 
     #[test]
     fn foo1_selector() {
-        assert_value(
-            selector(test_span!(b"[data-icon='test-1'] ")),
+        assert_eq!(
+            check_parse!(selector, b"[data-icon='test-1'] "),
             Selector(vec![SelectorPart::Attribute {
                 name: "data-icon".into(),
                 op: "=".into(),
@@ -178,8 +177,8 @@ mod test {
 
     #[test]
     fn pseudo_selector() {
-        assert_value(
-            selector(test_span!(b":before ")),
+        assert_eq!(
+            check_parse!(selector, b":before "),
             Selector(vec![SelectorPart::Pseudo {
                 name: "before".into(),
                 arg: None,
@@ -188,8 +187,8 @@ mod test {
     }
     #[test]
     fn pseudo_on_simple_selector() {
-        assert_value(
-            selector(test_span!(b"figure:before ")),
+        assert_eq!(
+            check_parse!(selector, b"figure:before "),
             Selector(vec![
                 SelectorPart::Simple("figure".into()),
                 SelectorPart::Pseudo {
@@ -202,22 +201,12 @@ mod test {
 
     #[test]
     fn selectors_simple() {
-        assert_value(
-            selectors(test_span!(b"foo, bar ")),
+        assert_eq!(
+            check_parse!(selectors, b"foo, bar "),
             Selectors::new(vec![
                 Selector(vec![SelectorPart::Simple("foo".into())]),
                 Selector(vec![SelectorPart::Simple("bar".into())]),
             ]),
-        )
-    }
-
-    fn assert_value<T: PartialEq + std::fmt::Debug>(
-        result: IResult<Span, T>,
-        value: T,
-    ) {
-        assert_eq!(
-            result.map(|(r, v)| (*r.fragment(), v)),
-            Ok((&b""[..], value))
         )
     }
 }

--- a/src/parser/selectors.rs
+++ b/src/parser/selectors.rs
@@ -118,19 +118,20 @@ fn selector_part(input: Span) -> IResult<Span, SelectorPart> {
 mod test {
     use super::*;
     use crate::sass::{SassString, StringPart};
+    use crate::test_span;
     use crate::value::Quotes;
 
     #[test]
     fn simple_selector() {
         assert_value(
-            selector(Span::new(b"foo ")),
+            selector(test_span!(b"foo ")),
             Selector(vec![SelectorPart::Simple("foo".into())]),
         )
     }
     #[test]
     fn escaped_simple_selector() {
         assert_value(
-            selector(Span::new(b"\\E9m ")),
+            selector(test_span!(b"\\E9m ")),
             Selector(vec![SelectorPart::Simple("ém".into())]),
         )
     }
@@ -138,7 +139,7 @@ mod test {
     #[test]
     fn selector2() {
         assert_value(
-            selector(Span::new(b"foo bar ")),
+            selector(test_span!(b"foo bar ")),
             Selector(vec![
                 SelectorPart::Simple("foo".into()),
                 SelectorPart::Descendant,
@@ -150,7 +151,7 @@ mod test {
     #[test]
     fn child_selector() {
         assert_value(
-            selector(Span::new(b"foo > bar ")),
+            selector(test_span!(b"foo > bar ")),
             Selector(vec![
                 SelectorPart::Simple("foo".into()),
                 SelectorPart::RelOp(b'>'),
@@ -162,7 +163,7 @@ mod test {
     #[test]
     fn foo1_selector() {
         assert_value(
-            selector(Span::new(b"[data-icon='test-1'] ")),
+            selector(test_span!(b"[data-icon='test-1'] ")),
             Selector(vec![SelectorPart::Attribute {
                 name: "data-icon".into(),
                 op: "=".into(),
@@ -178,7 +179,7 @@ mod test {
     #[test]
     fn pseudo_selector() {
         assert_value(
-            selector(Span::new(b":before ")),
+            selector(test_span!(b":before ")),
             Selector(vec![SelectorPart::Pseudo {
                 name: "before".into(),
                 arg: None,
@@ -188,7 +189,7 @@ mod test {
     #[test]
     fn pseudo_on_simple_selector() {
         assert_value(
-            selector(Span::new(b"figure:before ")),
+            selector(test_span!(b"figure:before ")),
             Selector(vec![
                 SelectorPart::Simple("figure".into()),
                 SelectorPart::Pseudo {
@@ -202,7 +203,7 @@ mod test {
     #[test]
     fn selectors_simple() {
         assert_value(
-            selectors(Span::new(b"foo, bar ")),
+            selectors(test_span!(b"foo, bar ")),
             Selectors::new(vec![
                 Selector(vec![SelectorPart::Simple("foo".into())]),
                 Selector(vec![SelectorPart::Simple("bar".into())]),

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -1,5 +1,5 @@
 use super::value::value_expression;
-use super::{input_to_str, input_to_string};
+use super::{input_to_str, input_to_string, Span};
 use crate::sass::{SassString, StringPart};
 use crate::value::Quotes;
 use nom::branch::alt;
@@ -13,7 +13,7 @@ use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 use nom::IResult;
 use std::str::from_utf8;
 
-pub fn sass_string(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn sass_string(input: Span) -> IResult<Span, SassString> {
     let (input, first) = alt((
         string_part_interpolation,
         map(unquoted_first_part, StringPart::Raw),
@@ -32,13 +32,13 @@ pub fn sass_string(input: &[u8]) -> IResult<&[u8], SassString> {
     Ok((input, SassString::new(parts, Quotes::None)))
 }
 
-pub fn sass_string_ext(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn sass_string_ext(input: Span) -> IResult<Span, SassString> {
     let (input, parts) =
         many1(alt((string_part_interpolation, extended_part)))(input)?;
     Ok((input, SassString::new(parts, Quotes::None)))
 }
 
-fn unquoted_first_part(input: &[u8]) -> IResult<&[u8], String> {
+fn unquoted_first_part(input: Span) -> IResult<Span, String> {
     let (input, first) = alt((
         map(selector_plain_part, String::from),
         normalized_first_escaped_char,
@@ -59,7 +59,7 @@ fn unquoted_first_part(input: &[u8]) -> IResult<&[u8], String> {
         },
     )(input)
 }
-fn unquoted_part(input: &[u8]) -> IResult<&[u8], String> {
+fn unquoted_part(input: Span) -> IResult<Span, String> {
     fold_many1(
         // Note: This could probably be a whole lot more efficient,
         // but try to get stuff correct before caring too much about that.
@@ -76,7 +76,7 @@ fn unquoted_part(input: &[u8]) -> IResult<&[u8], String> {
     )(input)
 }
 
-fn normalized_first_escaped_char(input: &[u8]) -> IResult<&[u8], String> {
+fn normalized_first_escaped_char(input: Span) -> IResult<Span, String> {
     let (rest, c) = escaped_char(input)?;
     let result = if c.is_alphabetic() || u32::from(c) >= 0xa1 {
         format!("{}", c)
@@ -87,7 +87,7 @@ fn normalized_first_escaped_char(input: &[u8]) -> IResult<&[u8], String> {
     };
     Ok((rest, result))
 }
-fn normalized_escaped_char(input: &[u8]) -> IResult<&[u8], String> {
+fn normalized_escaped_char(input: Span) -> IResult<Span, String> {
     let (rest, c) = escaped_char(input)?;
     let result = if c.is_alphanumeric() || c == '-' || u32::from(c) >= 0xa1 {
         format!("{}", c)
@@ -99,7 +99,7 @@ fn normalized_escaped_char(input: &[u8]) -> IResult<&[u8], String> {
     Ok((rest, result))
 }
 
-pub fn special_function_misc(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn special_function_misc(input: Span) -> IResult<Span, SassString> {
     let (input, start) = recognize(terminated(
         alt((
             map(
@@ -122,12 +122,12 @@ pub fn special_function_misc(input: &[u8]) -> IResult<&[u8], SassString> {
     let (input, mut args) = special_args(input)?;
     let (input, end) = alt((tag(")"), tag("")))(input)?;
 
-    args.prepend(from_utf8(start).unwrap());
-    args.append_str(from_utf8(end).unwrap());
+    args.prepend(from_utf8(start.fragment()).unwrap());
+    args.append_str(from_utf8(end.fragment()).unwrap());
     Ok((input, args))
 }
 
-pub fn special_function_minmax(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn special_function_minmax(input: Span) -> IResult<Span, SassString> {
     let (input, start) = recognize(terminated(
         alt((tag_no_case("max"), tag_no_case("min"))),
         tag("("),
@@ -135,16 +135,16 @@ pub fn special_function_minmax(input: &[u8]) -> IResult<&[u8], SassString> {
     let (input, mut args) = special_args_minmax(input)?;
     let (input, end) = tag(")")(input)?;
 
-    args.prepend(&from_utf8(start).unwrap().to_lowercase());
-    args.append_str(from_utf8(end).unwrap());
+    args.prepend(&from_utf8(start.fragment()).unwrap().to_lowercase());
+    args.append_str(from_utf8(end.fragment()).unwrap());
     Ok((input, args))
 }
 
-fn special_args(input: &[u8]) -> IResult<&[u8], SassString> {
+fn special_args(input: Span) -> IResult<Span, SassString> {
     let (input, parts) = special_arg_parts(input)?;
     Ok((input, SassString::new(parts, Quotes::None)))
 }
-pub fn special_arg_parts(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
+pub fn special_arg_parts(input: Span) -> IResult<Span, Vec<StringPart>> {
     let (input, parts) = many0(alt((
         map(string_part_interpolation, |part| vec![part]),
         map(hash_no_interpolation, |s| vec![StringPart::from(s)]),
@@ -167,12 +167,12 @@ pub fn special_arg_parts(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
     Ok((input, parts.into_iter().flatten().collect()))
 }
 
-fn special_args_minmax(input: &[u8]) -> IResult<&[u8], SassString> {
+fn special_args_minmax(input: Span) -> IResult<Span, SassString> {
     let (input, parts) = special_arg_parts_minmax(input)?;
     Ok((input, SassString::new(parts, Quotes::None)))
 }
 
-fn special_arg_parts_minmax(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
+fn special_arg_parts_minmax(input: Span) -> IResult<Span, Vec<StringPart>> {
     let (input, parts) = many0(alt((
         map(special_function_misc, |s| s.into_parts()),
         map(special_function_minmax, |s| s.into_parts()),
@@ -220,7 +220,7 @@ fn special_arg_parts_minmax(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
     Ok((input, parts))
 }
 
-pub fn special_url(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn special_url(input: Span) -> IResult<Span, SassString> {
     let (input, _start) = tag("url(")(input)?;
     let (input, _trim) = many0(is_a(" "))(input)?;
     let (input, mut parts) = many1(alt((
@@ -234,13 +234,13 @@ pub fn special_url(input: &[u8]) -> IResult<&[u8], SassString> {
     Ok((input, SassString::new(parts, Quotes::None)))
 }
 
-pub fn sass_string_dq(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn sass_string_dq(input: Span) -> IResult<Span, SassString> {
     let (input, mut parts) = dq_parts(input)?;
     cleanup_escape_ws(&mut parts);
     Ok((input, SassString::new(parts, Quotes::Double)))
 }
 
-fn dq_parts(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
+fn dq_parts(input: Span) -> IResult<Span, Vec<StringPart>> {
     delimited(
         tag("\""),
         many0(alt((
@@ -255,7 +255,7 @@ fn dq_parts(input: &[u8]) -> IResult<&[u8], Vec<StringPart>> {
     )(input)
 }
 
-pub fn sass_string_sq(input: &[u8]) -> IResult<&[u8], SassString> {
+pub fn sass_string_sq(input: Span) -> IResult<Span, SassString> {
     let (input, mut parts) = delimited(
         tag("'"),
         many0(alt((
@@ -295,7 +295,7 @@ fn cleanup_escape_ws(parts: &mut [StringPart]) {
     }
 }
 
-fn normalized_escaped_char_q(input: &[u8]) -> IResult<&[u8], String> {
+fn normalized_escaped_char_q(input: Span) -> IResult<Span, String> {
     let (rest, c) = escaped_char(input)?;
     let result = if c == '\0' {
         "\u{fffd}".to_string()
@@ -309,18 +309,18 @@ fn normalized_escaped_char_q(input: &[u8]) -> IResult<&[u8], String> {
     Ok((rest, result))
 }
 
-pub fn string_part_interpolation(input: &[u8]) -> IResult<&[u8], StringPart> {
+pub fn string_part_interpolation(input: Span) -> IResult<Span, StringPart> {
     let (input, expr) =
         delimited(tag("#{"), value_expression, tag("}"))(input)?;
     Ok((input, StringPart::Interpolation(expr)))
 }
 
-fn simple_qstring_part(input: &[u8]) -> IResult<&[u8], StringPart> {
+fn simple_qstring_part(input: Span) -> IResult<Span, StringPart> {
     let (input, part) = map_res(is_not("\\#'\""), input_to_string)(input)?;
     Ok((input, StringPart::Raw(part)))
 }
 
-fn selector_string(input: &[u8]) -> IResult<&[u8], String> {
+fn selector_string(input: Span) -> IResult<Span, String> {
     fold_many1(
         // Note: This could probably be a whole lot more efficient,
         // but try to get stuff correct before caring too much about that.
@@ -341,15 +341,15 @@ fn selector_string(input: &[u8]) -> IResult<&[u8], String> {
     )(input)
 }
 
-fn selector_plain_part(input: &[u8]) -> IResult<&[u8], &str> {
+fn selector_plain_part(input: Span) -> IResult<Span, &str> {
     map_res(is_not("\r\n\t >$\"'\\#+*/()[]{}:;,=!&@"), input_to_str)(input)
 }
 
-fn hash_no_interpolation(input: &[u8]) -> IResult<&[u8], &str> {
+fn hash_no_interpolation(input: Span) -> IResult<Span, &str> {
     map_res(terminated(tag("#"), peek(not(tag("{")))), input_to_str)(input)
 }
 
-pub fn extended_part(input: &[u8]) -> IResult<&[u8], StringPart> {
+pub fn extended_part(input: Span) -> IResult<Span, StringPart> {
     let (input, part) = map_res(
         recognize(pair(
             verify(take_char, is_ext_str_start_char),
@@ -384,7 +384,7 @@ fn is_ext_str_char(c: &char) -> bool {
         || *c == '|'
 }
 
-pub fn name(input: &[u8]) -> IResult<&[u8], String> {
+pub fn name(input: Span) -> IResult<Span, String> {
     map_opt(
         fold_many0(
             alt((escaped_char, name_char)),
@@ -398,11 +398,11 @@ pub fn name(input: &[u8]) -> IResult<&[u8], String> {
     )(input)
 }
 
-pub fn name_char(input: &[u8]) -> IResult<&[u8], char> {
+pub fn name_char(input: Span) -> IResult<Span, char> {
     verify(take_char, is_name_char)(input)
 }
 
-fn escaped_char(input: &[u8]) -> IResult<&[u8], char> {
+fn escaped_char(input: Span) -> IResult<Span, char> {
     preceded(
         tag("\\"),
         alt((
@@ -429,7 +429,7 @@ fn escaped_char(input: &[u8]) -> IResult<&[u8], char> {
     )(input)
 }
 
-fn take_char(input: &[u8]) -> IResult<&[u8], char> {
+fn take_char(input: Span) -> IResult<Span, char> {
     alt((
         map_opt(take(1usize), single_char),
         map_opt(take(2usize), single_char),
@@ -439,8 +439,10 @@ fn take_char(input: &[u8]) -> IResult<&[u8], char> {
     ))(input)
 }
 
-fn single_char(data: &[u8]) -> Option<char> {
-    from_utf8(&data).ok().and_then(|s| s.chars().next())
+fn single_char(data: Span) -> Option<char> {
+    from_utf8(data.fragment())
+        .ok()
+        .and_then(|s| s.chars().next())
 }
 
 fn is_name_char(c: &char) -> bool {

--- a/src/parser/unit.rs
+++ b/src/parser/unit.rs
@@ -1,10 +1,11 @@
 use super::strings::name;
+use super::Span;
 use crate::value::Unit;
 use nom::combinator::{map_opt, value};
 use nom::IResult;
 use nom::{branch::alt, bytes::complete::tag};
 
-pub fn unit(input: &[u8]) -> IResult<&[u8], Unit> {
+pub fn unit(input: Span) -> IResult<Span, Unit> {
     alt((
         value(Unit::Percent, tag("%")),
         map_opt(name, |name| match name.as_ref() {

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -79,28 +79,22 @@ mod test {
 
     #[test]
     fn comment_simple() {
-        do_test(b"/* hello */\n", " hello ", b"\n")
+        assert_eq!(check_parse!(comment, b"/* hello */"), " hello ".into());
     }
 
     #[test]
     fn comment_with_stars() {
-        do_test(b"/**** hello ****/\n", "*** hello ***", b"\n")
+        assert_eq!(
+            check_parse!(comment, b"/**** hello ****/"),
+            "*** hello ***".into()
+        )
     }
 
     #[test]
     fn comment_with_stars2() {
-        do_test(
-            b"/* / * / * / * hello * \\ * \\ * \\ */\n",
-            " / * / * / * hello * \\ * \\ * \\ ",
-            b"\n",
-        )
-    }
-
-    fn do_test(src: &[u8], content: &str, trail: &[u8]) {
-        use crate::test_span;
         assert_eq!(
-            comment(test_span!(src)).map(|(t, c)| (*t.fragment(), c)),
-            Ok((trail, content.into())),
+            check_parse!(comment, b"/* / * / * / * hello * \\ * \\ * \\ */"),
+            " / * / * / * hello * \\ * \\ * \\ ".into()
         )
     }
 }

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -75,7 +75,7 @@ fn ignore_lcomment(input: Span) -> IResult<Span, ()> {
 
 #[cfg(test)]
 mod test {
-    use super::{comment, Span};
+    use super::comment;
 
     #[test]
     fn comment_simple() {
@@ -97,8 +97,9 @@ mod test {
     }
 
     fn do_test(src: &[u8], content: &str, trail: &[u8]) {
+        use crate::test_span;
         assert_eq!(
-            comment(Span::new(src)).map(|(t, c)| (*t.fragment(), c)),
+            comment(test_span!(src)).map(|(t, c)| (*t.fragment(), c)),
             Ok((trail, content.into())),
         )
     }

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -504,11 +504,10 @@ pub fn dictionary_inner(input: Span) -> IResult<Span, Value> {
 
 #[cfg(test)]
 mod test {
-    use super::super::parse_value_data;
+    use super::super::{code_span, parse_value_data};
     use super::*;
     use crate::sass::CallArgs;
     use crate::sass::Value::*;
-    use crate::test_span;
     use crate::value::Unit;
     use crate::variablescope::GlobalScope;
     use num_rational::Rational;
@@ -799,7 +798,7 @@ mod test {
 
     fn check_expr(expr: &str, value: Value) {
         assert_eq!(
-            value_expression(test_span!(expr.as_bytes()))
+            value_expression(code_span(expr.as_bytes()))
                 .map(|(rest, value)| (*rest.fragment(), value)),
             Ok((&b";"[..], value)),
         )

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -508,6 +508,7 @@ mod test {
     use super::*;
     use crate::sass::CallArgs;
     use crate::sass::Value::*;
+    use crate::test_span;
     use crate::value::Unit;
     use crate::variablescope::GlobalScope;
     use num_rational::Rational;
@@ -798,7 +799,7 @@ mod test {
 
     fn check_expr(expr: &str, value: Value) {
         assert_eq!(
-            value_expression(Span::new(expr.as_bytes()))
+            value_expression(test_span!(expr.as_bytes()))
                 .map(|(rest, value)| (*rest.fragment(), value)),
             Ok((&b";"[..], value)),
         )

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -1,4 +1,5 @@
 use crate::functions::SassFunction;
+use crate::parser::SourcePos;
 use crate::sass::{CallArgs, FormalArgs, SassString, Value};
 use crate::selectors::Selectors;
 
@@ -6,7 +7,7 @@ use crate::selectors::Selectors;
 /// Scoping items contains further sequences of items.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Item {
-    Import(Vec<SassString>, Value),
+    Import(Vec<SassString>, Value, SourcePos),
     VariableDeclaration {
         name: String,
         val: Value,

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -90,9 +90,10 @@ impl Selectors {
         // The "simple" parts we get from evaluating interpolations may
         // contain high-level selector separators (i.e. ","), so we need to
         // parse the selectors again, from a string representation.
-        use crate::parser::selectors::selectors;
-        let s = format!("{} ", s);
-        Ok(ParseError::check(selectors(s.as_bytes()), s.as_bytes())?)
+        use crate::parser::{selectors::selectors, Span};
+        let data = format!("{} ", s);
+        let bytes = data.as_bytes();
+        Ok(ParseError::check(selectors(Span::new(bytes)), bytes)?)
     }
 }
 

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -90,10 +90,12 @@ impl Selectors {
         // The "simple" parts we get from evaluating interpolations may
         // contain high-level selector separators (i.e. ","), so we need to
         // parse the selectors again, from a string representation.
-        use crate::parser::{selectors::selectors, Span};
-        let data = format!("{} ", s);
-        let bytes = data.as_bytes();
-        Ok(ParseError::check(selectors(Span::new(bytes)))?)
+        use crate::parser::code_span;
+        use crate::parser::selectors::selectors;
+        // TODO: Get the span from the source of self!
+        Ok(ParseError::check(selectors(code_span(
+            format!("{} ", s).as_bytes(),
+        )))?)
     }
 }
 

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -93,7 +93,7 @@ impl Selectors {
         use crate::parser::{selectors::selectors, Span};
         let data = format!("{} ", s);
         let bytes = data.as_bytes();
-        Ok(ParseError::check(selectors(Span::new(bytes)), bytes)?)
+        Ok(ParseError::check(selectors(Span::new(bytes)))?)
     }
 }
 

--- a/src/spectest/main.rs
+++ b/src/spectest/main.rs
@@ -101,8 +101,7 @@ fn handle_suite(
          \npub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {{\
          \n    let mut file_context = FileContext::new();\
          \n    file_context.push_path(\"tests/spec\".as_ref());\
-         \n    let items = parse_scss_data(input)\
-         \n        .map_err(|err| err.in_file(\"input.scss\".as_ref()))?;\
+         \n    let items = parse_scss_data(input)?;\
          \n    format.write_root(&items, &mut GlobalScope::new(format), &file_context)\
          \n}}"
     )?;

--- a/src/spectest/testfixture.rs
+++ b/src/spectest/testfixture.rs
@@ -161,8 +161,7 @@ pub fn compile_scss(
 ) -> Result<Vec<u8>, rsass::Error> {
     let mut file_context = FileContext::new();
     file_context.push_path("tests/spec".as_ref());
-    let items = parse_scss_data(input)
-        .map_err(|err| err.in_file("input.scss".as_ref()))?;
+    let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }
 

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -719,18 +719,11 @@ pub mod test {
         use nom::sequence::terminated;
         let mut scope = GlobalScope::new(Default::default());
         for &(name, val) in s {
-            scope.define(
-                name,
-                &ParseError::check(value_expression(code_span(
-                    val.as_bytes(),
-                )))?
-                .evaluate(&scope)?,
-            );
+            let val = value_expression(code_span(val.as_bytes()));
+            scope.define(name, &ParseError::check(val)?.evaluate(&scope)?);
         }
-        let foo = ParseError::check(terminated(value_expression, tag(";"))(
-            code_span(expression),
-        ))?;
-        Ok(foo
+        let expr = terminated(value_expression, tag(";"));
+        Ok(ParseError::check(expr(code_span(expression)))?
             .evaluate(&mut scope)?
             .format(scope.get_format())
             .to_string())

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -380,7 +380,7 @@ impl Scope for GlobalScope {
 
 #[cfg(test)]
 pub mod test {
-    use crate::parser::value::value_expression;
+    use crate::parser::{value::value_expression, Span};
     use crate::variablescope::*;
     use crate::{Error, ParseError};
 
@@ -729,14 +729,14 @@ pub mod test {
             let val = val.as_bytes();
             scope.define(
                 name,
-                &ParseError::check(value_expression(val), val)?
+                &ParseError::check(value_expression(Span::new(val)), val)?
                     .evaluate(&scope)?,
             );
         }
         use nom::bytes::complete::tag;
         use nom::sequence::terminated;
         let foo = ParseError::check(
-            terminated(value_expression, tag(";"))(expression),
+            terminated(value_expression, tag(";"))(Span::new(expression)),
             expression,
         )?;
         Ok(foo

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -724,21 +724,21 @@ pub mod test {
         expression: &[u8],
     ) -> Result<String, Error> {
         use crate::parser::value::value_expression;
-        use crate::parser::Span;
+        use crate::test_span;
         use nom::bytes::complete::tag;
         use nom::sequence::terminated;
         let mut scope = GlobalScope::new(Default::default());
         for &(name, ref val) in s {
             scope.define(
                 name,
-                &ParseError::check(value_expression(Span::new(
-                    val.as_bytes(),
+                &ParseError::check(value_expression(test_span!(
+                    val.as_bytes()
                 )))?
                 .evaluate(&scope)?,
             );
         }
         let foo = ParseError::check(terminated(value_expression, tag(";"))(
-            Span::new(expression),
+            test_span!(expression),
         ))?;
         Ok(foo
             .evaluate(&mut scope)?

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -45,7 +45,6 @@ fn rsass_fmt(format: Format, input: &str) -> Result<String, String> {
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let mut file_context = FileContext::new();
     file_context.push_path("tests/spec".as_ref());
-    let items = parse_scss_data(input)
-        .map_err(|err| err.in_file("input.scss".as_ref()))?;
+    let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }


### PR DESCRIPTION
Use [`nom-locate`] to provide location of errors, improving error reporting.

[`nom-locate`]: https://crates.io/crates/nom-locate
