### PR TITLE
Fewer types in crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to
 * Improve name lookups in scopes and modules, PR #87.
 * A color can be Hsla or Hwba as well as Rgba. PR #88, #89.
 * Handle units in `@for` loops inside sass functions.
+* Some types moved into `value` mod, imporoved docs. PR #90.
 * Test suite sass-spec updated to 2021-02-04.
 * Some cleanups.
 

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -11,10 +11,16 @@ use std::fmt;
 pub struct CallArgs(pub Vec<(Option<String>, Value)>);
 
 impl CallArgs {
+    /// Create args from a vec of values with optional names.
     pub fn new(v: Vec<(Option<String>, Value)>) -> Self {
         CallArgs(v)
     }
 
+    /// Create args from a Value.
+    ///
+    /// The value may be a list of arguments or a single argument.
+    /// There is also special recognition of a list ending in an
+    /// unquoted "..." string, makring a varargs argument list.
     pub fn from_value(v: Value) -> Self {
         match v {
             Value::List(v, _, false) => {
@@ -46,18 +52,22 @@ impl CallArgs {
         }
     }
 
+    /// Iterate over values (and their optional names).
     pub fn iter(&self) -> ::std::slice::Iter<(Option<String>, Value)> {
         self.0.iter()
     }
 
+    /// Get number of arguments.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Return true if the argument list is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Get a specific argument by position.
     pub fn get(&self, index: usize) -> Option<&(Option<String>, Value)> {
         self.0.get(index)
     }

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -1,3 +1,4 @@
+//! Value type for css values.
 mod call_args;
 mod value;
 mod valueformat;

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -79,7 +79,7 @@ impl Value {
         }
     }
 
-    /// Get a copy of this value, but marked as calculated.
+    /// Get this value, but marked as calculated.
     pub fn into_calculated(self) -> Self {
         match self {
             Value::Numeric(num, unit, _) => Value::Numeric(num, unit, true),

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,15 @@ use std::{fmt, io};
 /// Most functions in rsass that returns a Result uses this Error type.
 #[derive(Debug)]
 pub enum Error {
+    /// An IO error encoundered on a specific path
     Input(String, io::Error),
     IoError(io::Error),
     Encoding(FromUtf8Error),
     BadValue(String),
     BadArguments(String),
+    /// A range error
     BadRange(RangeError),
+    /// Error parsing sass data.
     ParseError(ParseError),
     S(String),
     UndefinedVariable(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ pub use crate::parser::{
     parse_scss_data, parse_scss_file, parse_scss_path, parse_value_data,
     ParseError, SourcePos,
 };
-pub use crate::sass::Item;
 pub use crate::variablescope::{GlobalScope, Scope};
 
 /// Parse a scss value from a buffer and write its css representation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub mod output;
 mod parser;
 pub mod sass;
 pub mod selectors;
-mod value;
+pub mod value;
 mod variablescope;
 
 pub use crate::error::Error;
@@ -60,11 +60,7 @@ pub use crate::parser::{
     ParseError, SourcePos,
 };
 pub use crate::sass::Item;
-pub use crate::value::{
-    colors, Dimension, ListSeparator, Number, Quotes, Unit,
-};
 pub use crate::variablescope::{GlobalScope, Scope};
-pub use num_rational::Rational;
 
 /// Parse a scss value from a buffer and write its css representation
 /// in the given format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! usable for my personal projects, and the number of working tests are
 //! improving.
 #![forbid(unsafe_code)]
+// TODO: #![forbid(missing_docs)]
 use std::path::Path;
 
 pub mod css;

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -1,3 +1,4 @@
+//! Value and Item types (and some supporting) for sass.
 mod call_args;
 mod formal_args;
 mod item;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,4 +1,5 @@
-pub mod colors;
+//! Types used in sass and css values.
+mod colors;
 mod list_separator;
 mod number;
 mod operator;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -13,4 +13,5 @@ pub use self::number::{NumValue, Number};
 pub use self::operator::Operator;
 pub use self::quotes::Quotes;
 pub use self::unit::{Dimension, Unit};
+pub use num_rational::Rational;
 pub(crate) use range::{RangeError, ValueRange};

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,5 +1,5 @@
-use rsass::value::{Number, Rgba, Unit};
 use rsass::sass::Name;
+use rsass::value::{Number, Rgba, Unit};
 use rsass::*;
 use std::sync::Arc;
 
@@ -64,21 +64,21 @@ fn function_with_args() {
                 ("b".into(), sass::Value::scalar(0)),
             ],
             false,
-            Arc::new(|s| match (s.get("a")?, s.get("b")?) {
-                (
-                    css::Value::Numeric(a, au, ..),
-                    css::Value::Numeric(b, bu, ..),
-                ) => {
-                    if au == bu || bu == Unit::None {
-                        Ok(css::Value::Numeric(avg(a, b), au, true))
-                    } else if au == Unit::None {
-                        Ok(css::Value::Numeric(avg(a, b), bu, true))
-                    } else {
-                        Err(Error::BadArguments("Incopatible args".into()))
-                    }
-                }
-                (a, b) => {
-                    Err(Error::badargs(&["number", "number"], &[&a, &b]))
+            Arc::new(|s| {
+                let (a, au) = s
+                    .get("a")?
+                    .numeric_value()
+                    .map_err(|v| Error::badarg("number", &v))?;
+                let (b, bu) = s
+                    .get("b")?
+                    .numeric_value()
+                    .map_err(|v| Error::badarg("number", &v))?;
+                if au == bu || bu == Unit::None {
+                    Ok(css::Value::Numeric(avg(a, b), au, true))
+                } else if au == Unit::None {
+                    Ok(css::Value::Numeric(avg(a, b), bu, true))
+                } else {
+                    Err(Error::BadArguments("Incopatible args".into()))
                 }
             }),
         ),

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,4 +1,4 @@
-use rsass::colors::Rgba;
+use rsass::value::{Number, Rgba, Unit};
 use rsass::sass::Name;
 use rsass::*;
 use std::sync::Arc;


### PR DESCRIPTION
Expose the `value` module rather than the individual types it defines.  Also, `sass::Item` is public, so there is no need to reexport it as `Item`.

Also, add documentation to a lot of things that lacked it.