### PR TITLE
Handle `@use module as *`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ project adheres to
 
 * Update nom to 6.0 rasises the minimally supported compiler version
   to 1.44.0.  Also, the dependency is technically exposed.
+* `sass::Item::Use` was modified by #84.
 
 ### Improvements
 
+* Support the `@use name as *` syntax, PR #84.
 * Make `Error::BadValue` a little closer to whats expected.
 * Update nom to 6.0, PR #83.
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,7 +33,7 @@ use self::value::{
 use crate::functions::SassFunction;
 #[cfg(test)]
 use crate::sass::{CallArgs, FormalArgs};
-use crate::sass::{Item, Value};
+use crate::sass::{Item, UseAs, Value};
 use crate::selectors::Selectors;
 use crate::value::ListSeparator;
 #[cfg(test)]
@@ -306,13 +306,16 @@ fn use2(input: Span) -> IResult<Span, Item> {
                 ),
                 opt(delimited(
                     terminated(tag("as"), opt_spacelike),
-                    sass_string,
+                    alt((
+                        map(sass_string, UseAs::Name),
+                        value(UseAs::Star, tag("*")),
+                    )),
                     opt_spacelike,
                 )),
             ),
             tag(";"),
         ),
-        |(s, n)| Item::Use(s, n),
+        |(s, n)| Item::Use(s, n.unwrap_or(UseAs::KeepName)),
     )(input)
 }
 

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -56,11 +56,18 @@ pub enum Item {
     },
     While(Value, Vec<Item>),
 
-    Use(SassString, Option<SassString>),
+    Use(SassString, UseAs),
     Rule(Selectors, Vec<Item>),
     NamespaceRule(SassString, Value, Vec<Item>),
     Property(SassString, Value),
     Comment(SassString),
     Warn(Value),
     None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+pub enum UseAs {
+    KeepName,
+    Star,
+    Name(SassString),
 }

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -6,6 +6,6 @@ mod value;
 
 pub use self::call_args::CallArgs;
 pub use self::formal_args::FormalArgs;
-pub use self::item::Item;
+pub use self::item::{Item, UseAs};
 pub use self::string::{SassString, StringPart};
 pub use self::value::Value;

--- a/src/sass/string.rs
+++ b/src/sass/string.rs
@@ -188,8 +188,8 @@ impl From<&str> for StringPart {
     }
 }
 
-impl<'a> From<&'a str> for SassString {
-    fn from(s: &'a str) -> Self {
+impl From<&str> for SassString {
+    fn from(s: &str) -> Self {
         SassString {
             parts: vec![StringPart::from(s)],
             quotes: Quotes::None,

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -176,17 +176,6 @@ pub trait Scope {
         }
         Ok(None)
     }
-    fn do_use(&mut self, name: &str, as_name: Option<&str>) {
-        use crate::functions::get_global_module;
-        let as_name = as_name
-            .or_else(|| name.rfind(':').map(|i| &name[i + 1..]))
-            .unwrap_or(name);
-        if let Some(module) = get_global_module(name) {
-            self.define_module(as_name, module);
-        } else {
-            eprintln!("WARNING: module {:?} not found", name);
-        }
-    }
     fn define_module(&self, name: &str, module: &'static Module);
     fn get_module(&self, name: &str) -> Option<&Module>;
     fn get_selectors(&self) -> &Selectors;

--- a/tests/spec/core_functions/meta/load_css/mod.rs
+++ b/tests/spec/core_functions/meta/load_css/mod.rs
@@ -389,7 +389,7 @@ mod twice {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn different_extend() {
             assert_eq!(
                 rsass(

--- a/tests/spec/core_functions/meta/mod.rs
+++ b/tests/spec/core_functions/meta/mod.rs
@@ -771,7 +771,7 @@ mod global_variable_exists {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn chosen_prefix() {
             assert_eq!(
                 rsass(
@@ -787,7 +787,7 @@ mod global_variable_exists {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn defined() {
             assert_eq!(
                 rsass(
@@ -947,7 +947,7 @@ mod global_variable_exists {
         }
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn named() {
         assert_eq!(
             rsass(
@@ -2271,7 +2271,7 @@ mod mixin_exists {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn chosen_prefix() {
             assert_eq!(
                 rsass(
@@ -2287,7 +2287,7 @@ mod mixin_exists {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn defined() {
             assert_eq!(
                 rsass(
@@ -2447,7 +2447,7 @@ mod mixin_exists {
         }
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn named() {
         assert_eq!(
             rsass(
@@ -2606,7 +2606,7 @@ mod module_functions {
     );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn empty() {
         assert_eq!(
             rsass(
@@ -2796,7 +2796,7 @@ mod module_variables {
     #[allow(unused)]
     use super::rsass;
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn test_as() {
         assert_eq!(
             rsass(
@@ -2831,7 +2831,7 @@ mod module_variables {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn dash_sensitive() {
         assert_eq!(
             rsass(
@@ -2849,7 +2849,7 @@ mod module_variables {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn empty() {
         assert_eq!(
             rsass(
@@ -2885,7 +2885,7 @@ mod module_variables {
         // Ignoring "test_type", error tests are not supported yet.
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn multiple() {
         assert_eq!(
             rsass(
@@ -2903,7 +2903,7 @@ mod module_variables {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn named() {
         assert_eq!(
             rsass(
@@ -2924,7 +2924,7 @@ mod module_variables {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn test_as() {
             assert_eq!(
                 rsass(
@@ -2942,7 +2942,7 @@ mod module_variables {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn bare() {
             assert_eq!(
                 rsass(
@@ -2960,7 +2960,7 @@ mod module_variables {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn hide() {
             assert_eq!(
                 rsass(
@@ -2978,7 +2978,7 @@ mod module_variables {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn show() {
             assert_eq!(
                 rsass(
@@ -2997,7 +2997,7 @@ mod module_variables {
         }
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn through_import() {
         assert_eq!(
             rsass(

--- a/tests/spec/core_functions/modules/mod.rs
+++ b/tests/spec/core_functions/modules/mod.rs
@@ -358,7 +358,7 @@ mod general {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn test_as() {
             assert_eq!(
                 rsass(
@@ -374,7 +374,7 @@ mod general {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn bare() {
             assert_eq!(
                 rsass(
@@ -398,7 +398,7 @@ mod general {
             // Ignoring "show", error tests are not supported yet.
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn hide() {
             assert_eq!(
                 rsass(
@@ -414,7 +414,7 @@ mod general {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn show() {
             assert_eq!(
                 rsass(
@@ -431,7 +431,6 @@ mod general {
         }
     }
     #[test]
-    #[ignore] // unexepected error
     fn global() {
         assert_eq!(
             rsass(


### PR DESCRIPTION
Also, loading a module that cannot be loaded is an error (a nonexistent (new?) standard module, an extension for another implementation, or any user-provided module, since those are not yet supported).