### PR TITLE
More strange ways to call rgb/rgba function.

### DIFF
--- a/src/functions/colors_rgb.rs
+++ b/src/functions/colors_rgb.rs
@@ -45,7 +45,9 @@ fn do_rgba(fn_name: &str, s: &dyn Scope) -> Result<Value, Error> {
     }
 }
 
-fn values_from_list(vec: &[Value]) -> Option<(Value, Value, Value, Value)> {
+pub fn values_from_list(
+    vec: &[Value],
+) -> Option<(Value, Value, Value, Value)> {
     use crate::value::Operator::Div;
 
     if vec.len() == 3 {
@@ -85,7 +87,7 @@ fn rgba_from_values(
     Some(Value::rgba(r, g, b, a))
 }
 
-fn preserve_call(
+pub fn preserve_call(
     fn_name: &str,
     vec: Vec<Value>,
     sep: ListSeparator,

--- a/src/functions/colors_rgb.rs
+++ b/src/functions/colors_rgb.rs
@@ -1,6 +1,6 @@
 use super::{make_call, Error, SassFunction};
 use crate::css::{CallArgs, Value};
-use crate::value::{Number, Quotes, Unit};
+use crate::value::{ListSeparator, Number, Quotes, Unit};
 use crate::variablescope::Scope;
 use num_rational::Rational;
 use num_traits::{One, Zero};
@@ -26,58 +26,92 @@ fn do_rgba(fn_name: &str, s: &dyn Scope) -> Result<Value, Error> {
                 ],
             )),
         }
-    } else if let Value::List(vec, sep, bracketed) = red {
-        if vec.len() > 3 {
-            Err(Error::badarg(
-                "3 elements",
-                &Value::List(vec, sep, bracketed),
-            ))
+    } else if let Value::List(vec, sep, bracketed) = if red.is_null() {
+        s.get("channels")?
+    } else {
+        red.clone()
+    } {
+        if let Some((r, g, b, a)) = values_from_list(&vec) {
+            Ok(rgba_from_values(&r, &g, &b, &a)
+                .unwrap_or_else(|| make_call(fn_name, vec![r, g, b, a])))
         } else {
-            // If less than 3 arguments are passed, one of the arguments could be a variable containing
-            // multiple values, so we want to preserve the original separator.
-            let call_args = if vec.len() < 3 {
-                CallArgs::new(vec![(
-                    None,
-                    Value::Literal(
-                        Value::List(vec, sep, bracketed)
-                            .format(Default::default())
-                            .to_string(),
-                        Quotes::None,
-                    ),
-                )])
-            } else {
-                CallArgs::new(vec.into_iter().map(|v| (None, v)).collect())
-            };
-
-            Ok(Value::Call(fn_name.into(), call_args))
+            Ok(preserve_call(fn_name, vec, sep, bracketed))
         }
     } else {
         let green = s.get("green")?;
         let blue = s.get("blue")?;
-        if let (Ok(red), Ok(green), Ok(blue), Ok(alpha)) = (
-            to_int(&red),
-            to_int(&green),
-            to_int(&blue),
-            if a.is_null() {
-                Ok(Rational::one())
-            } else {
-                to_rational(&a)
-            },
-        ) {
-            Ok(Value::rgba(red, green, blue, alpha))
-        } else {
-            Ok(make_call(fn_name, vec![red, green, blue, a]))
-        }
+        Ok(rgba_from_values(&red, &green, &blue, &a)
+            .unwrap_or_else(|| make_call(fn_name, vec![red, green, blue, a])))
     }
 }
 
+fn values_from_list(vec: &[Value]) -> Option<(Value, Value, Value, Value)> {
+    use crate::value::Operator::Div;
+
+    if vec.len() == 3 {
+        if let Value::BinOp(a, _, Div, _, b) = &vec[2] {
+            if let (Value::Numeric(..), Value::Numeric(..)) = (&**a, &**b) {
+                Some((vec[0].clone(), vec[1].clone(), *a.clone(), *b.clone()))
+            } else {
+                None
+            }
+        } else {
+            Some((
+                vec[0].clone(),
+                vec[1].clone(),
+                vec[2].clone(),
+                Value::Null,
+            ))
+        }
+    } else {
+        None
+    }
+}
+
+fn rgba_from_values(
+    r: &Value,
+    g: &Value,
+    b: &Value,
+    a: &Value,
+) -> Option<Value> {
+    let r = to_int(r).ok()?;
+    let g = to_int(g).ok()?;
+    let b = to_int(b).ok()?;
+    let a = if a.is_null() {
+        Rational::one()
+    } else {
+        to_rational(a).ok()?
+    };
+    Some(Value::rgba(r, g, b, a))
+}
+
+fn preserve_call(
+    fn_name: &str,
+    vec: Vec<Value>,
+    sep: ListSeparator,
+    bracketed: bool,
+) -> Value {
+    Value::Call(
+        fn_name.into(),
+        CallArgs::new(vec![(
+            None,
+            Value::Literal(
+                Value::List(vec, sep, bracketed)
+                    .format(Default::default())
+                    .to_string(),
+                Quotes::None,
+            ),
+        )]),
+    )
+}
+
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
-    def!(f, rgb(red, green, blue, alpha, color), |s| do_rgba(
-        "rgb", s
-    ));
-    def!(f, rgba(red, green, blue, alpha, color), |s| do_rgba(
-        "rgba", s
-    ));
+    def!(f, rgb(red, green, blue, alpha, color, channels), |s| {
+        do_rgba("rgb", s)
+    });
+    def!(f, rgba(red, green, blue, alpha, color, channels), |s| {
+        do_rgba("rgba", s)
+    });
     fn num(v: &Rational) -> Result<Value, Error> {
         Ok(Value::Numeric(Number::from(*v), Unit::None, true))
     }

--- a/tests/spec/core_functions/color/hsl/four_args/mod.rs
+++ b/tests/spec/core_functions/color/hsl/four_args/mod.rs
@@ -38,7 +38,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn min() {
             assert_eq!(
                 rsass(
@@ -53,7 +52,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn negative() {
             assert_eq!(
                 rsass(
@@ -68,7 +66,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn positive() {
             assert_eq!(
                 rsass(
@@ -115,7 +112,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn min() {
             assert_eq!(
                 rsass(
@@ -130,7 +126,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn negative() {
             assert_eq!(
                 rsass(
@@ -145,7 +140,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn positive() {
             assert_eq!(
                 rsass(
@@ -199,7 +193,6 @@ mod clamped {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn blue() {
         assert_eq!(
             rsass(
@@ -214,7 +207,6 @@ mod clamped {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn saturation() {
         assert_eq!(
             rsass(
@@ -235,7 +227,6 @@ mod in_gamut {
     #[allow(unused)]
     use super::rsass;
     #[test]
-    #[ignore] // wrong result
     fn named() {
         assert_eq!(
         rsass(
@@ -264,7 +255,6 @@ mod in_gamut {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn partial() {
         assert_eq!(
             rsass(
@@ -279,7 +269,6 @@ mod in_gamut {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn transparent() {
         assert_eq!(
             rsass(
@@ -303,7 +292,6 @@ mod special_functions {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn arg_1() {
             assert_eq!(
                 rsass(
@@ -318,7 +306,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_2() {
             assert_eq!(
                 rsass(
@@ -333,7 +320,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 rsass(
@@ -348,7 +334,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 rsass(
@@ -367,7 +352,6 @@ mod special_functions {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn arg_1() {
             assert_eq!(
                 rsass(
@@ -382,7 +366,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_2() {
             assert_eq!(
                 rsass(
@@ -397,7 +380,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 rsass(
@@ -412,7 +394,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 rsass(
@@ -431,7 +412,6 @@ mod special_functions {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn arg_1() {
             assert_eq!(
                 rsass(
@@ -446,7 +426,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_2() {
             assert_eq!(
                 rsass(
@@ -461,7 +440,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 rsass(
@@ -476,7 +454,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 rsass(
@@ -495,7 +472,6 @@ mod special_functions {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn arg_1() {
             assert_eq!(
                 rsass(
@@ -510,7 +486,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_2() {
             assert_eq!(
                 rsass(
@@ -525,7 +500,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 rsass(
@@ -540,7 +514,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 rsass(
@@ -559,7 +532,6 @@ mod special_functions {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn arg_1() {
             assert_eq!(
                 rsass(
@@ -574,7 +546,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_2() {
             assert_eq!(
                 rsass(
@@ -589,7 +560,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 rsass(
@@ -604,7 +574,6 @@ mod special_functions {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 rsass(

--- a/tests/spec/core_functions/color/hsl/one_arg/mod.rs
+++ b/tests/spec/core_functions/color/hsl/one_arg/mod.rs
@@ -13,7 +13,6 @@ mod alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -28,7 +27,6 @@ mod alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -44,7 +42,6 @@ mod alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn lightness() {
             assert_eq!(
                 rsass(
@@ -59,7 +56,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn saturation() {
             assert_eq!(
                 rsass(
@@ -78,7 +74,6 @@ mod alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -93,7 +88,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 rsass(
@@ -108,7 +102,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         rsass(
@@ -124,7 +117,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 rsass(
@@ -139,7 +131,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 rsass(
@@ -167,7 +158,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -182,7 +172,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -201,7 +190,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -216,7 +204,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -236,7 +223,6 @@ mod no_alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn blue() {
             assert_eq!(
                 rsass(
@@ -254,7 +240,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn yellow() {
                 assert_eq!(
                     rsass(
@@ -270,7 +255,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn red() {
             assert_eq!(
                 rsass(
@@ -286,7 +270,6 @@ mod no_alpha {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn named() {
         assert_eq!(
             rsass(
@@ -307,7 +290,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn deg() {
                 assert_eq!(
                     rsass(
@@ -326,7 +308,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn unitless() {
                 assert_eq!(
                     rsass(
@@ -345,7 +326,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn unitless() {
                 assert_eq!(
                     rsass(
@@ -374,7 +354,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -389,7 +368,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -436,7 +414,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -451,7 +428,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -498,7 +474,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -513,7 +488,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -560,7 +534,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -575,7 +548,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -669,7 +641,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -684,7 +655,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -735,7 +705,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -750,7 +719,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -765,7 +733,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -784,7 +751,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -799,7 +765,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -814,7 +779,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -833,7 +797,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -848,7 +811,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -863,7 +825,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -882,7 +843,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -897,7 +857,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -912,7 +871,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -1002,7 +960,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -1017,7 +974,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -1032,7 +988,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(

--- a/tests/spec/core_functions/color/hsla/four_args/mod.rs
+++ b/tests/spec/core_functions/color/hsla/four_args/mod.rs
@@ -66,7 +66,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn positive() {
             assert_eq!(
                 rsass(

--- a/tests/spec/core_functions/color/hsla/one_arg/mod.rs
+++ b/tests/spec/core_functions/color/hsla/one_arg/mod.rs
@@ -13,7 +13,6 @@ mod alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -28,7 +27,6 @@ mod alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -44,7 +42,6 @@ mod alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn lightness() {
             assert_eq!(
                 rsass(
@@ -59,7 +56,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn saturation() {
             assert_eq!(
                 rsass(
@@ -78,7 +74,6 @@ mod alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -93,7 +88,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 rsass(
@@ -108,7 +102,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         rsass(
@@ -124,7 +117,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 rsass(
@@ -139,7 +131,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 rsass(
@@ -167,7 +158,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -182,7 +172,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -201,7 +190,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -216,7 +204,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -236,7 +223,6 @@ mod no_alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn blue() {
             assert_eq!(
                 rsass(
@@ -254,7 +240,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn yellow() {
                 assert_eq!(
                     rsass(
@@ -270,7 +255,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn red() {
             assert_eq!(
                 rsass(
@@ -286,7 +270,6 @@ mod no_alpha {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn named() {
         assert_eq!(
             rsass(
@@ -307,7 +290,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn deg() {
                 assert_eq!(
                     rsass(
@@ -326,7 +308,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn unitless() {
                 assert_eq!(
                     rsass(
@@ -345,7 +326,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn unitless() {
                 assert_eq!(
                     rsass(
@@ -374,7 +354,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -389,7 +368,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -436,7 +414,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -451,7 +428,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -498,7 +474,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -513,7 +488,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -560,7 +534,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -575,7 +548,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -669,7 +641,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -684,7 +655,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -735,7 +705,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -750,7 +719,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -765,7 +733,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -784,7 +751,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -799,7 +765,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -814,7 +779,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -833,7 +797,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -848,7 +811,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -863,7 +825,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -882,7 +843,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -897,7 +857,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -912,7 +871,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -978,7 +936,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -993,7 +950,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -1008,7 +964,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(

--- a/tests/spec/core_functions/color/rgb/one_arg/mod.rs
+++ b/tests/spec/core_functions/color/rgb/one_arg/mod.rs
@@ -13,7 +13,6 @@ mod alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -28,7 +27,6 @@ mod alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -44,7 +42,6 @@ mod alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn blue() {
             assert_eq!(
                 rsass(
@@ -59,7 +56,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn green() {
             assert_eq!(
                 rsass(
@@ -74,7 +70,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn red() {
             assert_eq!(
                 rsass(
@@ -93,7 +88,6 @@ mod alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -108,7 +102,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 rsass(
@@ -123,7 +116,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         rsass(
@@ -139,7 +131,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 rsass(
@@ -154,7 +145,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn percent() {
             assert_eq!(
                 rsass(
@@ -169,7 +159,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 rsass(
@@ -197,7 +186,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn percent() {
                 assert_eq!(
                     rsass(
@@ -213,7 +201,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn boundaries() {
             assert_eq!(
                 rsass(
@@ -231,7 +218,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn blue() {
                 assert_eq!(
                     rsass(
@@ -246,7 +232,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -261,7 +246,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn red() {
                 assert_eq!(
                     rsass(
@@ -280,7 +264,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -299,7 +282,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -319,7 +301,6 @@ mod no_alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn beaded() {
             assert_eq!(
                 rsass(
@@ -337,7 +318,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn blue() {
                 assert_eq!(
                     rsass(
@@ -352,7 +332,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -367,7 +346,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn red() {
                 assert_eq!(
                     rsass(
@@ -383,7 +361,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -398,7 +375,6 @@ mod no_alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn numbers() {
             assert_eq!(
                 rsass(
@@ -413,7 +389,6 @@ mod no_alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn springgreen() {
             assert_eq!(
                 rsass(
@@ -441,7 +416,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -456,7 +430,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -471,7 +444,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -486,7 +458,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -505,7 +476,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -520,7 +490,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -535,7 +504,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -550,7 +518,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -569,7 +536,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -584,7 +550,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -599,7 +564,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -614,7 +578,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -633,7 +596,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -648,7 +610,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -663,7 +624,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -678,7 +638,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -744,7 +703,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -759,7 +717,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -774,7 +731,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -789,7 +745,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(

--- a/tests/spec/core_functions/color/rgba/one_arg/mod.rs
+++ b/tests/spec/core_functions/color/rgba/one_arg/mod.rs
@@ -13,7 +13,6 @@ mod alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn above() {
                 assert_eq!(
                     rsass(
@@ -28,7 +27,6 @@ mod alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn below() {
                 assert_eq!(
                     rsass(
@@ -44,7 +42,6 @@ mod alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn blue() {
             assert_eq!(
                 rsass(
@@ -59,7 +56,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn green() {
             assert_eq!(
                 rsass(
@@ -74,7 +70,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn red() {
             assert_eq!(
                 rsass(
@@ -93,7 +88,6 @@ mod alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -108,7 +102,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 rsass(
@@ -123,7 +116,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         rsass(
@@ -139,7 +131,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 rsass(
@@ -154,7 +145,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn percent() {
             assert_eq!(
                 rsass(
@@ -169,7 +159,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 rsass(
@@ -197,7 +186,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn percent() {
                 assert_eq!(
                     rsass(
@@ -213,7 +201,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn boundaries() {
             assert_eq!(
                 rsass(
@@ -231,7 +218,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn blue() {
                 assert_eq!(
                     rsass(
@@ -246,7 +232,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -261,7 +246,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn red() {
                 assert_eq!(
                     rsass(
@@ -280,7 +264,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -299,7 +282,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -319,7 +301,6 @@ mod no_alpha {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn beaded() {
             assert_eq!(
                 rsass(
@@ -337,7 +318,6 @@ mod no_alpha {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn blue() {
                 assert_eq!(
                     rsass(
@@ -352,7 +332,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn green() {
                 assert_eq!(
                     rsass(
@@ -367,7 +346,6 @@ mod no_alpha {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn red() {
                 assert_eq!(
                     rsass(
@@ -383,7 +361,6 @@ mod no_alpha {
             }
         }
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 rsass(
@@ -398,7 +375,6 @@ mod no_alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn numbers() {
             assert_eq!(
                 rsass(
@@ -413,7 +389,6 @@ mod no_alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn springgreen() {
             assert_eq!(
                 rsass(
@@ -441,7 +416,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -456,7 +430,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -471,7 +444,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -486,7 +458,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -505,7 +476,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -520,7 +490,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -535,7 +504,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -550,7 +518,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -569,7 +536,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -584,7 +550,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -599,7 +564,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -614,7 +578,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -633,7 +596,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -648,7 +610,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -663,7 +624,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -678,7 +638,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(
@@ -744,7 +703,6 @@ mod special_functions {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // wrong result
             fn arg_1() {
                 assert_eq!(
                     rsass(
@@ -759,7 +717,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_2() {
                 assert_eq!(
                     rsass(
@@ -774,7 +731,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_3() {
                 assert_eq!(
                     rsass(
@@ -789,7 +745,6 @@ mod special_functions {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn arg_4() {
                 assert_eq!(
                     rsass(

--- a/tests/spec/core_functions/meta/mod.rs
+++ b/tests/spec/core_functions/meta/mod.rs
@@ -90,7 +90,6 @@ mod call {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn positional() {
                 assert_eq!(
                     rsass(


### PR DESCRIPTION
Support `rgba(r g b / a)` and `hsla(h s l / a)` functions, i.e. the `channels` parameter with div-separated alpha channel.