### PR TITLE
Refactor printing of numbers

### DIFF
--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -106,17 +106,15 @@ impl<'a> fmt::Display for Formatted<'a, Number> {
             out.write_char('-')?;
         }
 
-        let mut whole = self.value.value.to_integer().abs();
-        let mut dec = String::with_capacity(
-            self.value
-                .value
-                .denom()
-                .to_string()
-                .len()
-                .min(self.format.precision),
-        );
-
         let mut frac = self.value.value.fract();
+
+        let mut whole = self.value.value.to_integer().abs();
+        let mut dec = String::with_capacity(if frac.is_zero() {
+            0
+        } else {
+            self.format.precision + 1
+        });
+
         if !frac.is_zero() {
             dec.write_char('.')?;
             for _ in 0..(self.format.precision - 1) {

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -121,11 +121,11 @@ impl<'a> fmt::Display for Formatted<'a, Number> {
                 }
             }
             if frac != Rational::from_integer(0) {
-                let f = (frac * Rational::from_integer(10))
+                let end = (frac * Rational::from_integer(10))
                     .round()
                     .abs()
                     .to_integer();
-                if f == 10 {
+                if end == 10 {
                     loop {
                         match dec.pop().unwrap() {
                             '9' => continue,
@@ -142,8 +142,19 @@ impl<'a> fmt::Display for Formatted<'a, Number> {
                             }
                         }
                     }
+                } else if end == 0 {
+                    loop {
+                        match dec.pop().unwrap() {
+                            '0' => continue,
+                            '.' => break,
+                            c => {
+                                dec.push(c);
+                                break;
+                            }
+                        }
+                    }
                 } else {
-                    write!(dec, "{}", f)?;
+                    write!(dec, "{}", end)?;
                 }
             }
         }

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -1,6 +1,6 @@
 use crate::output::{Format, Formatted};
 use num_rational::Rational;
-use num_traits::{One, Signed, Zero};
+use num_traits::{Signed, Zero};
 use std::fmt::{self, Write};
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
@@ -149,7 +149,7 @@ impl<'a> fmt::Display for Formatted<'a, Number> {
         }
 
         let skip_zero = self.format.is_compressed() || !self.value.lead_zero;
-        if (whole != 0) ^ skip_zero {
+        if !(whole == 0 && skip_zero && !dec.is_empty()) {
             write!(out, "{}", whole)?;
         }
 

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -248,17 +248,14 @@ fn test_number_nines_d() {
     check_value("-.999", "-.999");
 }
 #[test]
-#[ignore = "Should be fixed by #67"]
 fn test_number_nines_e() {
-    check_value("0.9999999", "0.9999999");
+    check_value("0.9999999", "1");
 }
 #[test]
-#[ignore = "Should be fixed by #67"]
 fn test_number_nines_f() {
-    check_value("-0.9999999", "-0.9999999");
+    check_value("-0.9999999", "-1");
 }
 #[test]
-#[ignore = "Should be fixed by #67"]
 fn test_number_zeroes_a() {
     check_value("0.000000000000000001", "0");
 }


### PR DESCRIPTION
Resolves https://github.com/kaj/rsass/issues/66

I worked with the following test cases in mind,
```
a {
    color: 0.999;
    color: -0.999;
    color: .999;
    color: -.999;
    color: 0.999999;
    color: -0.999999;
    color: 0.9999999999999999;
    color: -0.999999999999999;
    color: 0;
    color: -0;
    color: 1;
    color: -1;
    color: 0.000000000000000001;
}
```

I should note that this PR removes printing of the leading `+`. In addition, I was not completely sure about the leading 0 mechanics -- it seems that libsass prints the leading 0 in all scenarios?

It seems there is also a parsing issue with decimals going back more than 18 places,

```scss
a {
  color: 0.0000000000000000001;
}
```
panics with 
```
thread 'main' panicked at 'attempt to multiply with overflow', src\parser\value.rs:302:62
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\rsass.exe input.scss` (exit code: 101)
```

libsass output
```
a {
  color: 0.999;
  color: -0.999;
  color: 0.999;
  color: -0.999;
  color: 0.999999;
  color: -0.999999;
  color: 1;
  color: -1;
  color: 0;
  color: 0;
  color: 1;
  color: -1;
  color: 0;
}
```

rsass output (precision 10)
```
a {
  color: 0.999;
  color: -0.999;
  color: .999;
  color: -.999;
  color: 0.999999;
  color: -0.999999;
  color: 1;
  color: -1;
  color: 0;
  color: 0;
  color: 1;
  color: -1;
  color: 0;
}
```