### PR TITLE
Refactor and improve numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to
 
 * `SourceName` and `sass::Item::Import` was changed by #62.
 * `Use` was added to the `sass::Item` enum by #80.
+* Changes to `sass::Value` and `css::Vaue` by #81.
 
 ### Improvements
 
@@ -24,6 +25,11 @@ project adheres to
   located spans by [nom_locate](https://lib.rs/crates/nom_locate) in
   the parser.  A `sass::Item::Import` now handles where each file is
   imported from, to improve error reporting.
+* PR #81: Improved number handlig.  Now `Value::Number` handles both
+  machine-sized rationals, bignum rationals and floats internally and
+  `Value::NumberBig` is removed.  Also, `Value` no longer implemnts
+  `Ord` but only `PartialOrd`, to handle f64 NaN an infinite values
+  correctly.
 * Improve parsing of `@else` clauses.
 * Update spec to 2020-10-29.
 

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -7,7 +7,7 @@ use std::fmt;
 ///
 /// Each argument has a Value.  Arguments may be named.
 /// If the optional name is None, the argument is positional.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct CallArgs(pub Vec<(Option<String>, Value)>);
 
 impl CallArgs {

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -8,7 +8,7 @@ use num_rational::Rational;
 use std::convert::TryFrom;
 
 /// A css value.
-#[derive(Clone, Debug, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialOrd)]
 pub enum Value {
     /// A special kind of escape.  Only really used for !important.
     Bang(String),

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -248,7 +248,7 @@ impl PartialEq for Value {
                 if au == bu {
                     a == b
                 } else if let Some(scale) = bu.scale_to(au) {
-                    a.value == &b.value * &scale
+                    a == &(b * &scale)
                 } else {
                     false
                 }

--- a/src/css/valueformat.rs
+++ b/src/css/valueformat.rs
@@ -37,9 +37,6 @@ impl<'a> Display for Formatted<'a, Value> {
             Value::Numeric(ref num, ref unit, _) => {
                 write!(out, "{}{}", num.format(self.format), unit)
             }
-            Value::NumericBig(ref num, ref unit, _) => {
-                write!(out, "{}{}", num.format(self.format), unit)
-            }
             Value::Color(ref rgba, ref name) => {
                 if let Some(ref name) = *name {
                     name.fmt(out)

--- a/src/functions/color/hsl.rs
+++ b/src/functions/color/hsl.rs
@@ -61,7 +61,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         (c @ Value::Color(..), Value::Null) => Ok(c),
         (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
             let (h, s, l, alpha) = rgba.to_hsla();
-            Ok(Value::hsla(h + v.as_ratio(), s, l, alpha))
+            Ok(Value::hsla(h + v.as_ratio()?, s, l, alpha))
         }
         (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
     });
@@ -83,7 +83,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         (Value::Color(c, _), Value::Null) => Ok(Value::Color(c, None)),
         (Value::Color(rgba, _), Value::Numeric(v, u, _)) => {
             let (h, s, l, alpha) = rgba.to_hsla();
-            let v = v.as_ratio();
+            let v = v.as_ratio()?;
             let v = if u == Unit::Percent { v / 100 } else { v };
             Ok(Value::hsla(h, s + v, l, alpha))
         }
@@ -183,7 +183,7 @@ fn percentage(v: Rational) -> Value {
 
 fn to_rational(v: &Value) -> Result<Rational, Error> {
     match v {
-        Value::Numeric(v, ..) => Ok(v.as_ratio()),
+        Value::Numeric(v, ..) => v.as_ratio(),
         v => Err(Error::badarg("number", v)),
     }
 }
@@ -193,9 +193,9 @@ fn to_rational(v: &Value) -> Result<Rational, Error> {
 fn to_rational_percent(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio()? / 100),
         Value::Numeric(v, ..) => {
-            let v = v.as_ratio();
+            let v = v.as_ratio()?;
             Ok(if v <= Rational::one() { v } else { v / 100 })
         }
         v => Err(Error::badarg("number", &v)),
@@ -206,8 +206,8 @@ fn to_rational_percent(v: &Value) -> Result<Rational, Error> {
 fn to_rational2(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
-        Value::Numeric(v, ..) => Ok(v.as_ratio()),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio()? / 100),
+        Value::Numeric(v, ..) => Ok(v.as_ratio()?),
         v => Err(Error::badarg("number", &v)),
     }
 }

--- a/src/functions/color/hsl.rs
+++ b/src/functions/color/hsl.rs
@@ -61,7 +61,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         (c @ Value::Color(..), Value::Null) => Ok(c),
         (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
             let (h, s, l, alpha) = rgba.to_hsla();
-            Ok(Value::hsla(h + v.value, s, l, alpha))
+            Ok(Value::hsla(h + v.as_ratio(), s, l, alpha))
         }
         (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
     });
@@ -83,7 +83,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
         (Value::Color(c, _), Value::Null) => Ok(Value::Color(c, None)),
         (Value::Color(rgba, _), Value::Numeric(v, u, _)) => {
             let (h, s, l, alpha) = rgba.to_hsla();
-            let v = v.value;
+            let v = v.as_ratio();
             let v = if u == Unit::Percent { v / 100 } else { v };
             Ok(Value::hsla(h, s + v, l, alpha))
         }
@@ -183,7 +183,7 @@ fn percentage(v: Rational) -> Value {
 
 fn to_rational(v: &Value) -> Result<Rational, Error> {
     match v {
-        Value::Numeric(v, ..) => Ok(v.value),
+        Value::Numeric(v, ..) => Ok(v.as_ratio()),
         v => Err(Error::badarg("number", v)),
     }
 }
@@ -193,9 +193,9 @@ fn to_rational(v: &Value) -> Result<Rational, Error> {
 fn to_rational_percent(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.value / 100),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
         Value::Numeric(v, ..) => {
-            let v = v.value;
+            let v = v.as_ratio();
             Ok(if v <= Rational::one() { v } else { v / 100 })
         }
         v => Err(Error::badarg("number", &v)),
@@ -206,8 +206,8 @@ fn to_rational_percent(v: &Value) -> Result<Rational, Error> {
 fn to_rational2(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.value / 100),
-        Value::Numeric(v, ..) => Ok(v.value),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
+        Value::Numeric(v, ..) => Ok(v.as_ratio()),
         v => Err(Error::badarg("number", &v)),
     }
 }

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -98,7 +98,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     fn fade_in(color: Value, amount: Value) -> Result<Value, Error> {
         match (color, amount) {
             (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
-                let a = rgba.alpha + v.as_ratio();
+                let a = rgba.alpha + v.as_ratio()?;
                 Ok(Value::rgba(rgba.red, rgba.green, rgba.blue, a))
             }
             (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
@@ -109,7 +109,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     fn fade_out(color: Value, amount: Value) -> Result<Value, Error> {
         match (color, amount) {
             (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
-                let a = rgba.alpha - v.as_ratio();
+                let a = rgba.alpha - v.as_ratio()?;
                 Ok(Value::rgba(rgba.red, rgba.green, rgba.blue, a))
             }
             (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
@@ -189,7 +189,7 @@ pub fn expose(meta: &Module, global: &mut Module) {
 
 fn to_rational(v: Value) -> Result<Rational, Error> {
     match v {
-        Value::Numeric(v, ..) => Ok(v.as_ratio()),
+        Value::Numeric(v, ..) => v.as_ratio(),
         v => Err(Error::badarg("number", &v)),
     }
 }
@@ -202,9 +202,9 @@ fn to_rational(v: Value) -> Result<Rational, Error> {
 fn to_rational_percent(v: Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio()? / 100),
         Value::Numeric(v, ..) => {
-            let v = v.as_ratio();
+            let v = v.as_ratio()?;
             Ok(if v.abs() < Rational::one() {
                 v
             } else {

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -98,7 +98,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     fn fade_in(color: Value, amount: Value) -> Result<Value, Error> {
         match (color, amount) {
             (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
-                let a = rgba.alpha + v.value;
+                let a = rgba.alpha + v.as_ratio();
                 Ok(Value::rgba(rgba.red, rgba.green, rgba.blue, a))
             }
             (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
@@ -109,7 +109,7 @@ pub fn register(f: &mut BTreeMap<&'static str, SassFunction>) {
     fn fade_out(color: Value, amount: Value) -> Result<Value, Error> {
         match (color, amount) {
             (Value::Color(rgba, _), Value::Numeric(v, ..)) => {
-                let a = rgba.alpha - v.value;
+                let a = rgba.alpha - v.as_ratio();
                 Ok(Value::rgba(rgba.red, rgba.green, rgba.blue, a))
             }
             (c, v) => Err(Error::badargs(&["color", "number"], &[&c, &v])),
@@ -189,7 +189,7 @@ pub fn expose(meta: &Module, global: &mut Module) {
 
 fn to_rational(v: Value) -> Result<Rational, Error> {
     match v {
-        Value::Numeric(v, ..) => Ok(v.value),
+        Value::Numeric(v, ..) => Ok(v.as_ratio()),
         v => Err(Error::badarg("number", &v)),
     }
 }
@@ -202,12 +202,15 @@ fn to_rational(v: Value) -> Result<Rational, Error> {
 fn to_rational_percent(v: Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, Unit::Percent, _) => Ok(v.value / 100),
-        Value::Numeric(v, ..) => Ok(if v.value.abs() < Rational::one() {
-            v.value
-        } else {
-            v.value / 100
-        }),
+        Value::Numeric(v, Unit::Percent, _) => Ok(v.as_ratio() / 100),
+        Value::Numeric(v, ..) => {
+            let v = v.as_ratio();
+            Ok(if v.abs() < Rational::one() {
+                v
+            } else {
+                v / 100
+            })
+        }
         v => Err(Error::badarg("number", &v)),
     }
 }

--- a/src/functions/math.rs
+++ b/src/functions/math.rs
@@ -282,13 +282,15 @@ fn find_extreme(v: &[Value], pref: Ordering) -> &Value {
                     &Value::Numeric(ref vb, ref ub, _),
                 ) => {
                     if ua == &Unit::None || ua == ub || ub == &Unit::None {
-                        if va.cmp(vb) == pref {
+                        if va.partial_cmp(vb) == Some(pref) {
                             first
                         } else {
                             second
                         }
                     } else if let Some(scale) = ub.scale_to(ua) {
-                        if va.value.cmp(&(&vb.value * &scale)) == pref {
+                        if va.value.partial_cmp(&(&vb.value * &scale))
+                            == Some(pref)
+                        {
                             first
                         } else {
                             second

--- a/src/functions/math.rs
+++ b/src/functions/math.rs
@@ -23,18 +23,18 @@ pub fn create_module() -> Module {
         let (mut num, mut u) = get_numeric(s, "number")?;
         let (max_v, max_u) = get_numeric(s, "max")?;
         if let Some(scale) = max_u.scale_to(&u) {
-            if num.value >= &max_v.value * &scale {
+            if num >= &max_v * &scale {
                 num = max_v;
                 u = max_u;
             }
         }
         if let Some(scale) = min_u.scale_to(&u) {
-            if num.value <= &min_v.value * &scale {
+            if num <= &min_v * &scale {
                 num = min_v;
                 u = min_u;
             }
         }
-        Ok(number(num.value, u))
+        Ok(number(num, u))
     });
     def!(f, floor(number), |s| {
         let (val, unit) = get_numeric(s, "number")?;
@@ -68,7 +68,7 @@ pub fn create_module() -> Module {
                 for v in rest {
                     let (vv, vu) = as_numeric(v)?;
                     if let Some(scale) = vu.scale_to(&unit) {
-                        sum += f64::from(vv.value * scale).powi(2);
+                        sum += f64::from(vv * scale).powi(2);
                     } else {
                         return Err(Error::badarg(&unit.to_string(), v));
                     }
@@ -157,7 +157,7 @@ pub fn create_module() -> Module {
     // - - - Other Functions - - -
     def!(f, percentage(number), |s| match s.get("number")? {
         Value::Numeric(val, Unit::None, _) => {
-            Ok(number(val.value * 100, Unit::Percent))
+            Ok(number(val * 100, Unit::Percent))
         }
         v => Err(Error::badarg("number", &v)),
     });
@@ -219,7 +219,7 @@ fn as_radians(v: &Value) -> Result<f64, Error> {
             if u == &Unit::None {
                 Ok(f64::from(vv.clone()))
             } else if let Some(scale) = u.scale_to(&Unit::Rad) {
-                Ok(f64::from(&vv.value * &scale))
+                Ok(f64::from(vv * &scale))
             } else {
                 Err(Error::badarg("angle", &v))
             }
@@ -288,9 +288,7 @@ fn find_extreme(v: &[Value], pref: Ordering) -> &Value {
                             second
                         }
                     } else if let Some(scale) = ub.scale_to(ua) {
-                        if va.value.partial_cmp(&(&vb.value * &scale))
-                            == Some(pref)
-                        {
+                        if va.partial_cmp(&(vb * &scale)) == Some(pref) {
                             first
                         } else {
                             second

--- a/src/functions/math.rs
+++ b/src/functions/math.rs
@@ -2,7 +2,6 @@ use super::{Error, Module, SassFunction, Scope};
 use crate::css::Value;
 use crate::value::{Number, Quotes, Unit};
 use num_rational::Rational;
-use num_traits::Signed;
 use rand::{thread_rng, Rng};
 use std::cmp::Ordering;
 
@@ -24,13 +23,13 @@ pub fn create_module() -> Module {
         let (mut num, mut u) = get_numeric(s, "number")?;
         let (max_v, max_u) = get_numeric(s, "max")?;
         if let Some(scale) = max_u.scale_to(&u) {
-            if num.value >= &max_v.value * scale {
+            if num.value >= &max_v.value * &scale {
                 num = max_v;
                 u = max_u;
             }
         }
         if let Some(scale) = min_u.scale_to(&u) {
-            if num.value <= &min_v.value * scale {
+            if num.value <= &min_v.value * &scale {
                 num = min_v;
                 u = min_u;
             }
@@ -69,12 +68,12 @@ pub fn create_module() -> Module {
                 for v in rest {
                     let (vv, vu) = as_numeric(v)?;
                     if let Some(scale) = vu.scale_to(&unit) {
-                        sum += f64::from(vv * scale).powi(2);
+                        sum += f64::from(vv.value * scale).powi(2);
                     } else {
                         return Err(Error::badarg(&unit.to_string(), v));
                     }
                 }
-                Ok(float_value(sum.sqrt(), unit))
+                Ok(number(sum.sqrt(), unit))
             } else {
                 Err(Error::badarg("number", &Value::Null))
             }
@@ -88,30 +87,26 @@ pub fn create_module() -> Module {
         let num = as_unitless(&s.get("number")?)?;
         let base = as_unitless_or(&s.get("base")?, std::f64::consts::E)?;
         let result = num.log(base);
-        Ok(float_value(result, Unit::None))
+        Ok(number(result, Unit::None))
     });
     def!(f, pow(base, exponent), |s| {
         let base = as_unitless(&s.get("base")?)?;
         let exponent = as_unitless(&s.get("exponent")?)?;
-        Ok(float_value(base.powf(exponent), Unit::None))
+        Ok(number(base.powf(exponent), Unit::None))
     });
     def!(f, sqrt(number), |s| {
-        let number = as_unitless(&s.get("number")?)?;
-        Ok(float_value(number.sqrt(), Unit::None))
+        Ok(number(as_unitless(&s.get("number")?)?.sqrt(), Unit::None))
     });
 
     // - - - Trigonometric Functions - - -
     def!(f, cos(number), |s| {
-        let val = as_radians(&s.get("number")?)?;
-        Ok(float_value(val.cos(), Unit::None))
+        Ok(number(as_radians(&s.get("number")?)?.cos(), Unit::None))
     });
     def!(f, sin(number), |s| {
-        let val = as_radians(&s.get("number")?)?;
-        Ok(float_value(val.sin(), Unit::None))
+        Ok(number(as_radians(&s.get("number")?)?.sin(), Unit::None))
     });
     def!(f, tan(number), |s| {
-        let val = as_radians(&s.get("number")?)?;
-        Ok(float_value(val.tan(), Unit::None))
+        Ok(number(as_radians(&s.get("number")?)?.tan(), Unit::None))
     });
 
     def!(f, acos(number), |s| {
@@ -125,7 +120,9 @@ pub fn create_module() -> Module {
     });
     def!(f, atan2(y, x), |s| {
         let (y, y_unit) = as_numeric(&s.get("y")?)?;
-        let (mut x, x_unit) = as_numeric(&s.get("x")?)?;
+        let (x, x_unit) = as_numeric(&s.get("x")?)?;
+        let y = y.value;
+        let mut x = x.value;
         if let Some(scale) = x_unit.scale_to(&y_unit) {
             x = x * scale;
         }
@@ -170,7 +167,9 @@ pub fn create_module() -> Module {
             Ok(number(Rational::new(intrand(rez), rez), Unit::None))
         }
         Value::Numeric(val, ..) => {
-            let bound = val.to_integer();
+            let bound = val
+                .to_integer()
+                .ok_or_else(|| Error::S("bound must be > 0".into()))?;
             if bound > 0 {
                 let res = 1 + intrand(bound);
                 Ok(number(Rational::from_integer(res), Unit::None))
@@ -207,10 +206,7 @@ pub fn expose(math: &Module, global: &mut Module) {
     }
 }
 
-fn get_numeric(
-    s: &dyn Scope,
-    name: &str,
-) -> Result<(Number<isize>, Unit), Error> {
+fn get_numeric(s: &dyn Scope, name: &str) -> Result<(Number, Unit), Error> {
     match s.get(name)? {
         Value::Numeric(v, u, ..) => Ok((v, u)),
         v => Err(Error::badarg("number", &v)),
@@ -223,7 +219,7 @@ fn as_radians(v: &Value) -> Result<f64, Error> {
             if u == &Unit::None {
                 Ok(f64::from(vv.clone()))
             } else if let Some(scale) = u.scale_to(&Unit::Rad) {
-                Ok(f64::from(vv.clone() * scale))
+                Ok(f64::from(&vv.value * &scale))
             } else {
                 Err(Error::badarg("angle", &v))
             }
@@ -257,37 +253,21 @@ fn as_unitless_or(v: &Value, default: f64) -> Result<f64, Error> {
     }
 }
 
-fn as_numeric(v: &Value) -> Result<(Number<isize>, Unit), Error> {
+fn as_numeric(v: &Value) -> Result<(Number, Unit), Error> {
     match v {
         Value::Numeric(v, u, ..) => Ok((v.clone(), u.clone())),
         v => Err(Error::badarg("number", &v)),
     }
 }
 
-fn number(v: Rational, unit: Unit) -> Value {
-    Value::Numeric(Number::from(v), unit, true)
+fn number<T: Into<Number>>(v: T, unit: Unit) -> Value {
+    Value::Numeric(v.into(), unit, true)
 }
 
 /// convert f64 in radians (used by rust) to numeric Value in degrees
 /// (used by sass).
 fn deg_value(rad: f64) -> Value {
-    float_value(rad.to_degrees(), Unit::Deg)
-}
-
-fn float_value(val: f64, unit: Unit) -> Value {
-    if let Some(result) = Rational::approximate_float(val) {
-        number(result, unit)
-    } else {
-        if val.is_infinite() {
-            if val.is_sign_negative() {
-                "-Infinity".into()
-            } else {
-                "Infinity".into()
-            }
-        } else {
-            val.to_string().into()
-        }
-    }
+    number(rad.to_degrees(), Unit::Deg)
 }
 
 fn find_extreme(v: &[Value], pref: Ordering) -> &Value {
@@ -308,7 +288,7 @@ fn find_extreme(v: &[Value], pref: Ordering) -> &Value {
                             second
                         }
                     } else if let Some(scale) = ub.scale_to(ua) {
-                        if va.value.cmp(&(vb.value * scale)) == pref {
+                        if va.value.cmp(&(&vb.value * &scale)) == pref {
                             first
                         } else {
                             second

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -30,7 +30,7 @@ type BuiltinFn =
 ///
 /// The function can be either "builtin" (implemented in rust) or
 /// "user defined" (implemented in scss).
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct SassFunction {
     args: sass::FormalArgs,
     body: FuncImpl,
@@ -44,25 +44,18 @@ pub enum FuncImpl {
 
 impl PartialOrd for FuncImpl {
     fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(rhs))
-    }
-}
-impl Ord for FuncImpl {
-    fn cmp(&self, rhs: &Self) -> cmp::Ordering {
         match (self, rhs) {
-            (&FuncImpl::Builtin(..), &FuncImpl::Builtin(..)) => {
-                cmp::Ordering::Equal
-            }
+            (&FuncImpl::Builtin(..), &FuncImpl::Builtin(..)) => None,
             (&FuncImpl::Builtin(..), &FuncImpl::UserDefined(..)) => {
-                cmp::Ordering::Less
+                Some(cmp::Ordering::Less)
             }
             (&FuncImpl::UserDefined(..), &FuncImpl::Builtin(..)) => {
-                cmp::Ordering::Greater
+                Some(cmp::Ordering::Greater)
             }
             (
                 &FuncImpl::UserDefined(ref a),
                 &FuncImpl::UserDefined(ref b),
-            ) => a.cmp(b),
+            ) => a.partial_cmp(b),
         }
     }
 }

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -320,15 +320,17 @@ fn number(input: Span) -> IResult<Span, Value> {
         |(sign, (lead_zero, num), unit)| match num {
             AnyRatio::Machine(num) => Value::Numeric(
                 Number {
-                    value: if sign == Some(b"-") { -num } else { num },
+                    value: (if sign == Some(b"-") { -num } else { num })
+                        .into(),
                     plus_sign: sign == Some(b"+"),
                     lead_zero,
                 },
                 unit,
             ),
-            AnyRatio::Big(num) => Value::NumericBig(
+            AnyRatio::Big(num) => Value::Numeric(
                 Number {
-                    value: if sign == Some(b"-") { -num } else { num },
+                    value: (if sign == Some(b"-") { -num } else { num })
+                        .into(),
                     plus_sign: sign == Some(b"+"),
                     lead_zero,
                 },
@@ -528,7 +530,7 @@ mod test {
             "+4;",
             Numeric(
                 Number {
-                    value: Rational::new(4, 1),
+                    value: 4.into(),
                     plus_sign: true,
                     lead_zero: true,
                 },
@@ -547,7 +549,7 @@ mod test {
             ".34;",
             Numeric(
                 Number {
-                    value: Rational::new(34, 100),
+                    value: Rational::new(34, 100).into(),
                     plus_sign: false,
                     lead_zero: false,
                 },
@@ -561,7 +563,7 @@ mod test {
             "-.34;",
             Numeric(
                 Number {
-                    value: Rational::new(-34, 100),
+                    value: Rational::new(-34, 100).into(),
                     plus_sign: false,
                     lead_zero: false,
                 },
@@ -575,7 +577,7 @@ mod test {
             "+.34;",
             Numeric(
                 Number {
-                    value: Rational::new(34, 100), // actually 17/50
+                    value: Rational::new(34, 100).into(),
                     plus_sign: true,
                     lead_zero: false,
                 },

--- a/src/sass/call_args.rs
+++ b/src/sass/call_args.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 ///
 /// Each argument has a Value.  Arguments may be named.
 /// If the optional name is None, the argument is positional.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct CallArgs(Vec<(Option<String>, Value)>);
 
 impl CallArgs {

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -9,7 +9,7 @@ use std::default::Default;
 ///
 /// The arguments are ordered (so they have a position).
 /// Each argument also has a name and may have a default value.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct FormalArgs(Vec<(String, Value)>, bool);
 
 impl FormalArgs {

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -5,7 +5,7 @@ use crate::selectors::Selectors;
 
 /// Every sass file is a sequence of sass items.
 /// Scoping items contains further sequences of items.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum Item {
     Import(Vec<SassString>, Value, SourcePos),
     VariableDeclaration {

--- a/src/sass/string.rs
+++ b/src/sass/string.rs
@@ -4,13 +4,13 @@ use crate::value::Quotes;
 use crate::variablescope::Scope;
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct SassString {
     parts: Vec<StringPart>,
     quotes: Quotes,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum StringPart {
     Raw(String),
     Interpolation(Value),

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -9,7 +9,7 @@ use num_rational::Rational;
 use num_traits::Zero;
 
 /// A sass value.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum Value {
     /// A special kind of escape.  Only really used for !important.
     Bang(String),

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -152,11 +152,7 @@ impl Value {
                 }
             }
             Value::Numeric(ref num, ref unit) => {
-                let mut num = num.clone();
-                if arithmetic {
-                    num.lead_zero = true;
-                }
-                Ok(css::Value::Numeric(num, unit.clone(), arithmetic))
+                Ok(css::Value::Numeric(num.clone(), unit.clone(), arithmetic))
             }
             Value::Map(ref m) => {
                 let items = m.iter()
@@ -213,15 +209,9 @@ impl Value {
                         Ok(css::Value::Numeric(-&v, u, true))
                     }
                     (Operator::Plus, css::Value::Numeric(v, u, _)) => {
-                        Ok(css::Value::Numeric(
-                            Number {
-                                value: v.value,
-                                plus_sign: true,
-                                lead_zero: v.lead_zero,
-                            },
-                            u,
-                            true,
-                        ))
+                        let mut num = v.clone();
+                        num.plus_sign = true;
+                        Ok(css::Value::Numeric(num, u, true))
                     }
                     (
                         Operator::Minus,

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -5,7 +5,6 @@ use crate::ordermap::OrderMap;
 use crate::sass::{CallArgs, SassString};
 use crate::value::{ListSeparator, Number, Operator, Quotes, Rgba, Unit};
 use crate::variablescope::Scope;
-use num_bigint::BigInt;
 use num_rational::Rational;
 use num_traits::Zero;
 
@@ -21,11 +20,7 @@ pub enum Value {
     List(Vec<Value>, ListSeparator, bool),
     /// A Numeric value is a rational value with a Unit (which may be
     /// Unit::None) and flags.
-    Numeric(Number<isize>, Unit),
-    /// A NumericBig value is a rational value with a Unit (which may be
-    /// Unit::None) and flags. The numerator and denominator of the value
-    /// may be arbitrarily large.
-    NumericBig(Number<BigInt>, Unit),
+    Numeric(Number, Unit),
     /// "(a/b) and a/b differs semantically.  Parens means the value
     /// should be evaluated numerically if possible, without parens /
     /// is not allways division.
@@ -162,13 +157,6 @@ impl Value {
                     num.lead_zero = true;
                 }
                 Ok(css::Value::Numeric(num, unit.clone(), arithmetic))
-            }
-            Value::NumericBig(ref num, ref unit) => {
-                let mut num = num.clone();
-                if arithmetic {
-                    num.lead_zero = true;
-                }
-                Ok(css::Value::NumericBig(num, unit.clone(), arithmetic))
             }
             Value::Map(ref m) => {
                 let items = m.iter()

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io::Write;
 
 /// A full set of selectors
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct Selectors {
     pub s: Vec<Selector>,
     backref: Selector,
@@ -103,7 +103,7 @@ impl Selectors {
 ///
 /// A selector does not contain `,`.  If it does, it is a `Selectors`,
 /// where each of the parts separated by the comma is a `Selector`.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct Selector(pub Vec<SelectorPart>);
 
 impl Selector {
@@ -148,7 +148,7 @@ impl Selector {
 }
 
 /// A selector consist of a sequence of these parts.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum SelectorPart {
     /// A simple selector, eg a class, id or element name.
     ///

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -7,7 +7,7 @@ mod unit;
 
 pub use self::colors::Rgba;
 pub use self::list_separator::ListSeparator;
-pub use self::number::Number;
+pub use self::number::{NumValue, Number};
 pub use self::operator::Operator;
 pub use self::quotes::Quotes;
 pub use self::unit::{Dimension, Unit};

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -328,14 +328,14 @@ impl NumValue {
 }
 
 impl Number {
-    // FIXME this probably needs to return a Result.
-    pub fn as_ratio(&self) -> Ratio<isize> {
+    pub fn as_ratio(&self) -> Result<Ratio<isize>, crate::Error> {
         match &self.value {
-            NumValue::Rational(r) => *r,
+            NumValue::Rational(r) => Ok(*r),
             NumValue::BigRational(_r) => {
                 panic!("FIXME: Should round down to rational")
             }
-            NumValue::Float(r) => Ratio::approximate_float(*r).unwrap(),
+            NumValue::Float(r) => Ratio::approximate_float(*r)
+                .ok_or_else(|| crate::Error::BadValue(r.to_string())),
         }
     }
 

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -394,6 +394,24 @@ impl Add for Number {
         Number::from(self.value + rhs.value)
     }
 }
+impl Mul<Ratio<isize>> for Number {
+    type Output = Self;
+    fn mul(self, rhs: Ratio<isize>) -> Self {
+        Number::from(self.value * rhs)
+    }
+}
+impl Mul<isize> for Number {
+    type Output = Self;
+    fn mul(self, rhs: isize) -> Self {
+        Number::from(self.value * rhs)
+    }
+}
+impl Div<isize> for Number {
+    type Output = Self;
+    fn div(self, rhs: isize) -> Self {
+        Number::from(self.value / rhs)
+    }
+}
 
 impl From<Number> for f64 {
     fn from(val: Number) -> f64 {
@@ -439,10 +457,16 @@ impl<'a> Div for &'a Number {
     }
 }
 
-impl<'a> Mul for &'a Number {
+impl Mul for &Number {
     type Output = Number;
     fn mul(self, rhs: Self) -> Self::Output {
         Number::from(&self.value * &rhs.value)
+    }
+}
+impl Mul<&Ratio<isize>> for &Number {
+    type Output = Number;
+    fn mul(self, rhs: &Ratio<isize>) -> Self::Output {
+        Number::from(&self.value * rhs)
     }
 }
 

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -4,6 +4,7 @@ use num_integer::Integer;
 use num_rational::Ratio;
 use num_traits::{One, Signed, Zero};
 use std::cmp::Ordering;
+use std::convert::TryFrom;
 use std::fmt::{self, Write};
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
@@ -334,7 +335,6 @@ impl Number {
             NumValue::BigRational(r) => {
                 let mut numer = r.numer().clone();
                 let mut denom = r.denom().clone();
-                use std::convert::TryFrom;
                 loop {
                     let tn = isize::try_from(&numer);
                     let td = isize::try_from(&denom);
@@ -377,11 +377,12 @@ impl Number {
     }
 
     /// Converts to an integer, rounding towards zero.
+    ///
+    /// An integer that is too big to fit in an isize returns `None`.
     pub fn to_integer(&self) -> Option<isize> {
         match &self.value {
             NumValue::Rational(s) => Some(s.to_integer()),
-            // TODO: Check if s is small enough
-            NumValue::BigRational(_s) => None, // s.is_integer(),
+            NumValue::BigRational(s) => isize::try_from(s.to_integer()).ok(),
             NumValue::Float(s) => Some(s.ceil() as isize),
         }
     }

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -19,7 +19,7 @@ pub struct Number {
     pub lead_zero: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug)]
 pub enum NumValue {
     Rational(Ratio<isize>),
     BigRational(Ratio<BigInt>),
@@ -125,6 +125,34 @@ impl Neg for &NumValue {
             NumValue::BigRational(s) => (-s).into(),
             NumValue::Float(s) => (-s.0).into(),
         }
+    }
+}
+
+impl Eq for NumValue {}
+impl PartialEq for NumValue {
+    fn eq(&self, rhs: &NumValue) -> bool {
+        self.cmp(rhs) == Ordering::Equal
+    }
+}
+impl Ord for NumValue {
+    fn cmp(&self, rhs: &NumValue) -> Ordering {
+        match (self, rhs) {
+            (NumValue::Rational(s), NumValue::Rational(r)) => s.cmp(r),
+            (NumValue::Rational(s), NumValue::BigRational(r)) => {
+                biggen(s).cmp(r)
+            }
+            (NumValue::BigRational(s), NumValue::Rational(r)) => {
+                s.cmp(&biggen(r))
+            }
+            (NumValue::BigRational(s), NumValue::BigRational(r)) => s.cmp(r),
+            (NumValue::Float(s), r) => s.cmp(&WrapFloat(f64::from(r))),
+            (s, NumValue::Float(r)) => WrapFloat(f64::from(s)).cmp(r),
+        }
+    }
+}
+impl PartialOrd for NumValue {
+    fn partial_cmp(&self, rhs: &NumValue) -> Option<Ordering> {
+        Some(self.cmp(rhs))
     }
 }
 

--- a/src/value/operator.rs
+++ b/src/value/operator.rs
@@ -53,11 +53,7 @@ impl Operator {
                     } else if au == Unit::None {
                         Some(Value::Numeric(a + b, bu, true))
                     } else if let Some(scale) = bu.scale_to(&au) {
-                        Some(Value::Numeric(
-                            (a.value + b.value * scale).into(),
-                            au,
-                            true,
-                        ))
+                        Some(Value::Numeric(a + b * scale, au, true))
                     } else {
                         None
                     }
@@ -99,7 +95,7 @@ impl Operator {
                         Some(Value::Numeric(av - bv, bu.clone(), true))
                     } else if let Some(scale) = bu.scale_to(au) {
                         Some(Value::Numeric(
-                            (&av.value - &(&bv.value * &scale)).into(),
+                            av - &(bv * &scale),
                             au.clone(),
                             true,
                         ))
@@ -135,17 +131,9 @@ impl Operator {
                     } else if au == &Unit::None {
                         Some(Value::Numeric(a * b, bu.clone(), true))
                     } else if bu == &Unit::Percent {
-                        Some(Value::Numeric(
-                            (&a.value * &b.value / 100).into(),
-                            au.clone(),
-                            true,
-                        ))
+                        Some(Value::Numeric(a * b / 100, au.clone(), true))
                     } else if au == &Unit::Percent {
-                        Some(Value::Numeric(
-                            (&a.value * &b.value / 100).into(),
-                            bu.clone(),
-                            true,
-                        ))
+                        Some(Value::Numeric(a * b / 100, bu.clone(), true))
                     } else {
                         None
                     }
@@ -181,7 +169,7 @@ impl Operator {
                                 ))
                             } else if let Some(scale) = bu.scale_to(&au) {
                                 Some(Value::Numeric(
-                                    av / &(bv * &scale.into()),
+                                    av / &(bv * &scale),
                                     Unit::None,
                                     true,
                                 ))

--- a/src/value/operator.rs
+++ b/src/value/operator.rs
@@ -1,7 +1,5 @@
 use crate::css::Value;
 use crate::value::{ListSeparator, Quotes, Unit};
-use crate::Rational;
-use num_traits::Zero;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -43,7 +41,7 @@ impl Operator {
             Operator::LesserE => Some(Value::from(a <= b)),
             Operator::Plus => match (a, b) {
                 (Value::Color(a, _), Value::Numeric(bn, Unit::None, _)) => {
-                    let bn = bn.value;
+                    let bn = bn.as_ratio();
                     Some(Value::Color(a + bn, None))
                 }
                 (Value::Color(a, _), Value::Color(b, _)) => {
@@ -85,7 +83,7 @@ impl Operator {
                     &Value::Color(ref a, _),
                     &Value::Numeric(ref bn, Unit::None, _),
                 ) => {
-                    let bn = bn.value;
+                    let bn = bn.as_ratio();
                     Some(Value::Color(a - bn, None))
                 }
                 (&Value::Color(ref a, _), &Value::Color(ref b, _)) => {
@@ -101,7 +99,7 @@ impl Operator {
                         Some(Value::Numeric(av - bv, bu.clone(), true))
                     } else if let Some(scale) = bu.scale_to(au) {
                         Some(Value::Numeric(
-                            (av.value - bv.value * scale).into(),
+                            (&av.value - &(&bv.value * &scale)).into(),
                             au.clone(),
                             true,
                         ))
@@ -138,13 +136,13 @@ impl Operator {
                         Some(Value::Numeric(a * b, bu.clone(), true))
                     } else if bu == &Unit::Percent {
                         Some(Value::Numeric(
-                            a * b * Rational::new(1, 100),
+                            (&a.value * &b.value / 100).into(),
                             au.clone(),
                             true,
                         ))
                     } else if au == &Unit::Percent {
                         Some(Value::Numeric(
-                            a * b * Rational::new(1, 100),
+                            (&a.value * &b.value / 100).into(),
                             bu.clone(),
                             true,
                         ))
@@ -162,16 +160,14 @@ impl Operator {
                             &Value::Color(ref a, _),
                             &Value::Numeric(ref bn, Unit::None, ..),
                         ) => {
-                            let bn = bn.value;
+                            let bn = bn.as_ratio();
                             Some(Value::Color(a / bn, None))
                         }
                         (
                             &Value::Numeric(ref av, ref au, ..),
                             &Value::Numeric(ref bv, ref bu, ..),
                         ) => {
-                            if bv.is_zero() {
-                                None
-                            } else if bu == &Unit::None {
+                            if bu == &Unit::None {
                                 Some(Value::Numeric(
                                     av / bv,
                                     au.clone(),
@@ -211,9 +207,9 @@ impl Operator {
                     &Value::Numeric(ref av, ref au, ..),
                     &Value::Numeric(ref bv, ref bu, ..),
                 ) => {
-                    if au == bu && !bv.is_zero() {
+                    if au == bu {
                         Some(Value::Numeric(av % bv, Unit::None, true))
-                    } else if bu == &Unit::None && !bv.is_zero() {
+                    } else if bu == &Unit::None {
                         Some(Value::Numeric(av % bv, au.clone(), true))
                     } else {
                         None

--- a/src/value/operator.rs
+++ b/src/value/operator.rs
@@ -41,7 +41,7 @@ impl Operator {
             Operator::LesserE => Some(Value::from(a <= b)),
             Operator::Plus => match (a, b) {
                 (Value::Color(a, _), Value::Numeric(bn, Unit::None, _)) => {
-                    let bn = bn.as_ratio();
+                    let bn = bn.as_ratio().ok()?;
                     Some(Value::Color(a + bn, None))
                 }
                 (Value::Color(a, _), Value::Color(b, _)) => {
@@ -79,7 +79,7 @@ impl Operator {
                     &Value::Color(ref a, _),
                     &Value::Numeric(ref bn, Unit::None, _),
                 ) => {
-                    let bn = bn.as_ratio();
+                    let bn = bn.as_ratio().ok()?;
                     Some(Value::Color(a - bn, None))
                 }
                 (&Value::Color(ref a, _), &Value::Color(ref b, _)) => {
@@ -148,7 +148,7 @@ impl Operator {
                             &Value::Color(ref a, _),
                             &Value::Numeric(ref bn, Unit::None, ..),
                         ) => {
-                            let bn = bn.as_ratio();
+                            let bn = bn.as_ratio().ok()?;
                             Some(Value::Color(a / bn, None))
                         }
                         (

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -499,12 +499,6 @@ pub mod test {
         assert_expr!(&[("m", "20")], b"1000px + $m * -2;", "960px")
     }
 
-    // ...
-    #[test]
-    fn div_by_zero() {
-        assert_expr!(b"(500px/0);", "500px/0")
-    }
-
     #[test]
     fn double_div_1() {
         assert_expr!(b"15/3/5;", "15/3/5")

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -228,6 +228,26 @@ fn div_simliar_unit() {
 }
 
 #[test]
+fn different_numbers_should_compare_as_same() {
+    check(
+        b"@use 'sass:math' as m;\
+          \np {\
+          \n  $t: 0.2;
+          \n  a: max(1, m.sin(30deg));\
+          \n  b: max(0.2, m.sin(30deg));\
+          \n  c: max($t, 0.23233234232231232312312323231223323);\
+          \n  d: max($t+0.1, 0.23233234232231232312312323231223323);\
+          \n}",
+        "p {\
+         \n  a: 1;\
+         \n  b: 0.5;\
+         \n  c: 0.2323323423;\
+         \n  d: 0.3;\
+         \n}\n",
+    )
+}
+
+#[test]
 fn test_number_0() {
     check_value("0", "0");
 }
@@ -289,6 +309,10 @@ fn check(input: &[u8], expected: &str) {
     assert_eq!(
         compile_scss(input, Default::default())
             .and_then(|s| Ok(String::from_utf8(s)?))
+            .map_err(|e| {
+                eprintln!("{}", e);
+                "rsass failed"
+            })
             .unwrap(),
         expected
     );

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -47,12 +47,8 @@ fn simple_function() {
 }
 
 #[cfg(test)]
-fn avg<N>(a: Number<N>, b: Number<N>) -> Number<N>
-where
-    N: Clone + num_integer::Integer + num_traits::Signed + From<i8>,
-{
-    let two: N = 2i8.into();
-    Number::from((a.value + b.value) / two)
+fn avg(a: Number, b: Number) -> Number {
+    Number::from((a.value + b.value) / 2)
 }
 
 #[test]

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -48,7 +48,7 @@ fn simple_function() {
 
 #[cfg(test)]
 fn avg(a: Number, b: Number) -> Number {
-    Number::from((a.value + b.value) / 2)
+    (a + b) / 2
 }
 
 #[test]

--- a/tests/spec/core_functions/math/atan2/mod.rs
+++ b/tests/spec/core_functions/math/atan2/mod.rs
@@ -69,7 +69,6 @@ mod y_infinite {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // unexepected error
             fn finite() {
                 assert_eq!(
                     rsass(
@@ -85,7 +84,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -101,7 +99,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_finite() {
                 assert_eq!(
                     rsass(
@@ -117,7 +114,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -133,7 +129,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_zero() {
                 assert_eq!(
                     rsass(
@@ -149,7 +144,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn zero() {
                 assert_eq!(
                     rsass(
@@ -173,7 +167,6 @@ mod y_infinite {
             #[allow(unused)]
             use super::rsass;
             #[test]
-            #[ignore] // unexepected error
             fn finite() {
                 assert_eq!(
                     rsass(
@@ -189,7 +182,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -205,7 +197,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_finite() {
                 assert_eq!(
                     rsass(
@@ -221,7 +212,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -237,7 +227,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_zero() {
                 assert_eq!(
                     rsass(
@@ -253,7 +242,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_zero_fuzzy() {
                 assert_eq!(
                     rsass(
@@ -269,7 +257,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn zero() {
                 assert_eq!(
                     rsass(
@@ -285,7 +272,6 @@ mod y_infinite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn zero_fuzzy() {
                 assert_eq!(
                     rsass(
@@ -330,7 +316,6 @@ mod y_non_zero_finite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -361,7 +346,6 @@ mod y_non_zero_finite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -460,7 +444,6 @@ mod y_non_zero_finite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -491,7 +474,6 @@ mod y_non_zero_finite {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -596,7 +578,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -628,7 +609,7 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
+            #[ignore] // wrong result
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -729,7 +710,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -761,7 +741,7 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
+            #[ignore] // wrong result
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -831,7 +811,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -862,7 +841,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -963,7 +941,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -994,7 +971,6 @@ mod y_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(

--- a/tests/spec/core_functions/math/mod.rs
+++ b/tests/spec/core_functions/math/mod.rs
@@ -157,7 +157,6 @@ mod acos {
         // Ignoring "zero_args", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // wrong result
     fn greater_than_one() {
         assert_eq!(
             rsass(
@@ -173,7 +172,6 @@ mod acos {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn less_than_negative_one() {
         assert_eq!(
             rsass(
@@ -267,7 +265,6 @@ mod asin {
         // Ignoring "zero_args", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // wrong result
     fn greater_than_one() {
         assert_eq!(
             rsass(
@@ -283,7 +280,6 @@ mod asin {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn less_than_negative_one() {
         assert_eq!(
             rsass(
@@ -422,7 +418,6 @@ mod atan {
         // Ignoring "zero_args", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -453,7 +448,6 @@ mod atan {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn negative_infinity() {
         assert_eq!(
             rsass(
@@ -1023,7 +1017,6 @@ mod cos {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -1054,7 +1047,6 @@ mod cos {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn negative_infinity() {
         assert_eq!(
             rsass(
@@ -1284,7 +1276,6 @@ mod hypot {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // unexepected error
         fn first() {
             assert_eq!(
                 rsass(
@@ -1300,7 +1291,6 @@ mod hypot {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn second() {
             assert_eq!(
                 rsass(
@@ -1316,7 +1306,6 @@ mod hypot {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn third() {
             assert_eq!(
                 rsass(
@@ -1492,7 +1481,6 @@ mod log {
         // Ignoring "zero_args", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -2326,7 +2314,6 @@ mod sin {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -2357,7 +2344,6 @@ mod sin {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn negative_infinity() {
         assert_eq!(
             rsass(
@@ -2496,7 +2482,6 @@ mod sqrt {
         // Ignoring "zero_args", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -2686,7 +2671,6 @@ mod tan {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn infinity() {
         assert_eq!(
             rsass(
@@ -2737,7 +2721,6 @@ mod tan {
         }
     }
     #[test]
-    #[ignore] // unexepected error
     fn negative_infinity() {
         assert_eq!(
             rsass(

--- a/tests/spec/core_functions/math/pow/mod.rs
+++ b/tests/spec/core_functions/math/pow/mod.rs
@@ -70,7 +70,6 @@ mod base_greater_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -116,7 +115,6 @@ mod base_greater_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -170,7 +168,6 @@ mod base_greater_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -186,7 +183,6 @@ mod base_greater_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -210,7 +206,7 @@ mod base_greater_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -226,7 +222,7 @@ mod base_greater_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -250,7 +246,7 @@ mod base_greater_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -266,7 +262,7 @@ mod base_greater_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -300,7 +296,6 @@ mod base_less_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -316,7 +311,6 @@ mod base_less_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -355,7 +349,6 @@ mod base_less_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -401,7 +394,6 @@ mod base_less_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -455,7 +447,7 @@ mod base_less_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -471,7 +463,7 @@ mod base_less_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -495,7 +487,7 @@ mod base_less_than_zero {
                 #[allow(unused)]
                 use super::rsass;
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn infinity() {
                     assert_eq!(
                         rsass(
@@ -511,7 +503,7 @@ mod base_less_than_zero {
                     );
                 }
                 #[test]
-                #[ignore] // unexepected error
+                #[ignore] // wrong result
                 fn negative_infinity() {
                     assert_eq!(
                         rsass(
@@ -539,7 +531,6 @@ mod base_negative_infinity {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // unexepected error
         fn decimal() {
             assert_eq!(
                 rsass(
@@ -555,7 +546,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn even_integer() {
             assert_eq!(
                 rsass(
@@ -571,7 +561,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn even_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -587,7 +576,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn infinity() {
             assert_eq!(
                 rsass(
@@ -603,7 +591,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_decimal() {
             assert_eq!(
                 rsass(
@@ -619,7 +606,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_even_integer() {
             assert_eq!(
                 rsass(
@@ -635,7 +621,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_even_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -651,7 +636,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 rsass(
@@ -667,7 +651,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_odd_integer() {
             assert_eq!(
                 rsass(
@@ -683,7 +666,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_odd_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -699,7 +681,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn odd_integer() {
             assert_eq!(
                 rsass(
@@ -715,7 +696,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn odd_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -731,7 +711,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn zero() {
             assert_eq!(
                 rsass(
@@ -747,7 +726,6 @@ mod base_negative_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn zero_fuzzy() {
             assert_eq!(
                 rsass(
@@ -806,7 +784,6 @@ mod base_negative_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -852,7 +829,6 @@ mod base_negative_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -964,7 +940,6 @@ mod base_negative_zero {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn infinity() {
             assert_eq!(
                 rsass(
@@ -1025,7 +1000,6 @@ mod base_negative_zero {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 rsass(
@@ -1143,7 +1117,6 @@ mod base_positive_infinity {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // unexepected error
         fn decimal() {
             assert_eq!(
                 rsass(
@@ -1159,7 +1132,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn even_integer() {
             assert_eq!(
                 rsass(
@@ -1175,7 +1147,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn even_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -1191,7 +1162,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn infinity() {
             assert_eq!(
                 rsass(
@@ -1207,7 +1177,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_decimal() {
             assert_eq!(
                 rsass(
@@ -1223,7 +1192,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_even_integer() {
             assert_eq!(
                 rsass(
@@ -1239,7 +1207,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_even_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -1255,7 +1222,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 rsass(
@@ -1271,7 +1237,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_odd_integer() {
             assert_eq!(
                 rsass(
@@ -1287,7 +1252,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_odd_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -1303,7 +1267,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn odd_integer() {
             assert_eq!(
                 rsass(
@@ -1319,7 +1282,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn odd_integer_fuzzy() {
             assert_eq!(
                 rsass(
@@ -1335,7 +1297,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn zero() {
             assert_eq!(
                 rsass(
@@ -1351,7 +1312,6 @@ mod base_positive_infinity {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn zero_fuzzy() {
             assert_eq!(
                 rsass(
@@ -1410,7 +1370,6 @@ mod base_positive_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn infinity() {
                 assert_eq!(
                     rsass(
@@ -1456,7 +1415,6 @@ mod base_positive_zero {
                 );
             }
             #[test]
-            #[ignore] // unexepected error
             fn negative_infinity() {
                 assert_eq!(
                     rsass(
@@ -1567,7 +1525,6 @@ mod base_positive_zero {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn infinity() {
             assert_eq!(
                 rsass(
@@ -1628,7 +1585,6 @@ mod base_positive_zero {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 rsass(

--- a/tests/spec/non_conformant/basic/mod.rs
+++ b/tests/spec/non_conformant/basic/mod.rs
@@ -574,7 +574,6 @@ fn t14_imports() {
 
 // From "sass-spec/spec/non_conformant/basic/15_arithmetic_and_lists.hrx"
 #[test]
-#[ignore] // wrong result
 fn t15_arithmetic_and_lists() {
     assert_eq!(
         rsass(

--- a/tests/spec/values/maps/mod.rs
+++ b/tests/spec/values/maps/mod.rs
@@ -53,6 +53,7 @@ mod key_equality {
         }
     }
     #[test]
+    #[ignore] // FIXME
     fn nan() {
         assert_eq!(
             rsass(

--- a/tests/spec/values/maps/mod.rs
+++ b/tests/spec/values/maps/mod.rs
@@ -53,7 +53,6 @@ mod key_equality {
         }
     }
     #[test]
-    #[ignore] // FIXME
     fn nan() {
         assert_eq!(
             rsass(

--- a/tests/spec/values/maps/mod.rs
+++ b/tests/spec/values/maps/mod.rs
@@ -53,7 +53,6 @@ mod key_equality {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn nan() {
         assert_eq!(
             rsass(


### PR DESCRIPTION
- Encapuslate the difference between a `Ratio<isize>` and a `Ratio<BigInt>` inside the `Number` type, so their use outside of `number.rs` is identical.
- Add a third case, the `Number` may be a `f64`.  This allows <del>semi-</del>correct handling of Infinity, -Infinity and NaN.
- For value comparisons, we <del>consider NaN == NaN, Infinity == Infinity and -Infinity == -Infinity.  This differs from sane and normal float handling in Rust, where each NaN or infinity is unique.  Therefore, `f64` is encapsulated in a type that implements `Ord` and `Eq` (and not just their partials)</del> <ins>actually treat float value with normal PartialOrd behaviour</ins>.
- `css::Value`, `sass::Value` and lots of related types no longer implement `Ord`.  `PartialOrd` is enough.
- Power and trigonometric functions in `sass:math` is simplified by the fact that a `Number` can now be a `f64`.