### PR TITLE
Do some refactoring of parse error handling

### DIFF
--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -1,9 +1,9 @@
 use super::SassFunction;
 use crate::css::Value;
-use crate::error::Error;
 use crate::parser::selectors::{selector, selectors};
 use crate::selectors::{Selector, Selectors};
 use crate::value::Quotes;
+use crate::{Error, ParseError};
 use std::collections::BTreeMap;
 
 pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
@@ -63,26 +63,12 @@ fn parse_selectors(v: Value) -> Result<Selectors, Error> {
     if s.is_empty() {
         Ok(Selectors::root())
     } else {
-        let (rest, result) = selectors(s.as_bytes())?;
-        if !rest.is_empty() && rest != b"," {
-            Err(Error::S(format!(
-                "Unexpected remains in parse_selectors: {:?}",
-                rest
-            )))
-        } else {
-            Ok(result)
-        }
+        let bytes = s.as_bytes();
+        Ok(ParseError::check(selectors(bytes), bytes)?)
     }
 }
 
 fn parse_selector(s: &str) -> Result<Selector, Error> {
-    let (rest, result) = selector(s.as_bytes())?;
-    if !rest.is_empty() {
-        Err(Error::S(format!(
-            "Unexpected remains in parse_selector: {:?}",
-            rest
-        )))
-    } else {
-        Ok(result)
-    }
+    let bytes = s.as_bytes();
+    Ok(ParseError::check(selector(bytes), bytes)?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,13 @@ pub mod selectors;
 mod value;
 mod variablescope;
 
-pub use crate::error::{ErrPos, Error};
+pub use crate::error::Error;
 pub use crate::file_context::FileContext;
 pub use crate::functions::SassFunction;
 use crate::output::Format;
-pub use crate::parser::{parse_scss_data, parse_scss_file, parse_value_data};
+pub use crate::parser::{
+    parse_scss_data, parse_scss_file, parse_value_data, ParseError,
+};
 pub use crate::sass::Item;
 pub use crate::value::{ListSeparator, Number, Quotes, Unit};
 pub use crate::variablescope::{GlobalScope, Scope};
@@ -103,12 +105,7 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 /// ```
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let file_context = FileContext::new();
-    let items =
-        parse_scss_data(input).map_err(|(pos, kind)| Error::ParseError {
-            file: "-".into(),
-            pos: ErrPos::pos_of(pos, input),
-            kind,
-        })?;
+    let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }
 

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,0 +1,90 @@
+use super::{SourceName, SourcePos};
+use nom::error::ErrorKind;
+use nom::{Err, IResult};
+use std::fmt;
+use std::path::Path;
+
+/// An error encountered when parsing sass.
+///
+/// This contains an error message (currently just a String, and often
+/// not very descriptive) and informaion on where in the parsed data
+/// the error occured.
+#[derive(Debug)]
+pub struct ParseError {
+    pub msg: String,
+    pub pos: SourcePos,
+}
+
+impl std::error::Error for ParseError {}
+
+impl ParseError {
+    /// Check a nom result for errors.
+    ///
+    /// This is not a `From` implementation for two reasons:
+    /// 1. It needs a reference to the original data to find the position.
+    /// 2. An `Ok` result with remaining unparsed data is also considered an error.
+    pub fn check<T>(res: IResult<&[u8], T>, data: &[u8]) -> Result<T, Self> {
+        match res {
+            Ok((b"", items)) => Ok(items),
+            Ok((rest, _styles)) => Err(ParseError::remaining(rest, data)),
+            Err(Err::Error((rest, err))) => {
+                Err(ParseError::err(err, rest, data))
+            }
+            Err(Err::Incomplete(_needed)) => {
+                Err(ParseError::incomplete(data))
+            }
+            Err(Err::Failure((rest, err))) => {
+                Err(ParseError::err(err, rest, data))
+            }
+        }
+    }
+
+    fn remaining(span: &[u8], data: &[u8]) -> ParseError {
+        ParseError {
+            msg: "Expected end of file.".into(),
+            pos: SourcePos::pos_of(span, data),
+        }
+    }
+    fn incomplete(data: &[u8]) -> ParseError {
+        ParseError {
+            msg: "Unexpected end of file.".into(),
+            pos: SourcePos::pos_of(&data[data.len()..], data),
+        }
+    }
+    fn err(kind: ErrorKind, span: &[u8], data: &[u8]) -> ParseError {
+        ParseError {
+            msg: format!("Parse error: {:?}", kind),
+            pos: SourcePos::pos_of(span, data),
+        }
+    }
+
+    /// Add information about in what file an error occurred to self.
+    pub fn in_file(mut self, file: &Path) -> Self {
+        self.pos.file = SourceName::root(file.to_string_lossy());
+        self
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
+        let line_no = self.pos.line_no.to_string();
+        write!(
+            out,
+            "{msg}\
+             \n{0:lnw$} ,\
+             \n{ln} | {line}\
+             \n{0:lnw$} | {0:>lpos$}^\
+             \n{0:lnw$} '\
+             \n{0:lnw$} {file} {ln}:{lpos}  {cause}",
+            "",
+            line = self.pos.line,
+            msg = self.msg,
+            ln = line_no,
+            lnw = line_no.len(),
+            lpos = self.pos.line_pos,
+            file = self.pos.file.name(),
+            cause = "root stylesheet", // TODO: Handle imports
+        )?;
+        Ok(())
+    }
+}

--- a/src/parser/pos.rs
+++ b/src/parser/pos.rs
@@ -1,0 +1,51 @@
+use std::str::from_utf8;
+
+/// A position in sass input.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SourcePos {
+    pub line: String,
+    pub line_no: u32,
+    pub line_pos: usize,
+    pub file: SourceName,
+}
+
+impl SourcePos {
+    pub fn pos_of(part: &[u8], whole: &[u8]) -> SourcePos {
+        let index = whole.len() - part.len();
+        let before = &whole[0..index];
+        let line_start = before.rsplit(|c| *c == b'\n').next().unwrap();
+        let line_end = part.split(|c| *c == b'\n').next().unwrap();
+        let line_bytes =
+            &whole[index - line_start.len()..index + line_end.len()];
+        SourcePos {
+            line: from_utf8(line_bytes)
+                .unwrap_or("<<failed to display line>>")
+                .to_string(),
+            line_no: 1 + bytecount::count(before, b'\n') as u32,
+            line_pos: bytecount::num_chars(line_start),
+            file: SourceName::root("-"),
+        }
+    }
+}
+
+/// The name of a scss source file.
+///
+/// Currently this is just a String.
+/// In a future version it should also contain the information if this
+/// was the root stylesheet or where it was imported from.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SourceName {
+    name: String,
+}
+
+impl SourceName {
+    pub fn root<T: ToString>(name: T) -> Self {
+        SourceName {
+            name: name.to_string(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -7,10 +7,10 @@
 //! This _may_ change to a something like a tree of operators with
 //! leafs of simple selectors in some future release.
 use crate::css::Value;
-use crate::error::Error;
 use crate::sass::SassString;
 use crate::value::{ListSeparator, Quotes};
 use crate::variablescope::Scope;
+use crate::{Error, ParseError};
 use std::fmt;
 use std::io::Write;
 
@@ -91,7 +91,8 @@ impl Selectors {
         // contain high-level selector separators (i.e. ","), so we need to
         // parse the selectors again, from a string representation.
         use crate::parser::selectors::selectors;
-        Ok(selectors(format!("{} ", s).as_bytes())?.1)
+        let s = format!("{} ", s);
+        Ok(ParseError::check(selectors(s.as_bytes()), s.as_bytes())?)
     }
 }
 

--- a/src/spectest/main.rs
+++ b/src/spectest/main.rs
@@ -71,7 +71,7 @@ fn handle_suite(
     writeln!(
         rs,
         "use rsass::output::Format;\
-         \nuse rsass::{{parse_scss_data, ErrPos, Error, FileContext, GlobalScope}};",
+         \nuse rsass::{{parse_scss_data, Error, FileContext, GlobalScope}};",
     )?;
 
     handle_entries(&mut rs, &base, &suitedir, &rssuitedir, None, ignored)
@@ -98,12 +98,8 @@ fn handle_suite(
          \npub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {{\
          \n    let mut file_context = FileContext::new();\
          \n    file_context.push_path(\"tests/spec\".as_ref());\
-         \n    let items =\
-         \n        parse_scss_data(input).map_err(|(pos, kind)| Error::ParseError {{\
-         \n            file: \"input.scss\".into(),\
-         \n            pos: ErrPos::pos_of(pos, input),\
-         \n            kind,\
-         \n        }})?;\
+         \n    let items = parse_scss_data(input)\
+         \n        .map_err(|err| err.in_file(\"input.scss\".as_ref()))?;\
          \n    format.write_root(&items, &mut GlobalScope::new(format), &file_context)\
          \n}}"
     )?;

--- a/src/spectest/testfixture.rs
+++ b/src/spectest/testfixture.rs
@@ -4,7 +4,7 @@ use super::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 use rsass::output::Format;
-use rsass::{parse_scss_data, ErrPos, FileContext, GlobalScope};
+use rsass::{parse_scss_data, FileContext, GlobalScope};
 use std::io::Write;
 
 pub struct TestFixture {
@@ -161,13 +161,8 @@ pub fn compile_scss(
 ) -> Result<Vec<u8>, rsass::Error> {
     let mut file_context = FileContext::new();
     file_context.push_path("tests/spec".as_ref());
-    let items = parse_scss_data(input).map_err(|(pos, kind)| {
-        rsass::Error::ParseError {
-            file: "input.scss".into(),
-            pos: ErrPos::pos_of(pos, input),
-            kind,
-        }
-    })?;
+    let items = parse_scss_data(input)
+        .map_err(|err| err.in_file("input.scss".as_ref()))?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }
 

--- a/tests/spec/libsass_closed_issues/mod.rs
+++ b/tests/spec/libsass_closed_issues/mod.rs
@@ -8930,7 +8930,7 @@ fn issue_2625() {
 
 // From "sass-spec/spec/libsass-closed-issues/issue_2633.hrx"
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn issue_2633() {
     assert_eq!(
         rsass(

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -4,7 +4,7 @@
 //! The following tests are excluded from conversion:
 //! ["core_functions/selector/extend", "core_functions/selector/is_superselector", "core_functions/selector/unify", "directives/forward", "directives/use", "libsass-closed-issues/issue_185/mixin.hrx", "libsass-todo-issues/issue_221262.hrx", "libsass-todo-issues/issue_221292.hrx", "libsass/Sa\u{301}ss-UT\u{327}F8.hrx", "libsass/unicode-bom/utf-16-big", "libsass/unicode-bom/utf-16-little", "non_conformant/scss/huge.hrx", "non_conformant/scss/mixin-content.hrx", "non_conformant/scss/multiline_var.hrx"]
 use rsass::output::Format;
-use rsass::{parse_scss_data, ErrPos, Error, FileContext, GlobalScope};
+use rsass::{parse_scss_data, Error, FileContext, GlobalScope};
 
 mod arguments;
 
@@ -42,11 +42,7 @@ fn rsass_fmt(format: Format, input: &str) -> Result<String, String> {
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let mut file_context = FileContext::new();
     file_context.push_path("tests/spec".as_ref());
-    let items =
-        parse_scss_data(input).map_err(|(pos, kind)| Error::ParseError {
-            file: "input.scss".into(),
-            pos: ErrPos::pos_of(pos, input),
-            kind,
-        })?;
+    let items = parse_scss_data(input)
+        .map_err(|err| err.in_file("input.scss".as_ref()))?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }

--- a/tests/spec/non_conformant/scss_tests/mod.rs
+++ b/tests/spec/non_conformant/scss_tests/mod.rs
@@ -1885,7 +1885,7 @@ fn t116_test_selector_interpolation_at_dashes() {
 
 // From "sass-spec/spec/non_conformant/scss-tests/118_test_parent_selector_with_parent_and_subject.hrx"
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn t118_test_parent_selector_with_parent_and_subject() {
     assert_eq!(
         rsass(


### PR DESCRIPTION
Unify `ParseError` and `Error`, so the ParseError case of Error just contains a ParseError struct. This also makes the reporting of a parse error look like in dart-sass, including a copy of the actual text on the line where it occurred.

Add a `check` method in `ParseError` to convert a `nom::IResult` to a `Result` with a possible `ParseError`, and get rid of the bogus conversion from `nom::IResult` to `Error::S`.