### PR TITLE
Handle user-defined modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to
 
 ## Unreleased
 
+* Support `@use` of user-defined modules.  PR #96.
 * Improve trigonometric precision by using f64 π rather than rational.
 * Handle more peculiarities with atan2, pow, infinities and negative zero.
 * Improve name lookups in scopes and modules, PR #87.

--- a/src/functions/color/mod.rs
+++ b/src/functions/color/mod.rs
@@ -6,7 +6,7 @@ mod hwb;
 mod other;
 mod rgb;
 
-pub fn create_module() -> Scope<'static> {
+pub fn create_module() -> Scope {
     let mut f = Scope::new_global(Default::default());
     hsl::register(&mut f);
     hwb::register(&mut f);

--- a/src/functions/list.rs
+++ b/src/functions/list.rs
@@ -3,8 +3,8 @@ use crate::css::Value;
 use crate::value::{ListSeparator, Quotes};
 use crate::Scope;
 
-pub fn create_module() -> Scope<'static> {
-    let mut f = Scope::new_global(Default::default());
+pub fn create_module() -> Scope {
+    let f = Scope::new_global(Default::default());
     def!(f, append(list, val, separator), |s| {
         let (mut list, sep, bra) = get_list(s.get("list")?);
         let sep = match (s.get("separator")?, sep) {

--- a/src/functions/map.rs
+++ b/src/functions/map.rs
@@ -8,8 +8,8 @@ use crate::Scope;
 ///
 /// Should conform to
 /// [the specification](https://sass-lang.com/documentation/modules/map).
-pub fn create_module() -> Scope<'static> {
-    let mut f = Scope::new_global(Default::default());
+pub fn create_module() -> Scope {
+    let f = Scope::new_global(Default::default());
     // TODO deep_merge and deep_remove
     def_va!(f, get(map, key, keys), |s| {
         let map = get_map(s.get("map")?)?;

--- a/src/functions/math.rs
+++ b/src/functions/math.rs
@@ -10,8 +10,8 @@ use std::f64::consts::{E, PI};
 ///
 /// Should conform to
 /// [the specification](https://sass-lang.com/documentation/modules/math).
-pub fn create_module() -> Scope<'static> {
-    let mut f = Scope::new_global(Default::default());
+pub fn create_module() -> Scope {
+    let f = Scope::new_global(Default::default());
 
     // - - - Boundig Functions - - -
     def!(f, ceil(number), |s| {

--- a/src/functions/meta.rs
+++ b/src/functions/meta.rs
@@ -33,7 +33,7 @@ pub fn create_module() -> Scope {
     });
     def!(f, content_exists(), |s| {
         let content = s.get_mixin(&Name::from_static("%%BODY%%"));
-        Ok(content.map(|m| !m.1.is_empty()).unwrap_or(false).into())
+        Ok(content.map(|m| !m.body.is_empty()).unwrap_or(false).into())
     });
     def!(f, feature_exists(feature), |s| match &s.get("feature")? {
         &Value::Literal(ref v, _) => {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -36,7 +36,9 @@ pub struct SassFunction {
 #[derive(Clone)]
 pub enum FuncImpl {
     Builtin(Arc<BuiltinFn>),
-    UserDefined(Vec<sass::Item>),
+    /// A user-defined function is really a closure, it has a scope
+    /// where it is defined and a body of items.
+    UserDefined(ScopeRef, Vec<sass::Item>),
 }
 
 impl PartialOrd for FuncImpl {
@@ -50,8 +52,8 @@ impl PartialOrd for FuncImpl {
                 Some(cmp::Ordering::Greater)
             }
             (
-                &FuncImpl::UserDefined(ref a),
-                &FuncImpl::UserDefined(ref b),
+                &FuncImpl::UserDefined(ref _sa, ref a),
+                &FuncImpl::UserDefined(ref _sb, ref b),
             ) => a.partial_cmp(b),
         }
     }
@@ -61,9 +63,9 @@ impl cmp::PartialEq for FuncImpl {
     fn eq(&self, rhs: &FuncImpl) -> bool {
         match (self, rhs) {
             (
-                &FuncImpl::UserDefined(ref a),
-                &FuncImpl::UserDefined(ref b),
-            ) => a == b,
+                &FuncImpl::UserDefined(ref sa, ref a),
+                &FuncImpl::UserDefined(ref sb, ref b),
+            ) => ScopeRef::is_same(sa, sb) && a == b,
             (&FuncImpl::Builtin(ref a), &FuncImpl::Builtin(ref b)) => {
                 // Each builtin function is only created once, so this
                 // should be ok.
@@ -80,7 +82,7 @@ impl fmt::Debug for FuncImpl {
     fn fmt(&self, out: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
             FuncImpl::Builtin(_) => write!(out, "(builtin function)"),
-            FuncImpl::UserDefined(_) => {
+            FuncImpl::UserDefined(..) => {
                 write!(out, "(user-defined function)")
             }
         }
@@ -101,10 +103,17 @@ impl SassFunction {
     }
 
     /// Create a new `SassFunction` from a scss implementation.
-    pub fn new(args: sass::FormalArgs, body: Vec<sass::Item>) -> Self {
+    ///
+    /// The scope is where the function is defined, used to bind any
+    /// non-parameter names in the body.
+    pub fn closure(
+        args: sass::FormalArgs,
+        scope: ScopeRef,
+        body: Vec<sass::Item>,
+    ) -> Self {
         SassFunction {
             args,
-            body: FuncImpl::UserDefined(body),
+            body: FuncImpl::UserDefined(scope, body),
         }
     }
 
@@ -112,15 +121,22 @@ impl SassFunction {
     /// arguments.
     pub fn call(
         &self,
-        scope: ScopeRef,
+        callscope: ScopeRef,
         args: &css::CallArgs,
     ) -> Result<css::Value, Error> {
-        let s = self.args.eval(scope.clone(), args)?;
         let cs = Name::from_static("%%CALLING_SCOPE%%");
-        s.define_module(cs, scope);
         match self.body {
-            FuncImpl::Builtin(ref body) => body(&s),
-            FuncImpl::UserDefined(ref body) => {
+            FuncImpl::Builtin(ref body) => {
+                let s = self.args.eval(
+                    Scope::new_global_ref(callscope.get_format()),
+                    args,
+                )?;
+                s.define_module(cs, callscope);
+                body(&s)
+            }
+            FuncImpl::UserDefined(ref defscope, ref body) => {
+                let s = self.args.eval(defscope.clone(), args)?;
+                s.define_module(cs, callscope);
                 Ok(s.eval_body(body)?.unwrap_or(css::Value::Null))
             }
         }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::sass::Name;
+use crate::variablescope::Module;
 use crate::{css, sass, Scope};
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
@@ -139,8 +140,8 @@ lazy_static! {
     };
 }
 
-pub fn get_global_module(name: &str) -> Option<&'static Scope<'static>> {
-    MODULES.get(name)
+pub fn get_global_module(name: &str) -> Option<Module> {
+    MODULES.get(name).map(Module::Builtin)
 }
 
 type FunctionMap = BTreeMap<Name, SassFunction>;

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -128,7 +128,7 @@ impl SassFunction {
         match self.body {
             FuncImpl::Builtin(ref body) => {
                 let s = self.args.eval(
-                    Scope::new_global_ref(callscope.get_format()),
+                    ScopeRef::new_global(callscope.get_format()),
                     args,
                 )?;
                 s.define_module(cs, callscope);
@@ -192,7 +192,7 @@ fn test_rgb() -> Result<(), Box<dyn std::error::Error>> {
     use crate::parser::code_span;
     use crate::parser::formalargs::call_args;
     use crate::value::Rgba;
-    let scope = Scope::new_global_ref(Default::default());
+    let scope = ScopeRef::new_global(Default::default());
     assert_eq!(
         FUNCTIONS.get(&name!(rgb)).unwrap().call(
             scope.clone(),

--- a/src/functions/selector.rs
+++ b/src/functions/selector.rs
@@ -6,8 +6,8 @@ use crate::selectors::{Selector, Selectors};
 use crate::value::Quotes;
 use crate::{ParseError, Scope};
 
-pub fn create_module() -> Scope<'static> {
-    let mut f = Scope::new_global(Default::default());
+pub fn create_module() -> Scope {
+    let f = Scope::new_global(Default::default());
     // TODO: is_superselector
     def_va!(f, append(selectors), |s| match s.get("selectors")? {
         Value::List(v, _, _) => Ok(Value::Literal(

--- a/src/functions/string.rs
+++ b/src/functions/string.rs
@@ -6,8 +6,8 @@ use lazy_static::lazy_static;
 use std::cmp::max;
 use std::sync::Mutex;
 
-pub fn create_module() -> Scope<'static> {
-    let mut f = Scope::new_global(Default::default());
+pub fn create_module() -> Scope {
+    let f = Scope::new_global(Default::default());
     def!(f, quote(string), |s| {
         let v = match s.get("string")? {
             Value::Literal(v, Quotes::None) => v.replace('\\', "\\\\"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use crate::variablescope::{Scope, ScopeRef};
 /// # }
 /// ```
 pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
-    let scope = Scope::new_global_ref(format);
+    let scope = ScopeRef::new_global(format);
     let value = parse_value_data(input)?.evaluate(scope)?;
     Ok(value.format(format).to_string().into_bytes())
 }
@@ -115,7 +115,7 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
     let items = parse_scss_data(input)?;
-    format.write_root(&items, Scope::new_global_ref(format), &file_context)
+    format.write_root(&items, ScopeRef::new_global(format), &file_context)
 }
 
 /// Parse a file of scss data and write css in the given style.
@@ -145,5 +145,5 @@ pub fn compile_scss_path(
     let file_context = FsFileContext::new();
     let (sub_context, path) = file_context.file(path);
     let items = parse_scss_path(&path)?;
-    format.write_root(&items, Scope::new_global_ref(format), &sub_context)
+    format.write_root(&items, ScopeRef::new_global(format), &sub_context)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod sass;
 pub mod selectors;
 #[forbid(missing_docs)]
 pub mod value;
-// TODO #[forbid(missing_docs)]
+#[forbid(missing_docs)]
 mod variablescope;
 
 pub use crate::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod sass;
 pub mod selectors;
 #[forbid(missing_docs)]
 pub mod value;
-#[forbid(missing_docs)]
+// TODO #[forbid(missing_docs)]
 mod variablescope;
 
 pub use crate::error::Error;
@@ -70,7 +70,7 @@ pub use crate::parser::{
     parse_scss_data, parse_scss_file, parse_scss_path, parse_value_data,
     ParseError, SourcePos,
 };
-pub use crate::variablescope::Scope;
+pub use crate::variablescope::{Scope, ScopeRef};
 
 /// Parse a scss value from a buffer and write its css representation
 /// in the given format.
@@ -86,8 +86,8 @@ pub use crate::variablescope::Scope;
 /// # }
 /// ```
 pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
-    let scope = Scope::new_global(format);
-    let value = parse_value_data(input)?.evaluate(&scope)?;
+    let scope = Scope::new_global_ref(format);
+    let value = parse_value_data(input)?.evaluate(scope)?;
     Ok(value.format(format).to_string().into_bytes())
 }
 
@@ -115,7 +115,7 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
     let items = parse_scss_data(input)?;
-    format.write_root(&items, &mut Scope::new_global(format), &file_context)
+    format.write_root(&items, Scope::new_global_ref(format), &file_context)
 }
 
 /// Parse a file of scss data and write css in the given style.
@@ -145,5 +145,5 @@ pub fn compile_scss_path(
     let file_context = FsFileContext::new();
     let (sub_context, path) = file_context.file(path);
     let items = parse_scss_path(&path)?;
-    format.write_root(&items, &mut Scope::new_global(format), &sub_context)
+    format.write_root(&items, Scope::new_global_ref(format), &sub_context)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use rsass::{
     output::{Format, Style},
-    parse_scss_path, Error, FsFileContext, Scope,
+    parse_scss_path, Error, FsFileContext, ScopeRef,
 };
 use std::io::{stdout, Write};
 use std::path::PathBuf;
@@ -63,7 +63,7 @@ impl Args {
             let items = parse_scss_path(&path)?;
             let result = format.write_root(
                 &items,
-                Scope::new_global_ref(format),
+                ScopeRef::new_global(format),
                 &sub_context,
             )?;
             let out = stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ impl Args {
             let items = parse_scss_path(&path)?;
             let result = format.write_root(
                 &items,
-                &mut Scope::new_global(format),
+                Scope::new_global_ref(format),
                 &sub_context,
             )?;
             let out = stdout();

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -3,7 +3,7 @@ use super::transform::handle_body;
 use super::Style;
 use crate::file_context::FileContext;
 use crate::sass::Item;
-use crate::{Error, Scope};
+use crate::{Error, ScopeRef};
 
 /// Specifies the format for outputing css.
 ///
@@ -39,7 +39,7 @@ impl Format {
     pub fn write_root(
         &self,
         items: &[Item],
-        globals: &mut Scope,
+        globals: ScopeRef,
         file_context: &impl FileContext,
     ) -> Result<Vec<u8>, Error> {
         let mut head = CssBuf::new(*self);

--- a/src/output/transform.rs
+++ b/src/output/transform.rs
@@ -6,7 +6,7 @@ use crate::parser::parse_imported_scss_file;
 use crate::sass::{FormalArgs, Item, Mixin, Name};
 use crate::selectors::Selectors;
 use crate::value::ValueRange;
-use crate::{Scope, ScopeRef};
+use crate::{SassFunction, Scope, ScopeRef};
 use std::io::Write;
 
 pub fn handle_body(
@@ -195,9 +195,15 @@ fn handle_item(
             let val = val.do_evaluate(scope.clone(), true)?;
             scope.set_variable(name.into(), val, *default, *global);
         }
-
-        Item::FunctionDeclaration(ref name, ref func) => {
-            scope.define_function(name.into(), func.clone());
+        Item::FunctionDeclaration(ref name, ref args, ref body) => {
+            scope.define_function(
+                name.into(),
+                SassFunction::closure(
+                    args.clone(),
+                    scope.clone(),
+                    body.clone(),
+                ),
+            );
         }
         Item::Return(_) => {
             return Err(Error::S(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -30,7 +30,6 @@ use self::util::{
 use self::value::{
     dictionary, function_call, single_value, value_expression,
 };
-use crate::functions::SassFunction;
 #[cfg(test)]
 use crate::sass::{CallArgs, FormalArgs};
 use crate::sass::{Item, Mixin, Name, UseAs, Value};
@@ -523,10 +522,7 @@ fn function_declaration2(input: Span) -> IResult<Span, Item> {
     let (input, name) = terminated(name, opt_spacelike)(input)?;
     let (input, args) = terminated(formal_args, opt_spacelike)(input)?;
     let (input, body) = body_block(input)?;
-    Ok((
-        input,
-        Item::FunctionDeclaration(name, SassFunction::new(args, body)),
-    ))
+    Ok((input, Item::FunctionDeclaration(name, args, body)))
 }
 
 fn return_stmt2(input: Span) -> IResult<Span, Item> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -256,7 +256,10 @@ fn mixin_call(input: Span) -> IResult<Span, Item> {
 
 /// What follows the `@include` tag.
 fn mixin_call2(input: Span) -> IResult<Span, Item> {
-    let (input, name) = terminated(name, opt_spacelike)(input)?;
+    let (input, n1) = terminated(name, opt_spacelike)(input)?;
+    let (input, n2) = opt(preceded(tag("."), name))(input)?;
+    let name = n2.map(|n2| format!("{}.{}", n1, n2)).unwrap_or(n1);
+    let (input, _) = opt_spacelike(input)?;
     let (input, args) = terminated(opt(call_args), opt_spacelike)(input)?;
     let (input, body) = terminated(
         opt(body_block),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -32,7 +32,7 @@ use self::value::{
 };
 #[cfg(test)]
 use crate::sass::{CallArgs, FormalArgs};
-use crate::sass::{Item, Mixin, Name, UseAs, Value};
+use crate::sass::{Item, Name, UseAs, Value};
 use crate::selectors::Selectors;
 use crate::value::ListSeparator;
 #[cfg(test)]
@@ -514,7 +514,7 @@ fn mixin_declaration2(input: Span) -> IResult<Span, Item> {
     let (input, body) = body_block(input)?;
     Ok((
         input,
-        Item::MixinDeclaration(name, Mixin(args.unwrap_or_default(), body)),
+        Item::MixinDeclaration(name, args.unwrap_or_default(), body),
     ))
 }
 
@@ -711,7 +711,11 @@ fn test_mixin_call_named_args() {
 fn test_mixin_declaration_empty() {
     assert_eq!(
         check_parse!(mixin_declaration, b"@mixin foo() {}\n"),
-        Item::MixinDeclaration("foo".into(), Default::default()),
+        Item::MixinDeclaration(
+            "foo".into(),
+            Default::default(),
+            Default::default()
+        ),
     )
 }
 
@@ -724,17 +728,15 @@ fn test_mixin_declaration() {
         ),
         Item::MixinDeclaration(
             "foo".into(),
-            Mixin(
-                FormalArgs::new(vec![("x".into(), Value::Null)], false),
-                vec![Item::Property(
-                    "foo-bar".into(),
-                    Value::List(
-                        vec![string("baz"), Value::Variable("x".into())],
-                        ListSeparator::Space,
-                        false,
-                    ),
-                )],
-            ),
+            FormalArgs::new(vec![("x".into(), Value::Null)], false),
+            vec![Item::Property(
+                "foo-bar".into(),
+                Value::List(
+                    vec![string("baz"), Value::Variable("x".into())],
+                    ListSeparator::Space,
+                    false,
+                ),
+            )],
         ),
     )
 }
@@ -753,25 +755,20 @@ fn test_mixin_declaration_default_and_subrules() {
         ),
         Item::MixinDeclaration(
             "bar".into(),
-            Mixin(
-                FormalArgs::new(
-                    vec![
-                        ("a".into(), Value::Null),
-                        ("b".into(), string("flug"))
-                    ],
-                    false,
-                ),
-                vec![
-                    Item::Property("foo-bar".into(), string("baz")),
-                    Item::Rule(
-                        selectors(code_span(b"foo, bar")).unwrap().1,
-                        vec![Item::Property(
-                            "property".into(),
-                            Value::Variable("b".into()),
-                        )],
-                    ),
-                ],
+            FormalArgs::new(
+                vec![("a".into(), Value::Null), ("b".into(), string("flug"))],
+                false,
             ),
+            vec![
+                Item::Property("foo-bar".into(), string("baz")),
+                Item::Rule(
+                    selectors(code_span(b"foo, bar")).unwrap().1,
+                    vec![Item::Property(
+                        "property".into(),
+                        Value::Variable("b".into()),
+                    )],
+                ),
+            ],
         ),
     )
 }

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -504,7 +504,7 @@ mod test {
     use super::*;
     use crate::sass::CallArgs;
     use crate::sass::Value::*;
-    use crate::Scope;
+    use crate::ScopeRef;
     use num_rational::Rational;
 
     #[test]
@@ -763,7 +763,7 @@ mod test {
     fn parse_extended_literal() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"http://#{\")\"}.com/")?
-                .evaluate(Scope::new_global_ref(Default::default()))?
+                .evaluate(ScopeRef::new_global(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "http://).com/".to_string(),
@@ -774,7 +774,7 @@ mod test {
     fn parse_extended_literal_in_arg() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"url(http://#{\")\"}.com/)")?
-                .evaluate(Scope::new_global_ref(Default::default()))?
+                .evaluate(ScopeRef::new_global(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "url(http://).com/)".to_string(),
@@ -785,7 +785,7 @@ mod test {
     fn parse_extended_literal_in_arg_2() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"url(//#{\")\"}.com/)")?
-                .evaluate(Scope::new_global_ref(Default::default()))?
+                .evaluate(ScopeRef::new_global(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "url(//).com/)".to_string(),

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -763,7 +763,7 @@ mod test {
     fn parse_extended_literal() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"http://#{\")\"}.com/")?
-                .evaluate(&Scope::new_global(Default::default()))?
+                .evaluate(Scope::new_global_ref(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "http://).com/".to_string(),
@@ -774,7 +774,7 @@ mod test {
     fn parse_extended_literal_in_arg() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"url(http://#{\")\"}.com/)")?
-                .evaluate(&Scope::new_global(Default::default()))?
+                .evaluate(Scope::new_global_ref(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "url(http://).com/)".to_string(),
@@ -785,7 +785,7 @@ mod test {
     fn parse_extended_literal_in_arg_2() -> Result<(), crate::Error> {
         assert_eq!(
             parse_value_data(b"url(//#{\")\"}.com/)")?
-                .evaluate(&Scope::new_global(Default::default()))?
+                .evaluate(Scope::new_global_ref(Default::default()))?
                 .format(Default::default())
                 .to_string(),
             "url(//).com/)".to_string(),

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -2,7 +2,7 @@ use crate::css;
 use crate::error::Error;
 use crate::sass::{Name, Value};
 use crate::value::ListSeparator;
-use crate::{Scope, ScopeRef};
+use crate::ScopeRef;
 use std::default::Default;
 
 /// The declared arguments of a mixin or function declaration.
@@ -33,7 +33,7 @@ impl FormalArgs {
         scope: ScopeRef,
         args: &css::CallArgs,
     ) -> Result<ScopeRef, Error> {
-        let argscope = ScopeRef::dynamic(Scope::sub(scope));
+        let argscope = ScopeRef::sub(scope);
         let n = self.0.len();
         for (i, &(ref name, ref default)) in self.0.iter().enumerate() {
             if let Some(value) = args

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -2,7 +2,7 @@ use crate::css;
 use crate::error::Error;
 use crate::sass::{Name, Value};
 use crate::value::ListSeparator;
-use crate::Scope;
+use crate::{Scope, ScopeRef};
 use std::default::Default;
 
 /// The declared arguments of a mixin or function declaration.
@@ -28,12 +28,12 @@ impl FormalArgs {
     /// Evaluate a set of call arguments for these formal arguments.
     ///
     /// Returns a Scope that is a sub-scope to the given `scope`.
-    pub fn eval<'a>(
+    pub fn eval(
         &self,
-        scope: &'a Scope<'a>,
+        scope: ScopeRef,
         args: &css::CallArgs,
-    ) -> Result<Scope<'a>, Error> {
-        let mut argscope = Scope::sub(scope);
+    ) -> Result<ScopeRef, Error> {
+        let argscope = ScopeRef::dynamic(Scope::sub(scope));
         let n = self.0.len();
         for (i, &(ref name, ref default)) in self.0.iter().enumerate() {
             if let Some(value) = args
@@ -56,7 +56,8 @@ impl FormalArgs {
                 match args.get(i) {
                     Some(&(None, ref v)) => argscope.define(name.clone(), v),
                     _ => {
-                        let v = default.do_evaluate(&argscope, true)?;
+                        let v =
+                            default.do_evaluate(argscope.clone(), true)?;
                         argscope.define(name.clone(), &v)
                     }
                 };

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -1,5 +1,4 @@
 use super::{CallArgs, FormalArgs, Name, SassString, Value};
-use crate::functions::SassFunction;
 use crate::parser::SourcePos;
 use crate::selectors::Selectors;
 
@@ -47,7 +46,7 @@ pub enum Item {
     Content,
 
     /// An `@function` declaration.
-    FunctionDeclaration(String, SassFunction),
+    FunctionDeclaration(String, FormalArgs, Vec<Item>),
     /// An `@return` statement in a function declaration.
     Return(Value),
 

--- a/src/sass/item.rs
+++ b/src/sass/item.rs
@@ -39,7 +39,7 @@ pub enum Item {
     Error(Value),
 
     /// A `@mixin` directive, declaring a mixin.
-    MixinDeclaration(String, Mixin),
+    MixinDeclaration(String, FormalArgs, Vec<Item>),
     /// An `@include` directive, calling a mixin.
     MixinCall(String, CallArgs, Vec<Item>),
     /// An `@content` directive (in a mixin declaration).
@@ -96,7 +96,3 @@ pub enum UseAs {
     /// An explicit name, `@use foo as bar`.
     Name(SassString),
 }
-
-/// A mixin is a callable body of items.
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd)]
-pub struct Mixin(pub FormalArgs, pub Vec<Item>);

--- a/src/sass/mixin.rs
+++ b/src/sass/mixin.rs
@@ -1,0 +1,13 @@
+use crate::sass::{FormalArgs, Item};
+use crate::ScopeRef;
+
+/// A mixin is a callable body of items.
+#[derive(Clone)]
+pub struct Mixin {
+    /// The arguments to this mixin.
+    pub args: FormalArgs,
+    /// The scope where this mixin is defined.
+    pub scope: ScopeRef,
+    /// The body of this mixin.
+    pub body: Vec<Item>,
+}

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -2,13 +2,15 @@
 mod call_args;
 mod formal_args;
 mod item;
+mod mixin;
 mod name;
 mod string;
 mod value;
 
 pub use self::call_args::CallArgs;
 pub use self::formal_args::FormalArgs;
-pub use self::item::{Item, Mixin, UseAs};
+pub use self::item::{Item, UseAs};
+pub use self::mixin::Mixin;
 pub use self::name::Name;
 pub use self::string::{SassString, StringPart};
 pub use self::value::Value;

--- a/src/sass/string.rs
+++ b/src/sass/string.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::sass::Value;
 use crate::value::Quotes;
-use crate::Scope;
+use crate::ScopeRef;
 use std::fmt;
 
 /// A string that may contain interpolations.
@@ -58,7 +58,10 @@ impl SassString {
     /// Evaluate this SassString to a literal String.
     ///
     /// All interpolated values are interpolated in the given `scope`.
-    pub fn evaluate(&self, scope: &Scope) -> Result<(String, Quotes), Error> {
+    pub fn evaluate(
+        &self,
+        scope: ScopeRef,
+    ) -> Result<(String, Quotes), Error> {
         let mut result = String::new();
         let mut interpolated = false;
         for part in &self.parts {
@@ -66,7 +69,7 @@ impl SassString {
                 StringPart::Interpolation(ref v) => {
                     interpolated = true;
                     let v = v
-                        .evaluate(scope)?
+                        .evaluate(scope.clone())?
                         .unquote()
                         .format(scope.get_format())
                         .to_string();
@@ -123,7 +126,7 @@ impl SassString {
 
     /// Evaluate this SassString and wrap the result in a SassString
     /// of a single raw value.
-    pub fn evaluate2(&self, scope: &Scope) -> Result<SassString, Error> {
+    pub fn evaluate2(&self, scope: ScopeRef) -> Result<SassString, Error> {
         let (result, quotes) = self.evaluate(scope)?;
         Ok(SassString {
             parts: vec![StringPart::Raw(result)],
@@ -137,7 +140,7 @@ impl SassString {
     /// If the value is name-like, unquote the resulting string.
     pub fn evaluate_opt_unquote(
         &self,
-        scope: &Scope,
+        scope: ScopeRef,
     ) -> Result<SassString, Error> {
         let (result, quotes) = self.evaluate(scope)?;
         let mut chars = result.chars();

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -1,8 +1,7 @@
 use crate::css;
 use crate::error::Error;
-use crate::functions::get_builtin_function;
 use crate::ordermap::OrderMap;
-use crate::sass::{CallArgs, Name, SassString};
+use crate::sass::{CallArgs, SassString};
 use crate::value::{ListSeparator, Number, Numeric, Operator, Quotes, Rgba};
 use crate::ScopeRef;
 use num_traits::Zero;
@@ -127,15 +126,9 @@ impl Value {
             Value::Call(ref name, ref args) => {
                 let args = args.evaluate(scope.clone(), true)?;
                 if let Some(name) = name.single_raw() {
-                    let nname: Name = name.into();
-                    match scope.call_function(&nname, &args) {
-                        Some(value) => Ok(value?),
-                        None => get_builtin_function(&nname)
-                            .map(|f| f.call(scope, &args))
-                            .unwrap_or_else(|| {
-                                Ok(css::Value::Call(name.to_string(), args))
-                            }),
-                    }
+                    scope.call_function(&name.into(), &args).unwrap_or_else(
+                        || Ok(css::Value::Call(name.to_string(), args)),
+                    )
                 } else {
                     let (name, _) = name.evaluate(scope)?;
                     Ok(css::Value::Call(name, args))

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -126,9 +126,11 @@ impl Value {
             Value::Call(ref name, ref args) => {
                 let args = args.evaluate(scope.clone(), true)?;
                 if let Some(name) = name.single_raw() {
-                    scope.call_function(&name.into(), &args).unwrap_or_else(
-                        || Ok(css::Value::Call(name.to_string(), args)),
-                    )
+                    if let Some(f) = scope.get_function(&name.into()) {
+                        f.call(scope.clone(), &args)
+                    } else {
+                        Ok(css::Value::Call(name.to_string(), args))
+                    }
                 } else {
                     let (name, _) = name.evaluate(scope)?;
                     Ok(css::Value::Call(name, args))

--- a/src/spectest/main.rs
+++ b/src/spectest/main.rs
@@ -102,7 +102,7 @@ fn handle_suite(
          \n    let mut file_context = FsFileContext::new();\
          \n    file_context.push_path(\"tests/spec\".as_ref());\
          \n    let items = parse_scss_data(input)?;\
-         \n    format.write_root(&items, &mut Scope::new_global(format), &file_context)\
+         \n    format.write_root(&items, Scope::new_global_ref(format), &file_context)\
          \n}}"
     )?;
     Ok(())

--- a/src/spectest/main.rs
+++ b/src/spectest/main.rs
@@ -71,7 +71,7 @@ fn handle_suite(
     writeln!(
         rs,
         "use rsass::output::Format;\
-         \nuse rsass::{{parse_scss_data, Error, FsFileContext, Scope}};",
+         \nuse rsass::{{parse_scss_data, Error, FsFileContext, ScopeRef}};",
     )?;
 
     handle_entries(&mut rs, &base, &suitedir, &rssuitedir, None, ignored)
@@ -102,7 +102,7 @@ fn handle_suite(
          \n    let mut file_context = FsFileContext::new();\
          \n    file_context.push_path(\"tests/spec\".as_ref());\
          \n    let items = parse_scss_data(input)?;\
-         \n    format.write_root(&items, Scope::new_global_ref(format), &file_context)\
+         \n    format.write_root(&items, ScopeRef::new_global(format), &file_context)\
          \n}}"
     )?;
     Ok(())

--- a/src/spectest/testfixture.rs
+++ b/src/spectest/testfixture.rs
@@ -162,7 +162,7 @@ pub fn compile_scss(
     let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
-    format.write_root(&items, &mut Scope::new_global(format), &file_context)
+    format.write_root(&items, Scope::new_global_ref(format), &file_context)
 }
 
 fn normalize_output_css(css: &str) -> String {

--- a/src/spectest/testfixture.rs
+++ b/src/spectest/testfixture.rs
@@ -4,7 +4,7 @@ use super::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 use rsass::output::Format;
-use rsass::{parse_scss_data, FsFileContext, Scope};
+use rsass::{parse_scss_data, FsFileContext, ScopeRef};
 use std::io::Write;
 
 pub struct TestFixture {
@@ -162,7 +162,7 @@ pub fn compile_scss(
     let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
-    format.write_root(&items, Scope::new_global_ref(format), &file_context)
+    format.write_root(&items, ScopeRef::new_global(format), &file_context)
 }
 
 fn normalize_output_css(css: &str) -> String {

--- a/src/value/colors/rgba.rs
+++ b/src/value/colors/rgba.rs
@@ -346,6 +346,7 @@ lazy_static! {
         ("plum", 0xdda0dd),
         ("powderblue", 0xb0e0e6),
         ("purple", 0x800080),
+        ("rebeccapurple", 0x663399),
         ("red", 0xff0000),
         ("rosybrown", 0xbc8f8f),
         ("royalblue", 0x4169e1),

--- a/src/value/numeric.rs
+++ b/src/value/numeric.rs
@@ -48,8 +48,8 @@ impl Numeric {
 
     /// Convert this numeric value to a given unit, if possible.
     ///
-    /// Like [as_unit], except a unitless numeric is considered to be
-    /// the expected unit.
+    /// Like [as_unit](Self::as_unit), except a unitless numeric is
+    /// considered to be the expected unit.
     pub fn as_unit_def(&self, unit: Unit) -> Option<Number> {
         if self.is_no_unit() {
             Some(self.value.clone())

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -1,6 +1,6 @@
 //! A scope is something that contains variable values.
 
-use crate::css::{self, Value};
+use crate::css::Value;
 use crate::functions::{get_builtin_function, SassFunction};
 use crate::output::Format;
 use crate::sass::{Item, Mixin, Name};
@@ -54,14 +54,6 @@ impl ScopeRef {
             }
             _ => false,
         }
-    }
-    /// Call a function.
-    pub fn call_function(
-        &self,
-        name: &Name,
-        args: &css::CallArgs,
-    ) -> Option<Result<Value, Error>> {
-        self.get_function(name).map(|f| f.call(self.clone(), args))
     }
 
     /// Evaluate a body of items in this scope.

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -11,14 +11,19 @@ use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
+/// A static or dynamic scope referece.
+///
+/// This dereferences to a [Scope].
 #[derive(Clone)]
 pub enum ScopeRef {
+    /// The builtin scopes in rsass is static.
     Builtin(&'static Scope),
+    /// All other scopes are dynamic.  This uses [Arc] reference counting.
     Dynamic(Arc<Scope>),
 }
 
 impl ScopeRef {
-    /// Create a new global scope
+    /// Create a new global scope.
     ///
     /// A "global" scope is just a scope that have no parent.
     /// There will be multiple global scopes existing during the
@@ -38,6 +43,7 @@ impl ScopeRef {
         ScopeRef::Dynamic(Arc::new(scope))
     }
 
+    /// Check if `a` and `b` references the same scope.
     pub fn is_same(a: &Self, b: &Self) -> bool {
         match (a, b) {
             (ScopeRef::Builtin(a), ScopeRef::Builtin(b)) => {
@@ -170,7 +176,7 @@ impl Deref for ScopeRef {
 /// Variables, functions and mixins are defined in a `Scope`.
 ///
 /// A scope can be a local scope, e.g. in a function, or the global scope.
-/// All scopes except the global scope has a parent.
+/// All non-global scopes have a parent.
 /// The global scope is global to a sass document, multiple different
 /// global scopes may exists in the same rust-language process.
 pub struct Scope {
@@ -184,7 +190,7 @@ pub struct Scope {
 }
 
 impl<'a> Scope {
-    /// Create a new global scope
+    /// Create a new global scope.
     ///
     /// A "global" scope is just a scope that have no parent.
     /// There will be multiple global scopes existing during the

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -369,12 +369,14 @@ impl<'a> Scope {
     ///
     /// Returns the formal args and the body of the mixin.
     pub fn get_mixin(&self, name: &Name) -> Option<Mixin> {
-        self.mixins
-            .lock()
-            .unwrap()
-            .get(name)
-            .cloned()
-            .or_else(|| self.parent.as_ref().and_then(|p| p.get_mixin(name)))
+        if let Some((modulename, name)) = name.split_module() {
+            self.get_module(&modulename)
+                .and_then(|m| m.get_mixin(&name))
+        } else {
+            self.mixins.lock().unwrap().get(name).cloned().or_else(|| {
+                self.parent.as_ref().and_then(|p| p.get_mixin(name))
+            })
+        }
     }
     /// Define a mixin.
     pub fn define_mixin(&self, name: Name, mixin: Mixin) {

--- a/tests/_test-hue.scss
+++ b/tests/_test-hue.scss
@@ -1,0 +1,12 @@
+@use 'sass:color';
+
+@mixin test-hue($hue) {
+  @for $whiteness from 0 through 5 {
+    whiteness-#{$whiteness * 20} {
+      @for $blackness from 0 through 5 {
+        blackness-#{$blackness * 20}:
+            color.hwb($hue, $whiteness * 20%, $blackness * 20%);
+      }
+    }
+  }
+}

--- a/tests/basic/defs.scss
+++ b/tests/basic/defs.scss
@@ -4,12 +4,12 @@ $color: purple;
     @if $v > 0 {
         @return $color;
     } @else {
-        @return black;
+        @return pink;
     }
 }
 
 @mixin myem {
     em {
-        color: pink;
+        color: foo(0);
     }
 }

--- a/tests/basic/defs.scss
+++ b/tests/basic/defs.scss
@@ -2,7 +2,7 @@ $color: purple;
 
 @function foo($v) {
     @if $v > 0 {
-        @return purple;
+        @return $color;
     } @else {
         @return black;
     }

--- a/tests/basic/defs.scss
+++ b/tests/basic/defs.scss
@@ -1,0 +1,15 @@
+$color: purple;
+
+@function foo($v) {
+    @if $v > 0 {
+        @return purple;
+    } @else {
+        @return black;
+    }
+}
+
+@mixin myem {
+    em {
+        color: pink;
+    }
+}

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -22,7 +22,7 @@ fn use_module_star() {
         "div {\
          \n  color: purple;\
          \n  col1: purple;\
-         \n  col2: black;\
+         \n  col2: pink;\
          \n}\
          \ndiv em {\
          \n  color: pink;\
@@ -41,7 +41,7 @@ fn use_module() {
         "div {\
          \n  color: purple;\
          \n  col1: purple;\
-         \n  col2: black;\
+         \n  col2: pink;\
          \n}\n",
     );
 }

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -37,11 +37,15 @@ fn use_module() {
           \n  color: defs.$color;\
           \n  col1: defs.foo(1);\
           \n  col2: defs.foo(0);\
+          \n  @include defs.myem;
           \n}\n",
         "div {\
          \n  color: purple;\
          \n  col1: purple;\
          \n  col2: pink;\
+         \n}\
+         \ndiv em {\
+         \n  color: pink;\
          \n}\n",
     );
 }

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -10,6 +10,43 @@ fn txx_empty_rule() {
 }
 
 #[test]
+fn use_module_star() {
+    check(
+        b"@use 'tests/basic/defs' as *;\
+          \ndiv {\
+          \n  color: $color;\
+          \n  col1: foo(1);\
+          \n  col2: foo(0);\
+          \n  @include myem;
+          \n}\n",
+        "div {\
+         \n  color: purple;\
+         \n  col1: purple;\
+         \n  col2: black;\
+         \n}\
+         \ndiv em {\
+         \n  color: pink;\
+         \n}\n",
+    );
+}
+#[test]
+fn use_module() {
+    check(
+        b"@use 'tests/basic/defs';\
+          \ndiv {\
+          \n  color: defs.$color;\
+          \n  col1: defs.foo(1);\
+          \n  col2: defs.foo(0);\
+          \n}\n",
+        "div {\
+         \n  color: purple;\
+         \n  col1: purple;\
+         \n  col2: black;\
+         \n}\n",
+    );
+}
+
+#[test]
 fn t14_imports() {
     let path = "tests/basic/14_imports/input.scss";
     assert_eq!(

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -10,14 +10,12 @@ fn simple_value() {
         style: output::Style::Compressed,
         precision: 5,
     };
-    let scope = Scope::new_global(format);
+    let scope = ScopeRef::new_global(format);
     scope.define(Name::from_static("color"), &Rgba::from_rgb(0, 0, 0).into());
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format
-                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
-                .unwrap()
+            format.write_root(&parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{color:#000}\n"
@@ -30,7 +28,7 @@ fn simple_function() {
         style: output::Style::Compressed,
         precision: 5,
     };
-    let scope = Scope::new_global(format);
+    let scope = ScopeRef::new_global(format);
     scope.define_function(
         Name::from_static("get_answer"),
         SassFunction::builtin(
@@ -43,9 +41,7 @@ fn simple_function() {
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format
-                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
-                .unwrap()
+            format.write_root(&parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{x:42}\n"
@@ -59,7 +55,7 @@ fn avg(a: Number, b: Number) -> Number {
 
 #[test]
 fn function_with_args() {
-    let scope = Scope::new_global(Default::default());
+    let scope = ScopeRef::new_global(Default::default());
     scope.define_function(
         Name::from_static("halfway"),
         SassFunction::builtin(
@@ -95,9 +91,7 @@ fn function_with_args() {
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format
-                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
-                .unwrap()
+            format.write_root(&parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{x:14}\n"

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -10,13 +10,13 @@ fn simple_value() {
         style: output::Style::Compressed,
         precision: 5,
     };
-    let mut scope = Scope::new_global(format);
+    let scope = Scope::new_global(format);
     scope.define(Name::from_static("color"), &Rgba::from_rgb(0, 0, 0).into());
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
             format
-                .write_root(&parsed, &mut scope, &file_context)
+                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
                 .unwrap()
         )
         .unwrap(),
@@ -30,7 +30,7 @@ fn simple_function() {
         style: output::Style::Compressed,
         precision: 5,
     };
-    let mut scope = Scope::new_global(format);
+    let scope = Scope::new_global(format);
     scope.define_function(
         Name::from_static("get_answer"),
         SassFunction::builtin(
@@ -44,7 +44,7 @@ fn simple_function() {
     assert_eq!(
         String::from_utf8(
             format
-                .write_root(&parsed, &mut scope, &file_context)
+                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
                 .unwrap()
         )
         .unwrap(),
@@ -59,7 +59,7 @@ fn avg(a: Number, b: Number) -> Number {
 
 #[test]
 fn function_with_args() {
-    let mut scope = Scope::new_global(Default::default());
+    let scope = Scope::new_global(Default::default());
     scope.define_function(
         Name::from_static("halfway"),
         SassFunction::builtin(
@@ -96,7 +96,7 @@ fn function_with_args() {
     assert_eq!(
         String::from_utf8(
             format
-                .write_root(&parsed, &mut scope, &file_context)
+                .write_root(&parsed, ScopeRef::dynamic(scope), &file_context)
                 .unwrap()
         )
         .unwrap(),

--- a/tests/spec/core_functions/color/hwb/three_args/w3c/mod.rs
+++ b/tests/spec/core_functions/color/hwb/three_args/w3c/mod.rs
@@ -4,7 +4,6 @@ use super::rsass;
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/blue_magentas.hrx"
 #[test]
-#[ignore] // unexepected error
 fn blue_magentas() {
     assert_eq!(
         rsass(
@@ -67,7 +66,6 @@ fn blue_magentas() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/blues.hrx"
 #[test]
-#[ignore] // unexepected error
 fn blues() {
     assert_eq!(
         rsass(
@@ -130,7 +128,6 @@ fn blues() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/cyan_blues.hrx"
 #[test]
-#[ignore] // unexepected error
 fn cyan_blues() {
     assert_eq!(
         rsass(
@@ -193,7 +190,6 @@ fn cyan_blues() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/cyans.hrx"
 #[test]
-#[ignore] // unexepected error
 fn cyans() {
     assert_eq!(
         rsass(
@@ -256,7 +252,6 @@ fn cyans() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/green_cyans.hrx"
 #[test]
-#[ignore] // unexepected error
 fn green_cyans() {
     assert_eq!(
         rsass(
@@ -319,7 +314,6 @@ fn green_cyans() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/greens.hrx"
 #[test]
-#[ignore] // unexepected error
 fn greens() {
     assert_eq!(
         rsass(
@@ -382,7 +376,6 @@ fn greens() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/magenta_reds.hrx"
 #[test]
-#[ignore] // unexepected error
 fn magenta_reds() {
     assert_eq!(
         rsass(
@@ -445,7 +438,6 @@ fn magenta_reds() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/magentas.hrx"
 #[test]
-#[ignore] // unexepected error
 fn magentas() {
     assert_eq!(
         rsass(
@@ -508,7 +500,6 @@ fn magentas() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/oranges.hrx"
 #[test]
-#[ignore] // unexepected error
 fn oranges() {
     assert_eq!(
         rsass(
@@ -571,7 +562,6 @@ fn oranges() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/reds.hrx"
 #[test]
-#[ignore] // unexepected error
 fn reds() {
     assert_eq!(
         rsass(
@@ -634,7 +624,6 @@ fn reds() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/yellow_greens.hrx"
 #[test]
-#[ignore] // unexepected error
 fn yellow_greens() {
     assert_eq!(
         rsass(
@@ -697,7 +686,6 @@ fn yellow_greens() {
 
 // From "sass-spec/spec/core_functions/color/hwb/three_args/w3c/yellows.hrx"
 #[test]
-#[ignore] // unexepected error
 fn yellows() {
     assert_eq!(
         rsass(

--- a/tests/spec/libsass_closed_issues/mod.rs
+++ b/tests/spec/libsass_closed_issues/mod.rs
@@ -11399,7 +11399,6 @@ fn issue_694() {
 
 // From "sass-spec/spec/libsass-closed-issues/issue_699.hrx"
 #[test]
-#[ignore] // wrong result
 fn issue_699() {
     assert_eq!(
         rsass(

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -4,7 +4,7 @@
 //! The following tests are excluded from conversion:
 //! ["core_functions/selector/extend", "core_functions/selector/is_superselector", "core_functions/selector/unify", "directives/extend", "directives/forward", "directives/use", "libsass-closed-issues/issue_185/mixin.hrx", "libsass-todo-issues/issue_221262.hrx", "libsass-todo-issues/issue_221292.hrx", "libsass/unicode-bom/utf-16-big", "libsass/unicode-bom/utf-16-little", "non_conformant/scss/huge.hrx", "non_conformant/scss/mixin-content.hrx", "non_conformant/scss/multiline_var.hrx"]
 use rsass::output::Format;
-use rsass::{parse_scss_data, Error, FsFileContext, Scope};
+use rsass::{parse_scss_data, Error, FsFileContext, ScopeRef};
 
 mod arguments;
 
@@ -48,5 +48,5 @@ pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
-    format.write_root(&items, Scope::new_global_ref(format), &file_context)
+    format.write_root(&items, ScopeRef::new_global(format), &file_context)
 }

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -48,5 +48,5 @@ pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let mut file_context = FsFileContext::new();
     file_context.push_path("tests/spec".as_ref());
     let items = parse_scss_data(input)?;
-    format.write_root(&items, &mut Scope::new_global(format), &file_context)
+    format.write_root(&items, Scope::new_global_ref(format), &file_context)
 }

--- a/tests/spec/non_conformant/misc/mod.rs
+++ b/tests/spec/non_conformant/misc/mod.rs
@@ -141,7 +141,6 @@ fn media_interpolation() {
 
 // From "sass-spec/spec/non_conformant/misc/mixin_content.hrx"
 #[test]
-#[ignore] // wrong result
 fn mixin_content() {
     assert_eq!(
         rsass(

--- a/tests/spec/non_conformant/scss/mod.rs
+++ b/tests/spec/non_conformant/scss/mod.rs
@@ -1872,7 +1872,6 @@ mod media;
 
 // From "sass-spec/spec/non_conformant/scss/mixin-content-selectors.hrx"
 #[test]
-#[ignore] // wrong result
 fn mixin_content_selectors() {
     assert_eq!(
         rsass(

--- a/tests/spec/non_conformant/scss_tests/mod.rs
+++ b/tests/spec/non_conformant/scss_tests/mod.rs
@@ -2363,7 +2363,6 @@ fn t187_test_multiline_var() {
 
 // From "sass-spec/spec/non_conformant/scss-tests/188_test_mixin_content.hrx"
 #[test]
-#[ignore] // wrong result
 fn t188_test_mixin_content() {
     assert_eq!(
         rsass(


### PR DESCRIPTION
Support loading and use of user-defined modules, i.e. `@use "foo";` where `foo` is a scss file and not a built-in module.

To make this useable, there is also a lot of refactorisation of how scopes are created and referenced.  A `ScopeRef` is either a static reference to a built-in scope or an `Arc` for a dynamic scope.

Also, both sass functions and mixins are now proper closures, so they can use names from the scope where they was declared rather than from the scope where they were called.

This is a large part of #60.