### PR TITLE
Further optimize number printing

### DIFF
--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -259,6 +259,10 @@ fn test_number_nines_f() {
 fn test_number_zeroes_a() {
     check_value("0.000000000000000001", "0");
 }
+#[test]
+fn test_number_zeroes_b() {
+    check_value("-0.000000000000000001", "0");
+}
 
 fn check_value(input: &str, expected: &str) {
     assert_eq!(

--- a/tests/spec/non_conformant/misc/mod.rs
+++ b/tests/spec/non_conformant/misc/mod.rs
@@ -197,7 +197,6 @@ fn namespace_properties_with_script_value() {
 
 // From "sass-spec/spec/non_conformant/misc/negative_numbers.hrx"
 #[test]
-#[ignore] // wrong result
 fn negative_numbers() {
     assert_eq!(
         rsass(


### PR DESCRIPTION
This builds on https://github.com/kaj/rsass/pull/67. It's a pretty minor change but removing the allocation to add to the last char is exciting. It also changes how the negative sign is emitted such that `-0.0000000000000000001` is not printed as `-0`. 

Performance gains are small but noticeable. For a 10,000 line file that looks like
```
a {
  color: 0.45684318453159234;
  color: 0.32462456760120406;
  color: 0.8137736535327419;
  color: 0.7358225117215007;
  color: 0.17214528398099915;
  color: 0.49902566583569585;
  color: 0.338644100262644;
  color: 0.20366595024608847;
  color: 0.9913235248842889;
  color: 0.4504985674365235;
  color: 0.4019760103825616;
  color: 0.050337450640631;
  color: 0.5651205053784689;
  color: 0.3858205416141207;
  color: 0.09217890891037928;
...
```
I was able to see a consistent speedup of about 20-40ms. The speedup increases as `--precision` does.