### PR TITLE
Allow customizing file loading using the new Context trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,13 @@
 use crate::css::Value;
 use crate::parser::ParseError;
 use std::convert::From;
-use std::path::PathBuf;
 use std::string::FromUtf8Error;
 use std::{fmt, io};
 
 /// Most functions in rsass that returns a Result uses this Error type.
 #[derive(Debug)]
 pub enum Error {
-    Input(PathBuf, io::Error),
+    Input(String, io::Error),
     IoError(io::Error),
     Encoding(FromUtf8Error),
     BadValue(String),

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -35,8 +35,12 @@ pub trait FileContext: Sized + std::fmt::Debug {
     ///
     /// If the file is imported from another file,
     /// the argument is the exact string specified in the import declaration.
+    ///
+    /// The official Sass spec prescribes that files are loaded by
+    /// url instead of by path to ensure universal compatibility of style sheets.
+    /// This effectively mandates the use of forward slashes on all platforms.
     fn find_file(
-        &self, name: &str
+        &self, url: &str
     ) -> Result<Option<(Self, String, Self::File)>, Error>;
 }
 

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -132,7 +132,7 @@ impl FileContext for FsFileContext {
                             self.clone()
                         };
                         let path = full.display().to_string();
-                        let file = Self::File::open(full.clone())?;
+                        let file = Self::File::open(full)?;
                         return Ok(Some((c, path, file)));
                     }
                 }

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 ///     }
 /// }
 /// ```
-pub trait Context: Clone + std::fmt::Debug {
+pub trait Context: Sized + std::fmt::Debug {
     type File: std::io::Read;
 
     /// Find a file.

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -1,7 +1,6 @@
 use crate::error::Error;
 use std::path::{Path, PathBuf};
 
-
 /// A file context manages finding and loading files.
 ///
 /// # Example
@@ -40,10 +39,10 @@ pub trait FileContext: Sized + std::fmt::Debug {
     /// url instead of by path to ensure universal compatibility of style sheets.
     /// This effectively mandates the use of forward slashes on all platforms.
     fn find_file(
-        &self, url: &str
+        &self,
+        url: &str,
     ) -> Result<Option<(Self, String, Self::File)>, Error>;
 }
-
 
 /// A filesystem file context specifies where to find local files.
 ///
@@ -102,7 +101,8 @@ impl FileContext for FsFileContext {
     type File = std::fs::File;
 
     fn find_file(
-        &self, name: &str
+        &self,
+        name: &str,
     ) -> Result<Option<(Self, String, Self::File)>, crate::Error> {
         // TODO Check docs what expansions should be tried!
         // Files with .sass extension needs another parser.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,8 @@ pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 ///     b"div span{moo:goo}\n"
 /// )
 /// ```
+///
+/// **Attention**: Previously, this function was named `compile_scss_file()`.
 pub fn compile_scss_path(
     path: &Path,
     format: Format,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod value;
 mod variablescope;
 
 pub use crate::error::Error;
-pub use crate::file_context::{Context, FileContext};
+pub use crate::file_context::{FileContext, FsFileContext};
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
@@ -104,7 +104,7 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 /// )
 /// ```
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
-    let file_context = FileContext::new();
+    let file_context = FsFileContext::new();
     let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)
 }
@@ -131,7 +131,7 @@ pub fn compile_scss_file(
     file: &Path,
     format: Format,
 ) -> Result<Vec<u8>, Error> {
-    let file_context = FileContext::new();
+    let file_context = FsFileContext::new();
     let (sub_context, file) = file_context.file(file);
     let items = parse_scss_file(&file)?;
     format.write_root(&items, &mut GlobalScope::new(format), &sub_context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@
 //! # Example
 //!
 //! ```
-//! use rsass::{compile_scss_file, output};
+//! use rsass::{compile_scss_path, output};
 //!
-//! let file = "tests/basic/14_imports/a.scss".as_ref();
+//! let path = "tests/basic/14_imports/a.scss".as_ref();
 //! let format = output::Format {
 //!     style: output::Style::Compressed,
 //!     precision: 5,
 //! };
-//! let css = compile_scss_file(file, format).unwrap();
+//! let css = compile_scss_path(path, format).unwrap();
 //!
 //! assert_eq!(css, b"div span{moo:goo}\n")
 //! ```
@@ -56,7 +56,7 @@ pub use crate::file_context::{FileContext, FsFileContext};
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_file, parse_scss_readable, parse_value_data, ParseError, SourcePos,
+    parse_scss_data, parse_scss_path, parse_scss_readable, parse_value_data, ParseError, SourcePos,
 };
 pub use crate::sass::Item;
 pub use crate::value::{Dimension, ListSeparator, Number, Quotes, Unit};
@@ -117,22 +117,22 @@ pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 /// # Example
 ///
 /// ```
-/// use rsass::{compile_scss_file, output::{Format, Style}};
+/// use rsass::{compile_scss_path, output::{Format, Style}};
 ///
 /// assert_eq!(
-///     compile_scss_file(
+///     compile_scss_path(
 ///         "tests/basic/14_imports/a.scss".as_ref(),
 ///         Format { style: Style::Compressed, precision: 5 },
 ///     ).unwrap(),
 ///     b"div span{moo:goo}\n"
 /// )
 /// ```
-pub fn compile_scss_file(
-    file: &Path,
+pub fn compile_scss_path(
+    path: &Path,
     format: Format,
 ) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
-    let (sub_context, file) = file_context.file(file);
-    let items = parse_scss_file(&file)?;
+    let (sub_context, path) = file_context.file(path);
+    let items = parse_scss_path(&path)?;
     format.write_root(&items, &mut GlobalScope::new(format), &sub_context)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,11 @@ mod value;
 mod variablescope;
 
 pub use crate::error::Error;
-pub use crate::file_context::FileContext;
+pub use crate::file_context::{Context, FileContext};
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_file, parse_value_data, ParseError, SourcePos,
+    parse_scss_data, parse_scss_file, parse_scss_readable, parse_value_data, ParseError, SourcePos,
 };
 pub use crate::sass::Item;
 pub use crate::value::{Dimension, ListSeparator, Number, Quotes, Unit};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::file_context::{FileContext, FsFileContext};
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_path, parse_scss_readable, parse_value_data, ParseError, SourcePos,
+    parse_scss_data, parse_scss_path, parse_scss_file, parse_value_data, ParseError, SourcePos,
 };
 pub use crate::sass::Item;
 pub use crate::value::{Dimension, ListSeparator, Number, Quotes, Unit};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@ pub use crate::file_context::{FileContext, FsFileContext};
 pub use crate::functions::SassFunction;
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_path, parse_scss_file, parse_value_data, ParseError, SourcePos,
+    parse_scss_data, parse_scss_file, parse_scss_path, parse_value_data,
+    ParseError, SourcePos,
 };
 pub use crate::sass::Item;
 pub use crate::value::{Dimension, ListSeparator, Number, Quotes, Unit};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use rsass::{
     output::{Format, Style},
-    parse_scss_file, Error, FsFileContext, GlobalScope,
+    parse_scss_path, Error, FsFileContext, GlobalScope,
 };
 use std::io::{stdout, Write};
 use std::path::PathBuf;
@@ -59,8 +59,8 @@ impl Args {
             if let Some(include_path) = &self.include_path {
                 file_context.push_path(include_path.as_ref());
             }
-            let (sub_context, file) = file_context.file(name.as_ref());
-            let items = parse_scss_file(&file)?;
+            let (sub_context, path) = file_context.file(name.as_ref());
+            let items = parse_scss_path(&path)?;
             let result = format.write_root(
                 &items,
                 &mut GlobalScope::new(format),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use rsass::{
     output::{Format, Style},
-    parse_scss_file, Error, FileContext, GlobalScope,
+    parse_scss_file, Error, FsFileContext, GlobalScope,
 };
 use std::io::{stdout, Write};
 use std::path::PathBuf;
@@ -55,7 +55,7 @@ impl Args {
             precision: self.precision,
         };
         for name in &self.input {
-            let mut file_context = FileContext::new();
+            let mut file_context = FsFileContext::new();
             if let Some(include_path) = &self.include_path {
                 file_context.push_path(include_path.as_ref());
             }

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -1,8 +1,8 @@
 use super::Format;
 use crate::css::Value;
 use crate::error::Error;
-use crate::file_context::FileContext;
-use crate::parser::parse_imported_scss_file;
+use crate::file_context::{Context, FileContext};
+use crate::parser::parse_imported_scss_readable;
 use crate::sass::{FormalArgs, Item, SassString};
 use crate::selectors::Selectors;
 use crate::variablescope::{Scope, ScopeImpl};
@@ -80,11 +80,15 @@ impl Format {
                 if args.is_null() {
                     for name in names {
                         let (x, _q) = name.evaluate(scope)?;
-                        if let Some((sub_context, file)) =
-                            file_context.find_file(x.as_ref())
+                        if let Some((sub_context, path, mut file)) =
+                            file_context.find_file(x.as_ref())?
                         {
                             for item in
-                                parse_imported_scss_file(&file, pos.clone())?
+                                parse_imported_scss_readable(
+                                    &mut file,
+                                    &path,
+                                    pos.clone(),
+                                )?
                             {
                                 self.handle_root_item(
                                     &item,
@@ -403,11 +407,12 @@ impl Format {
                     if args.is_null() {
                         for name in names {
                             let (x, _q) = name.evaluate(scope)?;
-                            if let Some((sub_context, file)) =
-                                file_context.find_file(x.as_ref())
+                            if let Some((sub_context, path, mut file)) =
+                                file_context.find_file(x.as_ref())?
                             {
-                                let items = parse_imported_scss_file(
-                                    &file,
+                                let items = parse_imported_scss_readable(
+                                    &mut file,
+                                    &path,
                                     pos.clone(),
                                 )?;
                                 self.handle_body(

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -81,7 +81,7 @@ impl Format {
                     for name in names {
                         let (x, _q) = name.evaluate(scope)?;
                         if let Some((sub_context, path, mut file)) =
-                            context.find_file(x.as_ref())?
+                            context.find_file(&x)?
                         {
                             for item in
                                 parse_imported_scss_readable(

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -83,13 +83,11 @@ impl Format {
                         if let Some((sub_context, path, mut file)) =
                             file_context.find_file(&x)?
                         {
-                            for item in
-                                parse_imported_scss_file(
-                                    &mut file,
-                                    &path,
-                                    pos.clone(),
-                                )?
-                            {
+                            for item in parse_imported_scss_file(
+                                &mut file,
+                                &path,
+                                pos.clone(),
+                            )? {
                                 self.handle_root_item(
                                     &item,
                                     scope,

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -2,7 +2,7 @@ use super::Format;
 use crate::css::Value;
 use crate::error::Error;
 use crate::file_context::FileContext;
-use crate::parser::parse_imported_scss_readable;
+use crate::parser::parse_imported_scss_file;
 use crate::sass::{FormalArgs, Item, SassString};
 use crate::selectors::Selectors;
 use crate::variablescope::{Scope, ScopeImpl};
@@ -84,7 +84,7 @@ impl Format {
                             context.find_file(&x)?
                         {
                             for item in
-                                parse_imported_scss_readable(
+                                parse_imported_scss_file(
                                     &mut file,
                                     &path,
                                     pos.clone(),
@@ -410,7 +410,7 @@ impl Format {
                             if let Some((sub_context, path, mut file)) =
                                 context.find_file(x.as_ref())?
                             {
-                                let items = parse_imported_scss_readable(
+                                let items = parse_imported_scss_file(
                                     &mut file,
                                     &path,
                                     pos.clone(),

--- a/src/output/style.rs
+++ b/src/output/style.rs
@@ -1,7 +1,7 @@
 use super::Format;
 use crate::css::Value;
 use crate::error::Error;
-use crate::file_context::Context;
+use crate::file_context::FileContext;
 use crate::parser::parse_imported_scss_readable;
 use crate::sass::{FormalArgs, Item, SassString};
 use crate::selectors::Selectors;
@@ -59,7 +59,7 @@ impl Format {
         &self,
         items: &[Item],
         globals: &mut dyn Scope,
-        context: &impl Context,
+        context: &impl FileContext,
     ) -> Result<Vec<u8>, Error> {
         let mut result = CssWriter::new(*self);
         for item in items {
@@ -71,7 +71,7 @@ impl Format {
         &self,
         item: &Item,
         scope: &mut dyn Scope,
-        context: &impl Context,
+        context: &impl FileContext,
         result: &mut CssWriter,
     ) -> Result<(), Error> {
         match *item {
@@ -362,7 +362,7 @@ impl Format {
         body: &[Item],
         out: &mut dyn Write,
         scope: &mut dyn Scope,
-        context: &impl Context,
+        context: &impl FileContext,
         indent: usize,
     ) -> Result<(), Error> {
         let selectors = selectors.eval(scope)?.inside(scope.get_selectors());
@@ -397,7 +397,7 @@ impl Format {
         sub: &mut dyn Write,
         scope: &mut dyn Scope,
         body: &[Item],
-        context: &impl Context,
+        context: &impl FileContext,
         indent: usize,
     ) -> Result<(), Error> {
         for b in body {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -92,16 +92,10 @@ fn test_parse_value_data_2() -> Result<(), Error> {
 ///
 /// Returns a vec of the top level items of the file (or an error message).
 pub fn parse_scss_path(path: &Path) -> Result<Vec<Item>, Error> {
-    do_parse_scss_path(path, &SourceName::root(path.display()))
-}
-
-fn do_parse_scss_path(
-    path: &Path,
-    source: &SourceName,
-) -> Result<Vec<Item>, Error> {
+    let source = SourceName::root(path.display());
     let mut f = File::open(path)
         .map_err(|e| Error::Input(source.name().to_string(), e))?;
-    do_parse_scss_file(&mut f, source)
+    do_parse_scss_file(&mut f, &source)
 }
 
 /// Parse a scss file.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -91,19 +91,19 @@ fn test_parse_value_data_2() -> Result<(), Error> {
 /// Parse a scss file by path.
 ///
 /// Returns a vec of the top level items of the file (or an error message).
-pub fn parse_scss_file(path: &Path) -> Result<Vec<Item>, Error> {
-    do_parse_scss_file(path, &SourceName::root(path.display()))
+pub fn parse_scss_path(path: &Path) -> Result<Vec<Item>, Error> {
+    do_parse_scss_path(path, &SourceName::root(path.display()))
 }
 
-pub fn parse_imported_scss_file(
+pub fn parse_imported_scss_path(
     path: &Path,
     from: SourcePos,
 ) -> Result<Vec<Item>, Error> {
     let source = SourceName::imported(path.display(), from);
-    do_parse_scss_file(path, &source)
+    do_parse_scss_path(path, &source)
 }
 
-fn do_parse_scss_file(
+fn do_parse_scss_path(
     path: &Path,
     source: &SourceName,
 ) -> Result<Vec<Item>, Error> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -115,15 +115,15 @@ fn do_parse_scss_file(
 /// Parse a scss file.
 ///
 /// Returns a vec of the top level items of the file (or an error message).
-pub fn parse_scss_readable(
-    file: &mut dyn Read,
+pub fn parse_scss_readable<T: Read>(
+    file: &mut T,
     path: &str,
 ) -> Result<Vec<Item>, Error> {
     do_parse_scss_readable(file, &SourceName::root(path))
 }
 
-pub fn parse_imported_scss_readable(
-    file: &mut dyn Read,
+pub fn parse_imported_scss_readable<T: Read>(
+    file: &mut T,
     path: &str,
     from: SourcePos,
 ) -> Result<Vec<Item>, Error> {
@@ -131,8 +131,8 @@ pub fn parse_imported_scss_readable(
     do_parse_scss_readable(file, &source)
 }
 
-fn do_parse_scss_readable(
-    file: &mut dyn Read,
+fn do_parse_scss_readable<T: Read>(
+    file: &mut T,
     source: &SourceName,
 ) -> Result<Vec<Item>, Error> {
     let mut data = vec![];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -109,29 +109,29 @@ fn do_parse_scss_path(
 ) -> Result<Vec<Item>, Error> {
     let mut f = File::open(path)
         .map_err(|e| Error::Input(source.name().to_string(), e))?;
-    do_parse_scss_readable(&mut f, source)
+    do_parse_scss_file(&mut f, source)
 }
 
 /// Parse a scss file.
 ///
 /// Returns a vec of the top level items of the file (or an error message).
-pub fn parse_scss_readable<T: Read>(
+pub fn parse_scss_file<T: Read>(
     file: &mut T,
     path: &str,
 ) -> Result<Vec<Item>, Error> {
-    do_parse_scss_readable(file, &SourceName::root(path))
+    do_parse_scss_file(file, &SourceName::root(path))
 }
 
-pub fn parse_imported_scss_readable<T: Read>(
+pub fn parse_imported_scss_file<T: Read>(
     file: &mut T,
     path: &str,
     from: SourcePos,
 ) -> Result<Vec<Item>, Error> {
     let source = SourceName::imported(path, from);
-    do_parse_scss_readable(file, &source)
+    do_parse_scss_file(file, &source)
 }
 
-fn do_parse_scss_readable<T: Read>(
+fn do_parse_scss_file<T: Read>(
     file: &mut T,
     source: &SourceName,
 ) -> Result<Vec<Item>, Error> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -115,6 +115,9 @@ fn do_parse_scss_path(
 /// Parse a scss file.
 ///
 /// Returns a vec of the top level items of the file (or an error message).
+///
+/// **Attention**: Previously, this function took a path to the file
+/// instead of a file itself. That function has been renamed to [`parse_scss_path()`].
 pub fn parse_scss_file<T: Read>(
     file: &mut T,
     path: &str,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -95,14 +95,6 @@ pub fn parse_scss_path(path: &Path) -> Result<Vec<Item>, Error> {
     do_parse_scss_path(path, &SourceName::root(path.display()))
 }
 
-pub fn parse_imported_scss_path(
-    path: &Path,
-    from: SourcePos,
-) -> Result<Vec<Item>, Error> {
-    let source = SourceName::imported(path.display(), from);
-    do_parse_scss_path(path, &source)
-}
-
 fn do_parse_scss_path(
     path: &Path,
     source: &SourceName,

--- a/src/spectest/main.rs
+++ b/src/spectest/main.rs
@@ -71,7 +71,7 @@ fn handle_suite(
     writeln!(
         rs,
         "use rsass::output::Format;\
-         \nuse rsass::{{parse_scss_data, Error, FileContext, GlobalScope}};",
+         \nuse rsass::{{parse_scss_data, Error, FsFileContext, GlobalScope}};",
     )?;
 
     handle_entries(&mut rs, &base, &suitedir, &rssuitedir, None, ignored)
@@ -99,7 +99,7 @@ fn handle_suite(
          \n        }})\
          \n}}\
          \npub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {{\
-         \n    let mut file_context = FileContext::new();\
+         \n    let mut file_context = FsFileContext::new();\
          \n    file_context.push_path(\"tests/spec\".as_ref());\
          \n    let items = parse_scss_data(input)?;\
          \n    format.write_root(&items, &mut GlobalScope::new(format), &file_context)\

--- a/src/spectest/testfixture.rs
+++ b/src/spectest/testfixture.rs
@@ -4,7 +4,7 @@ use super::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 use rsass::output::Format;
-use rsass::{parse_scss_data, FileContext, GlobalScope};
+use rsass::{parse_scss_data, FsFileContext, GlobalScope};
 use std::io::Write;
 
 pub struct TestFixture {
@@ -159,7 +159,7 @@ pub fn compile_scss(
     input: &[u8],
     format: Format,
 ) -> Result<Vec<u8>, rsass::Error> {
-    let mut file_context = FileContext::new();
+    let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -2,7 +2,7 @@
 //! See <https://github.com/sass/sass-spec> for source material.
 //! See `tests/basic/main.rs` for semi-autoimported tests.
 //! This file contains old tests that need special handling.
-use rsass::{compile_scss, compile_scss_file, compile_value};
+use rsass::{compile_scss, compile_scss_path, compile_value};
 
 #[test]
 fn txx_empty_rule() {
@@ -13,7 +13,7 @@ fn txx_empty_rule() {
 fn t14_imports() {
     let path = "tests/basic/14_imports/input.scss";
     assert_eq!(
-        compile_scss_file(path.as_ref(), Default::default())
+        compile_scss_path(path.as_ref(), Default::default())
             .and_then(|s| Ok(String::from_utf8(s)?))
             .unwrap(),
         "div span {\n  moo: goo;\n}\n\n\
@@ -125,7 +125,7 @@ fn t15_arithmetic_and_lists() {
 fn t33_ambigous_imports() {
     let path = "tests/basic/33_ambiguous_imports/input.scss";
     assert_eq!(
-        compile_scss_file(path.as_ref(), Default::default())
+        compile_scss_path(path.as_ref(), Default::default())
             .and_then(|s| Ok(String::from_utf8(s)?))
             .unwrap(),
         "main {\n  color: red;\n}\n\n\

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -10,7 +10,7 @@ fn simple_value() {
     };
     let mut scope = GlobalScope::new(format);
     scope.define("color", &css::Value::black());
-    let file_context = FileContext::new();
+    let file_context = FsFileContext::new();
     assert_eq!(
         format
             .write_root(&parsed, &mut scope, &file_context)
@@ -36,7 +36,7 @@ fn simple_function() {
         ),
     );
     let parsed = parse_scss_data(b"p { x: get_answer(); }").unwrap();
-    let file_context = FileContext::new();
+    let file_context = FsFileContext::new();
     assert_eq!(
         format
             .write_root(&parsed, &mut scope, &file_context)
@@ -86,7 +86,7 @@ fn function_with_args() {
         style: output::Style::Compressed,
         precision: 5,
     };
-    let file_context = FileContext::new();
+    let file_context = FsFileContext::new();
     assert_eq!(
         format
             .write_root(&parsed, &mut scope, &file_context)

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -4,7 +4,7 @@
 //! The following tests are excluded from conversion:
 //! ["core_functions/selector/extend", "core_functions/selector/is_superselector", "core_functions/selector/unify", "directives/extend", "directives/forward", "directives/use", "libsass-closed-issues/issue_185/mixin.hrx", "libsass-todo-issues/issue_221262.hrx", "libsass-todo-issues/issue_221292.hrx", "libsass/unicode-bom/utf-16-big", "libsass/unicode-bom/utf-16-little", "non_conformant/scss/huge.hrx", "non_conformant/scss/mixin-content.hrx", "non_conformant/scss/multiline_var.hrx"]
 use rsass::output::Format;
-use rsass::{parse_scss_data, Error, FileContext, GlobalScope};
+use rsass::{parse_scss_data, Error, FsFileContext, GlobalScope};
 
 mod arguments;
 
@@ -43,7 +43,7 @@ fn rsass_fmt(format: Format, input: &str) -> Result<String, String> {
         })
 }
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
-    let mut file_context = FileContext::new();
+    let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
     format.write_root(&items, &mut GlobalScope::new(format), &file_context)


### PR DESCRIPTION
This change allows customizing how files are loaded.

Changes:
  * Add a new trait `Context`, implemented by `FileContext`.
  * Change the public signature of the method `Format.write_root()` (and related private ones) to accepting this trait instead of a `FileContext` directly.
  * Add a new function `parse_scss_readable()`, like `do_parse_scss_file()` but accepting a `Read`.
    I was considering renaming the original functions from `X_file()` to `X_path()` since they accepts paths instead of files. Then the new ones that accept `Read` can become `X_file()`.
    This would be a breaking change, however.
  * Add a function `parse_imported_scss_readable()`, like `parse_imported_scss_file()`
    This function isn't used or public so it causes a warning, it can probably be removed.
  * Change a field of `Error::Input`, from a `PathBuf` to a `String`.
    This should be the only backwards incompatible change.

### Example of how to use this
given:
```rust
use std::collections::HashMap;
use rsass::{Context, Error};

#[derive(Clone, Debug)]
struct StaticContext<'a> {
    files: HashMap<String, &'a[u8]>,
}

impl<'a> Context for StaticContext<'a> {
    type File = &'a [u8];

    fn find_file(
        &self, name: &str
    ) -> Result<Option<(Self, String, Self::File)>, Error> {
        if let Some(file) = self.files.get(name).map(|data| *data) {
            Ok(Some((self.clone(), name.to_string(), file)))
        } else {
            Ok(None)
        }
    }
}
```
then:
```rust
let format = ...
let entry = "import 'a'; import 'b';".as_bytes();
let file_a = "a { color: red }".as_bytes();
let file_b = "p { color: blue }".as_bytes();
let mut context = StaticContext { files: HashMap::new() };
context.files.insert("a".to_string(), file_a);
context.files.insert("b".to_string(), file_b);

output = format.write_root(
    parse_scss_data()?,
    &mut rsass::GlobalScope::new(self.format),
    context)?;
assert_eq!(
    output,
    format!("{}\n{}",
        std::str::from_utf8(file_a).unwrap(),
        std::str::from_utf8(file_b).unwrap()));
```