### PR TITLE
Remove three unwraps from escaped_char

### DIFF
--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -315,22 +315,22 @@ fn escaped_char(input: &[u8]) -> IResult<&[u8], char> {
         tag("\\"),
         alt((
             value('\\', tag("\\")),
-            map(
-                terminated(
-                    recognize(many_m_n(
-                        1,
-                        6,
-                        one_of("0123456789ABCDEFabcdef"),
-                    )),
-                    opt(tag(" ")),
+            map_opt(
+                map_res(
+                    map_res(
+                        terminated(
+                            recognize(many_m_n(
+                                1,
+                                6,
+                                one_of("0123456789ABCDEFabcdef"),
+                            )),
+                            opt(tag(" ")),
+                        ),
+                        input_to_str,
+                    ),
+                    |s| u32::from_str_radix(s, 16),
                 ),
-                |hp| {
-                    std::char::from_u32(
-                        u32::from_str_radix(input_to_str(hp).unwrap(), 16)
-                            .unwrap(),
-                    )
-                    .unwrap()
-                },
+                std::char::from_u32
             ),
             take_char,
         )),

--- a/tests/fuzz_cases.rs
+++ b/tests/fuzz_cases.rs
@@ -1,0 +1,10 @@
+use rsass::{compile_scss, output};
+
+#[test]
+fn bad_escape() {
+    let format = output::Format {
+        style: output::Style::Compressed,
+        precision: 5,
+    };
+    assert!(compile_scss(b"\\d00000", format).is_err());
+}


### PR DESCRIPTION
I found through fuzzing that the minimized input `\d00000` panics upon unwrapping None. This PR adds that input as a test, and refactors escaped_char() to use additional combinators instead of unwrap calls.