### PR TITLE
Color integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ project adheres to
 * Improve trigonometric precision by using f64 π rather than rational.
 * Handle more peculiarities with atan2, pow, infinities and negative zero.
 * Improve name lookups in scopes and modules, PR #87.
-* A color can be Hsla or Hwba as well as Rgba. PR #88.
+* A color can be Hsla or Hwba as well as Rgba. PR #88, #89.
 * Handle units in `@for` loops inside sass functions.
 * Test suite sass-spec updated to 2021-02-04.
 * Some cleanups.

--- a/src/functions/color/hwb.rs
+++ b/src/functions/color/hwb.rs
@@ -1,6 +1,6 @@
 use super::hsl::{percentage, to_rational2, to_rational_percent};
 use super::rgb::values_from_list;
-use super::{Error, Module, SassFunction};
+use super::{get_color, Error, Module, SassFunction};
 use crate::css::Value;
 use crate::value::{Hwba, NumValue, Unit};
 use num_rational::Rational;
@@ -33,13 +33,11 @@ pub fn register(f: &mut Module) {
         };
         Ok(Hwba::new(hue.as_ratio()?, w, b, a).into())
     });
-    def!(f, blackness(color), |args| match args.get("color")? {
-        Value::Color(col, _) => Ok(percentage(col.to_hwba().blackness())),
-        v => Err(Error::badarg("color", &v)),
+    def!(f, blackness(color), |s| {
+        Ok(percentage(get_color(s, "color")?.to_hwba().blackness()))
     });
-    def!(f, whiteness(color), |args| match args.get("color")? {
-        Value::Color(col, _) => Ok(percentage(col.to_hwba().whiteness())),
-        v => Err(Error::badarg("color", &v)),
+    def!(f, whiteness(color), |s| {
+        Ok(percentage(get_color(s, "color")?.to_hwba().whiteness()))
     });
 }
 

--- a/src/functions/color/hwb.rs
+++ b/src/functions/color/hwb.rs
@@ -34,11 +34,11 @@ pub fn register(f: &mut Module) {
         Ok(Hwba::new(hue.as_ratio()?, w, b, a).into())
     });
     def!(f, blackness(color), |args| match args.get("color")? {
-        Value::Color(col, _) => Ok(percentage(col.to_hwba().b)),
+        Value::Color(col, _) => Ok(percentage(col.to_hwba().blackness())),
         v => Err(Error::badarg("color", &v)),
     });
     def!(f, whiteness(color), |args| match args.get("color")? {
-        Value::Color(col, _) => Ok(percentage(col.to_hwba().w)),
+        Value::Color(col, _) => Ok(percentage(col.to_hwba().whiteness())),
         v => Err(Error::badarg("color", &v)),
     });
 }

--- a/src/functions/color/mod.rs
+++ b/src/functions/color/mod.rs
@@ -1,4 +1,6 @@
 use super::{make_call, Error, Module, SassFunction};
+use crate::{css::Value, value::Color, Scope};
+
 mod hsl;
 mod hwb;
 mod other;
@@ -17,4 +19,11 @@ pub fn expose(m: &Module, global: &mut Module) {
     rgb::expose(m, global);
     hsl::expose(m, global);
     other::expose(m, global);
+}
+
+fn get_color(s: &dyn Scope, name: &str) -> Result<Color, Error> {
+    match s.get(name)? {
+        Value::Color(col, _) => Ok(col),
+        value => Err(Error::badarg("color", &value)),
+    }
 }

--- a/src/functions/color/mod.rs
+++ b/src/functions/color/mod.rs
@@ -1,6 +1,6 @@
-use super::{make_call, Error, Module, SassFunction};
-use crate::{css::Value, value::Color, Scope};
-
+use super::{Error, Module, SassFunction};
+use crate::css::{CallArgs, Value};
+use crate::{value::Color, Scope};
 mod hsl;
 mod hwb;
 mod other;
@@ -26,4 +26,16 @@ fn get_color(s: &dyn Scope, name: &str) -> Result<Color, Error> {
         Value::Color(col, _) => Ok(col),
         value => Err(Error::badarg("color", &value)),
     }
+}
+
+fn make_call(name: &str, args: Vec<Value>) -> Value {
+    Value::Call(
+        name.into(),
+        CallArgs::new(
+            args.into_iter()
+                .filter(|v| v != &Value::Null)
+                .map(|v| (None, v))
+                .collect(),
+        ),
+    )
 }

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -1,6 +1,6 @@
 use super::{get_color, make_call, Error, Module, SassFunction};
 use crate::css::Value;
-use crate::value::{Hsla, Hwba, Quotes, Rgba, Unit};
+use crate::value::{Hsla, Hwba, Rgba, Unit};
 use crate::variablescope::Scope;
 use num_rational::Rational;
 use num_traits::{One, Signed, Zero};
@@ -223,10 +223,7 @@ pub fn register(f: &mut Module) {
     );
     def!(f, ie_hex_str(color), |s| {
         let (r, g, b, alpha) = get_color(s, "color")?.to_rgba().to_bytes();
-        Ok(Value::Literal(
-            format!("#{:02X}{:02X}{:02X}{:02X}", alpha, r, g, b),
-            Quotes::None,
-        ))
+        Ok(format!("#{:02X}{:02X}{:02X}{:02X}", alpha, r, g, b).into())
     });
 }
 

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -31,10 +31,10 @@ pub fn register(f: &mut Module) {
                 {
                     let rgba = rgba.to_rgba();
                     Ok(Rgba::new(
-                        c_add(rgba.red, "red")?,
-                        c_add(rgba.green, "green")?,
-                        c_add(rgba.blue, "blue")?,
-                        c_add(rgba.alpha, "alpha")?,
+                        c_add(rgba.red(), "red")?,
+                        c_add(rgba.green(), "green")?,
+                        c_add(rgba.blue(), "blue")?,
+                        c_add(rgba.alpha(), "alpha")?,
                     )
                     .into())
                 } else if b_adj.is_null() && w_adj.is_null() {
@@ -105,10 +105,10 @@ pub fn register(f: &mut Module) {
                 {
                     let rgba = rgba.to_rgba();
                     Ok(Rgba::new(
-                        comb(rgba.red, s.get("red")?, ff)?,
-                        comb(rgba.green, s.get("green")?, ff)?,
-                        comb(rgba.blue, s.get("blue")?, ff)?,
-                        comb(rgba.alpha, a_adj, one)?,
+                        comb(rgba.red(), s.get("red")?, ff)?,
+                        comb(rgba.green(), s.get("green")?, ff)?,
+                        comb(rgba.blue(), s.get("blue")?, ff)?,
+                        comb(rgba.alpha(), a_adj, one)?,
                     )
                     .into())
                 } else if b_adj.is_null() && w_adj.is_null() {
@@ -200,10 +200,10 @@ pub fn register(f: &mut Module) {
                 {
                     let rgba = rgba.to_rgba();
                     Ok(Rgba::new(
-                        c_or("red", rgba.red)?,
-                        c_or("green", rgba.green)?,
-                        c_or("blue", rgba.blue)?,
-                        a_or("alpha", rgba.alpha)?,
+                        c_or("red", rgba.red())?,
+                        c_or("green", rgba.green())?,
+                        c_or("blue", rgba.blue())?,
+                        a_or("alpha", rgba.alpha())?,
                     )
                     .into())
                 } else if b_adj.is_null() && w_adj.is_null() {

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -44,10 +44,10 @@ pub fn register(f: &mut Module) {
                         x => to_rational_percent(x).map(|x| orig + x),
                     };
                     Ok(Hsla::new(
-                        c_add(hsla.hue, "hue")?,
-                        sl_add(hsla.sat, s_adj)?,
-                        sl_add(hsla.lum, l_adj)?,
-                        c_add(hsla.alpha, "alpha")?,
+                        c_add(hsla.hue(), "hue")?,
+                        sl_add(hsla.sat(), s_adj)?,
+                        sl_add(hsla.lum(), l_adj)?,
+                        c_add(hsla.alpha(), "alpha")?,
                     )
                     .into())
                 } else {
@@ -112,12 +112,14 @@ pub fn register(f: &mut Module) {
                     )
                     .into())
                 } else if b_adj.is_null() && w_adj.is_null() {
-                    let mut hsla = rgba.to_hsla().into_owned();
-                    hsla.hue = comb(hsla.hue, h_adj, one)?;
-                    hsla.sat = comb(hsla.sat, s_adj, one)?;
-                    hsla.lum = comb(hsla.lum, l_adj, one)?;
-                    hsla.alpha = comb(hsla.alpha, a_adj, one)?;
-                    Ok(hsla.into())
+                    let hsla = rgba.to_hsla();
+                    Ok(Hsla::new(
+                        comb(hsla.hue(), h_adj, one)?,
+                        comb(hsla.sat(), s_adj, one)?,
+                        comb(hsla.lum(), l_adj, one)?,
+                        comb(hsla.alpha(), a_adj, one)?,
+                    )
+                    .into())
                 } else {
                     let hwba = rgba.to_hwba();
                     Ok(Hwba::new(
@@ -207,10 +209,10 @@ pub fn register(f: &mut Module) {
                 } else if b_adj.is_null() && w_adj.is_null() {
                     let hsla = rgba.to_hsla();
                     Ok(Hsla::new(
-                        a_or("hue", hsla.hue)?,
-                        sl_or(s_adj, hsla.sat)?,
-                        sl_or(l_adj, hsla.lum)?,
-                        a_or("alpha", hsla.alpha)?,
+                        a_or("hue", hsla.hue())?,
+                        sl_or(s_adj, hsla.sat())?,
+                        sl_or(l_adj, hsla.lum())?,
+                        a_or("alpha", hsla.alpha())?,
                     )
                     .into())
                 } else {

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -59,10 +59,10 @@ pub fn register(f: &mut Module) {
                         }
                     };
                     Ok(Hwba::new(
-                        c_add(hwba.hue, "hue")?,
-                        sl_add(hwba.w, w_adj)?,
-                        sl_add(hwba.b, b_adj)?,
-                        c_add(hwba.alpha, "alpha")?,
+                        c_add(hwba.hue(), "hue")?,
+                        sl_add(hwba.whiteness(), w_adj)?,
+                        sl_add(hwba.blackness(), b_adj)?,
+                        c_add(hwba.alpha(), "alpha")?,
                     )
                     .into())
                 }
@@ -121,10 +121,10 @@ pub fn register(f: &mut Module) {
                 } else {
                     let hwba = rgba.to_hwba();
                     Ok(Hwba::new(
-                        comb(hwba.hue, h_adj, one)?,
-                        comb(hwba.w, w_adj, one)?,
-                        comb(hwba.b, b_adj, one)?,
-                        comb(hwba.alpha, a_adj, one)?,
+                        comb(hwba.hue(), h_adj, one)?,
+                        comb(hwba.whiteness(), w_adj, one)?,
+                        comb(hwba.blackness(), b_adj, one)?,
+                        comb(hwba.alpha(), a_adj, one)?,
                     )
                     .into())
                 }
@@ -216,10 +216,10 @@ pub fn register(f: &mut Module) {
                 } else {
                     let hwba = rgba.to_hwba();
                     Ok(Hwba::new(
-                        a_or("hue", hwba.hue)?,
-                        sl_or(w_adj, hwba.w)?,
-                        sl_or(b_adj, hwba.b)?,
-                        a_or("alpha", hwba.alpha)?,
+                        a_or("hue", hwba.hue())?,
+                        sl_or(w_adj, hwba.whiteness())?,
+                        sl_or(b_adj, hwba.blackness())?,
+                        a_or("alpha", hwba.alpha())?,
                     )
                     .into())
                 }

--- a/src/functions/color/other.rs
+++ b/src/functions/color/other.rs
@@ -1,4 +1,4 @@
-use super::{make_call, Error, Module, SassFunction};
+use super::{get_color, make_call, Error, Module, SassFunction};
 use crate::css::Value;
 use crate::value::{Hsla, Hwba, Quotes, Rgba, Unit};
 use crate::variablescope::Scope;
@@ -12,62 +12,58 @@ pub fn register(f: &mut Module) {
             color, red, green, blue, hue, saturation, lightness, whiteness,
             blackness, alpha
         ),
-        |s: &dyn Scope| match s.get("color")? {
-            Value::Color(rgba, _) => {
-                let c_add = |orig: Rational, name: &str| match s.get(name)? {
+        |s: &dyn Scope| {
+            let rgba = get_color(s, "color")?;
+            let c_add = |orig: Rational, name: &str| match s.get(name)? {
+                Value::Null => Ok(orig),
+                x => to_rational(x).map(|x| orig + x),
+            };
+            let h_adj = s.get("hue")?;
+            let s_adj = s.get("saturation")?;
+            let l_adj = s.get("lightness")?;
+            let b_adj = s.get("blackness")?;
+            let w_adj = s.get("whiteness")?;
+            if h_adj.is_null()
+                && s_adj.is_null()
+                && l_adj.is_null()
+                && b_adj.is_null()
+                && w_adj.is_null()
+            {
+                let rgba = rgba.to_rgba();
+                Ok(Rgba::new(
+                    c_add(rgba.red(), "red")?,
+                    c_add(rgba.green(), "green")?,
+                    c_add(rgba.blue(), "blue")?,
+                    c_add(rgba.alpha(), "alpha")?,
+                )
+                .into())
+            } else if b_adj.is_null() && w_adj.is_null() {
+                let hsla = rgba.to_hsla();
+                let sl_add = |orig: Rational, x: Value| match x {
                     Value::Null => Ok(orig),
-                    x => to_rational(x).map(|x| orig + x),
+                    x => to_rational_percent(x).map(|x| orig + x),
                 };
-                let h_adj = s.get("hue")?;
-                let s_adj = s.get("saturation")?;
-                let l_adj = s.get("lightness")?;
-                let b_adj = s.get("blackness")?;
-                let w_adj = s.get("whiteness")?;
-                if h_adj.is_null()
-                    && s_adj.is_null()
-                    && l_adj.is_null()
-                    && b_adj.is_null()
-                    && w_adj.is_null()
-                {
-                    let rgba = rgba.to_rgba();
-                    Ok(Rgba::new(
-                        c_add(rgba.red(), "red")?,
-                        c_add(rgba.green(), "green")?,
-                        c_add(rgba.blue(), "blue")?,
-                        c_add(rgba.alpha(), "alpha")?,
-                    )
-                    .into())
-                } else if b_adj.is_null() && w_adj.is_null() {
-                    let hsla = rgba.to_hsla();
-                    let sl_add = |orig: Rational, x: Value| match x {
-                        Value::Null => Ok(orig),
-                        x => to_rational_percent(x).map(|x| orig + x),
-                    };
-                    Ok(Hsla::new(
-                        c_add(hsla.hue(), "hue")?,
-                        sl_add(hsla.sat(), s_adj)?,
-                        sl_add(hsla.lum(), l_adj)?,
-                        c_add(hsla.alpha(), "alpha")?,
-                    )
-                    .into())
-                } else {
-                    let hwba = rgba.to_hwba();
-                    let sl_add = |orig: Rational, x: Value| match x {
-                        Value::Null => Ok(orig),
-                        x => {
-                            to_rational_percent(x).map(|x| clamp_z1(orig + x))
-                        }
-                    };
-                    Ok(Hwba::new(
-                        c_add(hwba.hue(), "hue")?,
-                        sl_add(hwba.whiteness(), w_adj)?,
-                        sl_add(hwba.blackness(), b_adj)?,
-                        c_add(hwba.alpha(), "alpha")?,
-                    )
-                    .into())
-                }
+                Ok(Hsla::new(
+                    c_add(hsla.hue(), "hue")?,
+                    sl_add(hsla.sat(), s_adj)?,
+                    sl_add(hsla.lum(), l_adj)?,
+                    c_add(hsla.alpha(), "alpha")?,
+                )
+                .into())
+            } else {
+                let hwba = rgba.to_hwba();
+                let sl_add = |orig: Rational, x: Value| match x {
+                    Value::Null => Ok(orig),
+                    x => to_rational_percent(x).map(|x| clamp_z1(orig + x)),
+                };
+                Ok(Hwba::new(
+                    c_add(hwba.hue(), "hue")?,
+                    sl_add(hwba.whiteness(), w_adj)?,
+                    sl_add(hwba.blackness(), b_adj)?,
+                    c_add(hwba.alpha(), "alpha")?,
+                )
+                .into())
             }
-            v => Err(Error::badarg("color", &v)),
         }
     );
     def!(
@@ -76,62 +72,60 @@ pub fn register(f: &mut Module) {
             color, red, green, blue, hue, saturation, lightness, whiteness,
             blackness, alpha
         ),
-        |s: &dyn Scope| match s.get("color")? {
-            Value::Color(rgba, _) => {
-                let h_adj = s.get("hue")?;
-                let s_adj = s.get("saturation")?;
-                let l_adj = s.get("lightness")?;
-                let b_adj = s.get("blackness")?;
-                let w_adj = s.get("whiteness")?;
-                let a_adj = s.get("alpha")?;
+        |s: &dyn Scope| {
+            let rgba = get_color(s, "color")?;
+            let h_adj = s.get("hue")?;
+            let s_adj = s.get("saturation")?;
+            let l_adj = s.get("lightness")?;
+            let b_adj = s.get("blackness")?;
+            let w_adj = s.get("whiteness")?;
+            let a_adj = s.get("alpha")?;
 
-                let comb = |orig: Rational, x: Value, max: Rational| match x {
-                    Value::Null => Ok(orig),
-                    x => to_rational_percent(x).map(|x| {
-                        if x.is_positive() {
-                            orig + (max - orig) * x
-                        } else {
-                            orig + orig * x
-                        }
-                    }),
-                };
-                let one = Rational::one();
-                let ff = Rational::from_integer(255);
-                if h_adj.is_null()
-                    && s_adj.is_null()
-                    && l_adj.is_null()
-                    && b_adj.is_null()
-                    && w_adj.is_null()
-                {
-                    let rgba = rgba.to_rgba();
-                    Ok(Rgba::new(
-                        comb(rgba.red(), s.get("red")?, ff)?,
-                        comb(rgba.green(), s.get("green")?, ff)?,
-                        comb(rgba.blue(), s.get("blue")?, ff)?,
-                        comb(rgba.alpha(), a_adj, one)?,
-                    )
-                    .into())
-                } else if b_adj.is_null() && w_adj.is_null() {
-                    let hsla = rgba.to_hsla();
-                    Ok(Hsla::new(
-                        comb(hsla.hue(), h_adj, one)?,
-                        comb(hsla.sat(), s_adj, one)?,
-                        comb(hsla.lum(), l_adj, one)?,
-                        comb(hsla.alpha(), a_adj, one)?,
-                    )
-                    .into())
-                } else {
-                    let hwba = rgba.to_hwba();
-                    Ok(Hwba::new(
-                        comb(hwba.hue(), h_adj, one)?,
-                        comb(hwba.whiteness(), w_adj, one)?,
-                        comb(hwba.blackness(), b_adj, one)?,
-                        comb(hwba.alpha(), a_adj, one)?,
-                    )
-                    .into())
-                }
+            let comb = |orig: Rational, x: Value, max: Rational| match x {
+                Value::Null => Ok(orig),
+                x => to_rational_percent(x).map(|x| {
+                    if x.is_positive() {
+                        orig + (max - orig) * x
+                    } else {
+                        orig + orig * x
+                    }
+                }),
+            };
+            let one = Rational::one();
+            let ff = Rational::from_integer(255);
+            if h_adj.is_null()
+                && s_adj.is_null()
+                && l_adj.is_null()
+                && b_adj.is_null()
+                && w_adj.is_null()
+            {
+                let rgba = rgba.to_rgba();
+                Ok(Rgba::new(
+                    comb(rgba.red(), s.get("red")?, ff)?,
+                    comb(rgba.green(), s.get("green")?, ff)?,
+                    comb(rgba.blue(), s.get("blue")?, ff)?,
+                    comb(rgba.alpha(), a_adj, one)?,
+                )
+                .into())
+            } else if b_adj.is_null() && w_adj.is_null() {
+                let hsla = rgba.to_hsla();
+                Ok(Hsla::new(
+                    comb(hsla.hue(), h_adj, one)?,
+                    comb(hsla.sat(), s_adj, one)?,
+                    comb(hsla.lum(), l_adj, one)?,
+                    comb(hsla.alpha(), a_adj, one)?,
+                )
+                .into())
+            } else {
+                let hwba = rgba.to_hwba();
+                Ok(Hwba::new(
+                    comb(hwba.hue(), h_adj, one)?,
+                    comb(hwba.whiteness(), w_adj, one)?,
+                    comb(hwba.blackness(), b_adj, one)?,
+                    comb(hwba.alpha(), a_adj, one)?,
+                )
+                .into())
             }
-            v => Err(Error::badarg("color", &v)),
         }
     );
 
@@ -172,72 +166,67 @@ pub fn register(f: &mut Module) {
             color, red, green, blue, hue, saturation, lightness, blackness,
             whiteness, alpha
         ),
-        |s: &dyn Scope| match s.get("color")? {
-            Value::Color(rgba, _) => {
-                let h_adj = s.get("hue")?;
-                let s_adj = s.get("saturation")?;
-                let l_adj = s.get("lightness")?;
-                let b_adj = s.get("blackness")?;
-                let w_adj = s.get("whiteness")?;
+        |s: &dyn Scope| {
+            let rgba = get_color(s, "color")?;
+            let h_adj = s.get("hue")?;
+            let s_adj = s.get("saturation")?;
+            let l_adj = s.get("lightness")?;
+            let b_adj = s.get("blackness")?;
+            let w_adj = s.get("whiteness")?;
 
-                let c_or = |name: &str, orig: Rational| match s.get(name)? {
-                    Value::Null => Ok(orig),
-                    x => to_rational(x),
-                };
-                let a_or = |name: &str, orig: Rational| match s.get(name)? {
-                    Value::Null => Ok(orig),
-                    x => to_rational(x),
-                };
-                let sl_or = |x: Value, orig: Rational| match x {
-                    Value::Null => Ok(orig),
-                    x => to_rational_percent(x),
-                };
-                if h_adj.is_null()
-                    && s_adj.is_null()
-                    && l_adj.is_null()
-                    && b_adj.is_null()
-                    && w_adj.is_null()
-                {
-                    let rgba = rgba.to_rgba();
-                    Ok(Rgba::new(
-                        c_or("red", rgba.red())?,
-                        c_or("green", rgba.green())?,
-                        c_or("blue", rgba.blue())?,
-                        a_or("alpha", rgba.alpha())?,
-                    )
-                    .into())
-                } else if b_adj.is_null() && w_adj.is_null() {
-                    let hsla = rgba.to_hsla();
-                    Ok(Hsla::new(
-                        a_or("hue", hsla.hue())?,
-                        sl_or(s_adj, hsla.sat())?,
-                        sl_or(l_adj, hsla.lum())?,
-                        a_or("alpha", hsla.alpha())?,
-                    )
-                    .into())
-                } else {
-                    let hwba = rgba.to_hwba();
-                    Ok(Hwba::new(
-                        a_or("hue", hwba.hue())?,
-                        sl_or(w_adj, hwba.whiteness())?,
-                        sl_or(b_adj, hwba.blackness())?,
-                        a_or("alpha", hwba.alpha())?,
-                    )
-                    .into())
-                }
+            let c_or = |name: &str, orig: Rational| match s.get(name)? {
+                Value::Null => Ok(orig),
+                x => to_rational(x),
+            };
+            let a_or = |name: &str, orig: Rational| match s.get(name)? {
+                Value::Null => Ok(orig),
+                x => to_rational(x),
+            };
+            let sl_or = |x: Value, orig: Rational| match x {
+                Value::Null => Ok(orig),
+                x => to_rational_percent(x),
+            };
+            if h_adj.is_null()
+                && s_adj.is_null()
+                && l_adj.is_null()
+                && b_adj.is_null()
+                && w_adj.is_null()
+            {
+                let rgba = rgba.to_rgba();
+                Ok(Rgba::new(
+                    c_or("red", rgba.red())?,
+                    c_or("green", rgba.green())?,
+                    c_or("blue", rgba.blue())?,
+                    a_or("alpha", rgba.alpha())?,
+                )
+                .into())
+            } else if b_adj.is_null() && w_adj.is_null() {
+                let hsla = rgba.to_hsla();
+                Ok(Hsla::new(
+                    a_or("hue", hsla.hue())?,
+                    sl_or(s_adj, hsla.sat())?,
+                    sl_or(l_adj, hsla.lum())?,
+                    a_or("alpha", hsla.alpha())?,
+                )
+                .into())
+            } else {
+                let hwba = rgba.to_hwba();
+                Ok(Hwba::new(
+                    a_or("hue", hwba.hue())?,
+                    sl_or(w_adj, hwba.whiteness())?,
+                    sl_or(b_adj, hwba.blackness())?,
+                    a_or("alpha", hwba.alpha())?,
+                )
+                .into())
             }
-            v => Err(Error::badarg("color", &v)),
         }
     );
-    def!(f, ie_hex_str(color), |s| match s.get("color")? {
-        Value::Color(col, _) => {
-            let (r, g, b, alpha) = col.to_rgba().to_bytes();
-            Ok(Value::Literal(
-                format!("#{:02X}{:02X}{:02X}{:02X}", alpha, r, g, b),
-                Quotes::None,
-            ))
-        }
-        v => Err(Error::badarg("color", &v)),
+    def!(f, ie_hex_str(color), |s| {
+        let (r, g, b, alpha) = get_color(s, "color")?.to_rgba().to_bytes();
+        Ok(Value::Literal(
+            format!("#{:02X}{:02X}{:02X}{:02X}", alpha, r, g, b),
+            Quotes::None,
+        ))
     });
 }
 

--- a/src/functions/color/rgb.rs
+++ b/src/functions/color/rgb.rs
@@ -13,16 +13,19 @@ fn do_rgba(fn_name: &str, s: &dyn Scope) -> Result<Value, Error> {
         let rgba = rgba.to_rgba();
         let a = if a.is_null() { s.get("green")? } else { a };
         match a {
-            Value::Numeric(a, ..) => {
-                Ok(Rgba::new(rgba.red, rgba.green, rgba.blue, a.as_ratio()?)
-                    .into())
-            }
+            Value::Numeric(a, ..) => Ok(Rgba::new(
+                rgba.red(),
+                rgba.green(),
+                rgba.blue(),
+                a.as_ratio()?,
+            )
+            .into()),
             _ => Ok(make_call(
                 fn_name,
                 vec![
-                    int_value(rgba.red),
-                    int_value(rgba.green),
-                    int_value(rgba.blue),
+                    int_value(rgba.red()),
+                    int_value(rgba.green()),
+                    int_value(rgba.blue()),
                     a,
                 ],
             )),
@@ -119,15 +122,15 @@ pub fn register(f: &mut Module) {
         Ok(Value::Numeric(Number::from(*v), Unit::None, true))
     }
     def!(f, red(color), |s| match s.get("color")? {
-        Value::Color(rgba, _) => num(&rgba.to_rgba().red),
+        Value::Color(rgba, _) => num(&rgba.to_rgba().red()),
         value => Err(Error::badarg("color", &value)),
     });
     def!(f, green(color), |s| match s.get("color")? {
-        Value::Color(rgba, _) => num(&rgba.to_rgba().green),
+        Value::Color(rgba, _) => num(&rgba.to_rgba().green()),
         value => Err(Error::badarg("color", &value)),
     });
     def!(f, blue(color), |s| match s.get("color")? {
-        Value::Color(rgba, _) => num(&rgba.to_rgba().blue),
+        Value::Color(rgba, _) => num(&rgba.to_rgba().blue()),
         value => Err(Error::badarg("color", &value)),
     });
     def!(f, mix(color1, color2, weight = b"50%"), |s| match (
@@ -142,7 +145,7 @@ pub fn register(f: &mut Module) {
             let one = Rational::one();
 
             let w_a = {
-                let wa = a.alpha - b.alpha;
+                let wa = a.alpha() - b.alpha();
                 let w2 = w * 2 - 1;
                 let divis = w2 * wa + 1;
                 if divis.is_zero() {
@@ -155,10 +158,10 @@ pub fn register(f: &mut Module) {
 
             let m_c = |c_a, c_b| w_a * c_a + w_b * c_b;
             Ok(Rgba::new(
-                m_c(a.red, b.red),
-                m_c(a.green, b.green),
-                m_c(a.blue, b.blue),
-                a.alpha * w + b.alpha * (one - w),
+                m_c(a.red(), b.red()),
+                m_c(a.green(), b.green()),
+                m_c(a.blue(), b.blue()),
+                a.alpha() * w + b.alpha() * (one - w),
             )
             .into())
         }
@@ -180,10 +183,10 @@ pub fn register(f: &mut Module) {
             };
             let inv = |v: Rational| -(v - 255) * w + v * -(w - 1);
             Ok(Rgba::new(
-                inv(rgba.red),
-                inv(rgba.green),
-                inv(rgba.blue),
-                rgba.alpha,
+                inv(rgba.red()),
+                inv(rgba.green()),
+                inv(rgba.blue()),
+                rgba.alpha(),
             )
             .into())
         }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -169,18 +169,6 @@ lazy_static! {
     };
 }
 
-fn make_call(name: &str, args: Vec<css::Value>) -> css::Value {
-    css::Value::Call(
-        name.into(),
-        css::CallArgs::new(
-            args.into_iter()
-                .filter(|v| v != &css::Value::Null)
-                .map(|v| (None, v))
-                .collect(),
-        ),
-    )
-}
-
 #[test]
 fn test_rgb() -> Result<(), Box<dyn std::error::Error>> {
     use crate::parser::code_span;

--- a/src/value/colors/convert.rs
+++ b/src/value/colors/convert.rs
@@ -58,11 +58,11 @@ impl From<&Hwba> for Hsla {
 impl From<&Rgba> for Hsla {
     fn from(rgba: &Rgba) -> Hsla {
         let (red, green, blue) =
-            (rgba.red / 255, rgba.green / 255, rgba.blue / 255);
+            (rgba.red() / 255, rgba.green() / 255, rgba.blue() / 255);
         let (max, min, largest) = max_min_largest(red, green, blue);
 
         if max == min {
-            Hsla::new(zero(), zero(), max, rgba.alpha)
+            Hsla::new(zero(), zero(), max, rgba.alpha())
         } else {
             let d = max - min;
             let hue = match largest {
@@ -72,7 +72,7 @@ impl From<&Rgba> for Hsla {
             } * (360 / 6);
             let mm = max + min;
             let sat = d / if mm > one() { -mm + 2 } else { mm };
-            Hsla::new(hue, sat, mm / 2, rgba.alpha)
+            Hsla::new(hue, sat, mm / 2, rgba.alpha())
         }
     }
 }
@@ -80,7 +80,7 @@ impl From<&Rgba> for Hsla {
 impl From<&Rgba> for Hwba {
     fn from(rgba: &Rgba) -> Hwba {
         let hsla = Hsla::from(rgba);
-        let arr = [&rgba.red, &rgba.blue, &rgba.green];
+        let arr = [rgba.red(), rgba.blue(), rgba.green()];
         Hwba::new(
             hsla.hue(),
             *arr.iter().min().unwrap() / 255,
@@ -92,7 +92,7 @@ impl From<&Rgba> for Hwba {
 impl From<&Hsla> for Hwba {
     fn from(hsla: &Hsla) -> Hwba {
         let rgba = Rgba::from(hsla);
-        let arr = [&rgba.red, &rgba.blue, &rgba.green];
+        let arr = [rgba.red(), rgba.blue(), rgba.green()];
         Hwba::new(
             hsla.hue(),
             Rational::one() - *arr.iter().max().unwrap() / 255,

--- a/src/value/colors/convert.rs
+++ b/src/value/colors/convert.rs
@@ -43,20 +43,15 @@ impl From<&Hwba> for Rgba {
 
 impl From<&Hwba> for Hsla {
     fn from(hwba: &Hwba) -> Hsla {
-        let wbsum = hwba.w + hwba.b;
-        let (w, b) = if wbsum > one() {
-            (hwba.w / wbsum, hwba.b / wbsum)
-        } else {
-            (hwba.w, hwba.b)
-        };
-
+        let w = hwba.whiteness();
+        let b = hwba.blackness();
         let l = (Rational::one() - b + w) / 2;
         let s = if l.is_zero() || l.is_one() {
             zero()
         } else {
             (Rational::one() - b - l) / std::cmp::min(l, Rational::one() - l)
         };
-        Hsla::new(hwba.hue, s, l, hwba.alpha)
+        Hsla::new(hwba.hue(), s, l, hwba.alpha())
     }
 }
 
@@ -96,24 +91,24 @@ impl From<&Rgba> for Hwba {
     fn from(rgba: &Rgba) -> Hwba {
         let hsla = Hsla::from(rgba);
         let arr = [&rgba.red, &rgba.blue, &rgba.green];
-        Hwba {
-            hue: hsla.hue,
-            w: *arr.iter().min().unwrap() / 255,
-            b: Rational::one() - *arr.iter().max().unwrap() / 255,
-            alpha: hsla.alpha,
-        }
+        Hwba::new(
+            hsla.hue,
+            *arr.iter().min().unwrap() / 255,
+            Rational::one() - *arr.iter().max().unwrap() / 255,
+            hsla.alpha,
+        )
     }
 }
 impl From<&Hsla> for Hwba {
     fn from(hsla: &Hsla) -> Hwba {
         let rgba = Rgba::from(hsla);
         let arr = [&rgba.red, &rgba.blue, &rgba.green];
-        Hwba {
-            hue: hsla.hue,
-            w: Rational::one() - *arr.iter().max().unwrap() / 255,
-            b: *arr.iter().min().unwrap() / 255,
-            alpha: hsla.alpha,
-        }
+        Hwba::new(
+            hsla.hue,
+            Rational::one() - *arr.iter().max().unwrap() / 255,
+            *arr.iter().min().unwrap() / 255,
+            hsla.alpha,
+        )
     }
 }
 

--- a/src/value/colors/convert.rs
+++ b/src/value/colors/convert.rs
@@ -2,12 +2,12 @@ use super::*;
 
 impl From<&Hsla> for Rgba {
     fn from(hsla: &Hsla) -> Rgba {
-        let hue = hsla.hue / 360;
-        let sat = clamp(hsla.sat, zero(), one());
-        let lum = clamp(hsla.lum, zero(), one());
+        let hue = hsla.hue() / 360;
+        let sat = hsla.sat();
+        let lum = hsla.lum();
         if sat.is_zero() {
             let gray = lum * 255;
-            Rgba::new(gray, gray, gray, hsla.alpha)
+            Rgba::new(gray, gray, gray, hsla.alpha())
         } else {
             fn hue2rgb(p: Rational, q: Rational, t: Rational) -> Rational {
                 let t = (t - t.floor()) * 6;
@@ -29,7 +29,7 @@ impl From<&Hsla> for Rgba {
                 hue2rgb(p, q, hue + Rational::new(1, 3)) * 255,
                 hue2rgb(p, q, hue) * 255,
                 hue2rgb(p, q, hue - Rational::new(1, 3)) * 255,
-                hsla.alpha,
+                hsla.alpha(),
             )
         }
     }
@@ -62,12 +62,7 @@ impl From<&Rgba> for Hsla {
         let (max, min, largest) = max_min_largest(red, green, blue);
 
         if max == min {
-            Hsla {
-                hue: zero(),
-                sat: zero(),
-                lum: max,
-                alpha: rgba.alpha,
-            }
+            Hsla::new(zero(), zero(), max, rgba.alpha)
         } else {
             let d = max - min;
             let hue = match largest {
@@ -77,12 +72,7 @@ impl From<&Rgba> for Hsla {
             } * (360 / 6);
             let mm = max + min;
             let sat = d / if mm > one() { -mm + 2 } else { mm };
-            Hsla {
-                hue,
-                sat,
-                lum: mm / 2,
-                alpha: rgba.alpha,
-            }
+            Hsla::new(hue, sat, mm / 2, rgba.alpha)
         }
     }
 }
@@ -92,10 +82,10 @@ impl From<&Rgba> for Hwba {
         let hsla = Hsla::from(rgba);
         let arr = [&rgba.red, &rgba.blue, &rgba.green];
         Hwba::new(
-            hsla.hue,
+            hsla.hue(),
             *arr.iter().min().unwrap() / 255,
             Rational::one() - *arr.iter().max().unwrap() / 255,
-            hsla.alpha,
+            hsla.alpha(),
         )
     }
 }
@@ -104,10 +94,10 @@ impl From<&Hsla> for Hwba {
         let rgba = Rgba::from(hsla);
         let arr = [&rgba.red, &rgba.blue, &rgba.green];
         Hwba::new(
-            hsla.hue,
+            hsla.hue(),
             Rational::one() - *arr.iter().max().unwrap() / 255,
             *arr.iter().min().unwrap() / 255,
-            hsla.alpha,
+            hsla.alpha(),
         )
     }
 }

--- a/src/value/colors/hsla.rs
+++ b/src/value/colors/hsla.rs
@@ -5,10 +5,10 @@ use num_traits::{one, zero, Signed};
 /// A color defined by hue, saturation, luminance, and alpha.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Hsla {
-    pub hue: Rational,
-    pub sat: Rational,
-    pub lum: Rational,
-    pub alpha: Rational,
+    hue: Rational,
+    sat: Rational,
+    lum: Rational,
+    alpha: Rational,
 }
 
 impl Hsla {
@@ -21,10 +21,35 @@ impl Hsla {
     ) -> Hsla {
         Hsla {
             hue: deg_mod(hue),
-            sat,
-            lum,
+            sat: clamp(sat, zero(), one()),
+            lum: clamp(lum, zero(), one()),
             alpha: clamp(alpha, zero(), one()),
         }
+    }
+
+    /// Get the hue of this color.
+    pub fn hue(&self) -> Rational {
+        self.hue
+    }
+    /// Get the saturation of this color.
+    pub fn sat(&self) -> Rational {
+        self.sat
+    }
+    /// Get the lumination of this color.
+    pub fn lum(&self) -> Rational {
+        self.lum
+    }
+    /// Get the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn alpha(&self) -> Rational {
+        self.alpha
+    }
+    /// Set the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn set_alpha(&mut self, alpha: Rational) {
+        self.alpha = clamp(alpha, zero(), one())
     }
 }
 

--- a/src/value/colors/hwba.rs
+++ b/src/value/colors/hwba.rs
@@ -3,26 +3,72 @@ use num_rational::Rational;
 use num_traits::{one, zero};
 
 /// A color defined by hue, whiteness, blackness, and alpha.
+///
+/// All components are rational numbers.
+/// The hue is in degrees (0..360).
+/// The whiteness, blackness, and alpha are all in the zero to one
+/// range (inclusive), whith the additional invariant that whiteness +
+/// blackness will never be more than one.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Hwba {
-    pub hue: Rational,
-    pub w: Rational,
-    pub b: Rational,
-    pub alpha: Rational,
+    hue: Rational,
+    w: Rational,
+    b: Rational,
+    alpha: Rational,
 }
 
 impl Hwba {
+    /// Create a new hwba color value.
+    ///
+    /// Hue is modulo 360 degrees.  Other inputs will be clamped to
+    /// their ranges.
     pub fn new(
         hue: Rational,
         w: Rational,
         b: Rational,
         alpha: Rational,
     ) -> Hwba {
+        let mut w = clamp(w, zero(), one());
+        let mut b = clamp(b, zero(), one());
+        let wbsum = w + b;
+        if w + b > one() {
+            w /= wbsum;
+            b /= wbsum;
+        }
         Hwba {
             hue,
             w,
             b,
             alpha: clamp(alpha, zero(), one()),
         }
+    }
+
+    /// Get the hue of this color.
+    pub fn hue(&self) -> Rational {
+        self.hue
+    }
+    /// Get the whiteness of this color.
+    ///
+    /// Zero is no whiteness, one means this color is white.
+    pub fn whiteness(&self) -> Rational {
+        self.w
+    }
+    /// Get the black of this color.
+    ///
+    /// Zero is no blackness, one means this color is black.
+    pub fn blackness(&self) -> Rational {
+        self.b
+    }
+    /// Get the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn alpha(&self) -> Rational {
+        self.alpha
+    }
+    /// Set the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn set_alpha(&mut self, alpha: Rational) {
+        self.alpha = clamp(alpha, zero(), one())
     }
 }

--- a/src/value/colors/mod.rs
+++ b/src/value/colors/mod.rs
@@ -63,7 +63,7 @@ impl Color {
     pub fn get_alpha(&self) -> Rational {
         match self {
             Color::Rgba(rgba) => rgba.alpha,
-            Color::Hsla(hsla) => hsla.alpha,
+            Color::Hsla(hsla) => hsla.alpha(),
             Color::Hwba(hwba) => hwba.alpha(),
         }
     }
@@ -74,8 +74,36 @@ impl Color {
         let alpha = clamp(alpha, zero(), one());
         match self {
             Color::Rgba(ref mut rgba) => rgba.alpha = alpha,
-            Color::Hsla(ref mut hsla) => hsla.alpha = alpha,
+            Color::Hsla(ref mut hsla) => hsla.set_alpha(alpha),
             Color::Hwba(ref mut hwba) => hwba.set_alpha(alpha),
+        }
+    }
+    pub fn rotate_hue(&self, val: Rational) -> Self {
+        match self {
+            Color::Rgba(rgba) => {
+                let hsla = Hsla::from(rgba);
+                Hsla::new(
+                    hsla.hue() + val,
+                    hsla.sat(),
+                    hsla.lum(),
+                    hsla.alpha(),
+                )
+                .into()
+            }
+            Color::Hsla(hsla) => Hsla::new(
+                hsla.hue() + val,
+                hsla.sat(),
+                hsla.lum(),
+                hsla.alpha(),
+            )
+            .into(),
+            Color::Hwba(hwba) => Hwba::new(
+                hwba.hue() + val,
+                hwba.whiteness(),
+                hwba.blackness(),
+                hwba.alpha(),
+            )
+            .into(),
         }
     }
     pub fn format(&self, format: Format) -> Formatted<Self> {

--- a/src/value/colors/mod.rs
+++ b/src/value/colors/mod.rs
@@ -62,7 +62,7 @@ impl Color {
     /// The alpha channel is a rational value between 0 and 1.
     pub fn get_alpha(&self) -> Rational {
         match self {
-            Color::Rgba(rgba) => rgba.alpha,
+            Color::Rgba(rgba) => rgba.alpha(),
             Color::Hsla(hsla) => hsla.alpha(),
             Color::Hwba(hwba) => hwba.alpha(),
         }
@@ -73,7 +73,7 @@ impl Color {
     pub fn set_alpha(&mut self, alpha: Rational) {
         let alpha = clamp(alpha, zero(), one());
         match self {
-            Color::Rgba(ref mut rgba) => rgba.alpha = alpha,
+            Color::Rgba(ref mut rgba) => rgba.set_alpha(alpha),
             Color::Hsla(ref mut hsla) => hsla.set_alpha(alpha),
             Color::Hwba(ref mut hwba) => hwba.set_alpha(alpha),
         }

--- a/src/value/colors/mod.rs
+++ b/src/value/colors/mod.rs
@@ -64,7 +64,7 @@ impl Color {
         match self {
             Color::Rgba(rgba) => rgba.alpha,
             Color::Hsla(hsla) => hsla.alpha,
-            Color::Hwba(hwba) => hwba.alpha,
+            Color::Hwba(hwba) => hwba.alpha(),
         }
     }
     /// Set the alpha channel of this color.
@@ -75,7 +75,7 @@ impl Color {
         match self {
             Color::Rgba(ref mut rgba) => rgba.alpha = alpha,
             Color::Hsla(ref mut hsla) => hsla.alpha = alpha,
-            Color::Hwba(ref mut hwba) => hwba.alpha = alpha,
+            Color::Hwba(ref mut hwba) => hwba.set_alpha(alpha),
         }
     }
     pub fn format(&self, format: Format) -> Formatted<Self> {

--- a/src/value/colors/rgba.rs
+++ b/src/value/colors/rgba.rs
@@ -1,19 +1,18 @@
 //! Color names from <https://www.w3.org/TR/css3-color/>
 #![allow(clippy::unreadable_literal)]
-
 use lazy_static::lazy_static;
 use num_rational::Rational;
-use num_traits::{One, Signed, Zero};
+use num_traits::{one, One, Signed, Zero};
 use std::collections::BTreeMap;
 use std::ops::{Add, Div, Sub};
 
 /// A color defined by red, green, blue, and alpha components.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Rgba {
-    pub red: Rational,
-    pub green: Rational,
-    pub blue: Rational,
-    pub alpha: Rational,
+    red: Rational,
+    green: Rational,
+    blue: Rational,
+    alpha: Rational,
 }
 
 impl Rgba {
@@ -82,11 +81,35 @@ impl Rgba {
         let a = self.alpha * 255;
         (byte(self.red), byte(self.green), byte(self.blue), byte(a))
     }
+    /// Get the red component.
+    pub fn red(&self) -> Rational {
+        self.red
+    }
+    /// Get the green component.
+    pub fn green(&self) -> Rational {
+        self.green
+    }
+    /// Get the blue component.
+    pub fn blue(&self) -> Rational {
+        self.blue
+    }
+    /// Get the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn alpha(&self) -> Rational {
+        self.alpha
+    }
+    /// Set the alpha value of this color.
+    ///
+    /// Zero is fully transparent, one is fully opaque.
+    pub fn set_alpha(&mut self, alpha: Rational) {
+        self.alpha = cap(alpha, &one())
+    }
 }
 
-fn cap(n: Rational, ff: &Rational) -> Rational {
-    if n > *ff {
-        *ff
+fn cap(n: Rational, max: &Rational) -> Rational {
+    if n > *max {
+        *max
     } else if n.is_negative() {
         Rational::zero()
     } else {


### PR DESCRIPTION
Refactor color handling, mainly by making the fields of the different color structs private, so invariants can be upheld.