### PR TITLE
Implement values with multiple units.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ project adheres to
 
 ## Unreleased
 
+### Breaking changes
+
+* The unit of a `Numeric` is now a `UnitSet` rather than a `Unit`.
+
+### Improvements
+
 * Added a Contributing section to readme.
+* Handle values with multiple units. PR #97.
+
 
 ## Release 0.18.0 - 2021-02-25
 

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -308,8 +308,8 @@ fn number(input: Span) -> IResult<Span, Value> {
             unit,
         )),
         |(sign, num, unit)| {
-            Value::Numeric(Numeric {
-                value: if sign == Some(b"-") {
+            Value::Numeric(Numeric::new(
+                if sign == Some(b"-") {
                     // Only f64-based Number can represent negative zero.
                     if num.is_zero() {
                         (-0.0).into()
@@ -320,7 +320,7 @@ fn number(input: Span) -> IResult<Span, Value> {
                     num
                 },
                 unit,
-            })
+            ))
         },
     )(input)
 }

--- a/src/sass/functions/color/hsl.rs
+++ b/src/sass/functions/color/hsl.rs
@@ -159,7 +159,7 @@ pub fn to_rational_percent(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
         Value::Numeric(v, ..) => {
-            if v.unit == Unit::Percent || v.value > one() {
+            if v.unit.is_percent() || v.value > one() {
                 Ok(v.as_ratio()? / 100)
             } else {
                 Ok(v.as_ratio()?)
@@ -174,7 +174,7 @@ pub fn to_rational2(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
         Value::Numeric(v, ..) => {
-            if v.unit == Unit::Percent {
+            if v.unit.is_percent() {
                 Ok(v.as_ratio()? / 100)
             } else {
                 Ok(v.as_ratio()?)

--- a/src/sass/functions/color/other.rs
+++ b/src/sass/functions/color/other.rs
@@ -1,6 +1,6 @@
 use super::{get_color, make_call, Error, FunctionMap};
 use crate::css::Value;
-use crate::value::{Hsla, Hwba, Rgba, Unit};
+use crate::value::{Hsla, Hwba, Rgba};
 use crate::Scope;
 use num_rational::Rational;
 use num_traits::{One, Signed, Zero};
@@ -259,7 +259,7 @@ fn to_rational(v: Value) -> Result<Rational, Error> {
 fn to_rational_percent(v: Value) -> Result<Rational, Error> {
     match v {
         Value::Null => Ok(Rational::zero()),
-        Value::Numeric(v, _) if v.unit == Unit::Percent => {
+        Value::Numeric(v, _) if v.unit.is_percent() => {
             Ok(v.as_ratio()? / 100)
         }
         Value::Numeric(v, ..) => {

--- a/src/sass/functions/color/rgb.rs
+++ b/src/sass/functions/color/rgb.rs
@@ -215,7 +215,7 @@ fn int_value(v: Rational) -> Value {
 fn to_int(v: &Value) -> Result<Rational, Error> {
     match v {
         Value::Numeric(v, ..) => {
-            if v.unit == Unit::Percent {
+            if v.unit.is_percent() {
                 Ok(v.as_ratio()? * 255 / 100)
             } else {
                 v.as_ratio()
@@ -227,10 +227,10 @@ fn to_int(v: &Value) -> Result<Rational, Error> {
 
 fn to_rational(v: &Value) -> Result<Rational, Error> {
     match v {
-        Value::Numeric(num, _) if num.unit == Unit::Percent => {
+        Value::Numeric(num, _) if num.unit.is_percent() => {
             Ok(num.as_ratio()? / 100)
         }
-        Value::Numeric(num, _) if num.unit == Unit::None => num.as_ratio(),
+        Value::Numeric(num, _) if num.unit.is_none() => num.as_ratio(),
         v => Err(Error::badarg("number", &v)),
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -7,6 +7,7 @@ mod operator;
 mod quotes;
 mod range;
 mod unit;
+mod unitset;
 
 pub use self::colors::{Color, Hsla, Hwba, Rgba};
 pub use self::list_separator::ListSeparator;
@@ -15,5 +16,6 @@ pub use self::numeric::Numeric;
 pub use self::operator::Operator;
 pub use self::quotes::Quotes;
 pub use self::unit::{Dimension, Unit};
+pub use self::unitset::UnitSet;
 pub use num_rational::Rational;
 pub(crate) use range::{RangeError, ValueRange};

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -425,6 +425,14 @@ impl Number {
             NumValue::Float(s) => Some(s.ceil() as isize),
         }
     }
+    /// Computes self^p.
+    pub fn powi(self, p: i32) -> Self {
+        match self.value {
+            NumValue::Rational(s) => s.pow(p).into(),
+            NumValue::BigRational(s) => s.pow(p).into(),
+            NumValue::Float(s) => s.powi(p).into(),
+        }
+    }
 
     /// Get a reference to this `Value` bound to an output format.
     pub fn format(&self, format: Format) -> Formatted<Self> {

--- a/src/value/numeric.rs
+++ b/src/value/numeric.rs
@@ -1,8 +1,8 @@
-use super::{Number, Rational, Unit};
+use super::{Number, Rational, Unit, UnitSet};
 use crate::output::{Format, Formatted};
 use crate::Error;
 use std::fmt::{self, Display};
-use std::ops::Neg;
+use std::ops::{Div, Mul, Neg};
 
 /// A Numeric value is a [`Number`] with a [`Unit`] (which may be
 /// Unit::None).
@@ -11,7 +11,7 @@ pub struct Numeric {
     /// The number value of this numeric.
     pub value: Number,
     /// The unit of this numeric.
-    pub unit: Unit,
+    pub unit: UnitSet,
 }
 
 impl Numeric {
@@ -19,17 +19,17 @@ impl Numeric {
     ///
     /// The value can be given as anything that can be converted into
     /// a [`Number`], e.g. an [`isize`], a [`Rational`], or a [`f64`].
-    pub fn new(value: impl Into<Number>, unit: Unit) -> Numeric {
+    pub fn new<V: Into<Number>, U: Into<UnitSet>>(value: V, unit: U) -> Self {
         Numeric {
             value: value.into(),
-            unit,
+            unit: unit.into(),
         }
     }
     /// Create a new numeric value with no unit.
     pub fn scalar(value: impl Into<Number>) -> Numeric {
         Numeric {
             value: value.into(),
-            unit: Unit::None,
+            unit: UnitSet::scalar(),
         }
     }
 
@@ -43,7 +43,21 @@ impl Numeric {
     /// assert_eq!(inch.as_unit(Unit::Deg), None);
     /// ```
     pub fn as_unit(&self, unit: Unit) -> Option<Number> {
-        self.unit.scale_to(&unit).map(|scale| &self.value * &scale)
+        self.unit
+            .scale_to_unit(&unit)
+            .map(|scale| &self.value * &scale)
+    }
+    /// Convert this numeric value to a given unit, if possible.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rsass::value::{Numeric, Unit};
+    /// let inch = Numeric::new(1, Unit::In);
+    /// assert_eq!(inch.as_unit(Unit::Mm).unwrap() * 5, 127.into());
+    /// assert_eq!(inch.as_unit(Unit::Deg), None);
+    /// ```
+    pub fn as_unitset(&self, unit: &UnitSet) -> Option<Number> {
+        self.unit.scale_to(unit).map(|scale| &self.value * &scale)
     }
 
     /// Convert this numeric value to a given unit, if possible.
@@ -69,7 +83,7 @@ impl Numeric {
 
     /// Return true if this value has no unit.
     pub fn is_no_unit(&self) -> bool {
-        self.unit == Unit::None
+        self.unit.is_none()
     }
 
     /// Get a reference to this `Value` bound to an output format.
@@ -91,7 +105,7 @@ impl PartialOrd for Numeric {
     fn partial_cmp(&self, other: &Numeric) -> Option<std::cmp::Ordering> {
         if self.unit == other.unit {
             self.value.partial_cmp(&other.value)
-        } else if let Some(scaled) = other.as_unit(self.unit.clone()) {
+        } else if let Some(scaled) = other.as_unitset(&self.unit) {
             self.value.partial_cmp(&scaled)
         } else {
             None
@@ -109,9 +123,30 @@ impl Neg for &Numeric {
     }
 }
 
+impl Div for &Numeric {
+    type Output = Numeric;
+    fn div(self, rhs: Self) -> Self::Output {
+        Numeric {
+            value: &self.value / &rhs.value,
+            unit: &self.unit / &rhs.unit,
+        }
+    }
+}
+impl Mul for &Numeric {
+    type Output = Numeric;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Numeric {
+            value: &self.value * &rhs.value,
+            unit: &self.unit * &rhs.unit,
+        }
+    }
+}
+
 impl<'a> Display for Formatted<'a, Numeric> {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        self.value.value.format(self.format).fmt(out)?;
-        self.value.unit.fmt(out)
+        let mut unit = self.value.unit.clone();
+        let value = &self.value.value * &unit.simplify();
+        value.format(self.format).fmt(out)?;
+        unit.fmt(out)
     }
 }

--- a/src/value/range.rs
+++ b/src/value/range.rs
@@ -1,4 +1,4 @@
-use super::{Number, Numeric, Unit};
+use super::{Number, Numeric, UnitSet};
 use crate::css::Value;
 use std::fmt;
 
@@ -6,7 +6,7 @@ pub struct ValueRange {
     from: Number,
     to: Number,
     step: Number,
-    unit: Unit,
+    unit: UnitSet,
 }
 
 impl ValueRange {
@@ -21,7 +21,7 @@ impl ValueRange {
 
         let to = if from.is_no_unit() || to.is_no_unit() {
             to.value
-        } else if let Some(scaled) = to.as_unit(from.unit.clone()) {
+        } else if let Some(scaled) = to.as_unitset(&from.unit) {
             scaled
         } else {
             return Err(RangeError::IncompatibleUnits(from.unit, to.unit));
@@ -61,7 +61,7 @@ impl Iterator for ValueRange {
 pub enum RangeError {
     FromNotNumeric(Value),
     ToNotNumeric(Value),
-    IncompatibleUnits(Unit, Unit),
+    IncompatibleUnits(UnitSet, UnitSet),
 }
 
 impl fmt::Display for RangeError {

--- a/src/value/unit.rs
+++ b/src/value/unit.rs
@@ -179,8 +179,8 @@ impl Unit {
             Unit::Hz => one(),
             Unit::Khz => Number::rational(1000, 1),
 
-            Unit::Dpi => Number::rational(96, 1),
-            Unit::Dpcm => Number::rational(9600, 254),
+            Unit::Dpi => Number::rational(1, 96),
+            Unit::Dpcm => Number::rational(254, 9600),
             Unit::Dppx => one(),
 
             Unit::Percent => Number::rational(1, 100),

--- a/src/value/unitset.rs
+++ b/src/value/unitset.rs
@@ -1,0 +1,158 @@
+use super::{Number, Unit};
+use num_traits::one;
+use std::fmt::{self, Display};
+use std::ops::{Div, Mul};
+
+/// A set of units.
+///
+/// Eg. `10em * 10em` is an area of 100em².
+/// Css does not support such arbitrary units, but sass does, and if
+/// you divide it by a length you get a valid css length.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnitSet {
+    units: Vec<(Unit, i8)>,
+}
+
+impl UnitSet {
+    /// An empty UnitSet for a scalar value.
+    pub fn scalar() -> Self {
+        UnitSet { units: vec![] }
+    }
+
+    /// Check if this UnitSet is empty.
+    pub fn is_none(&self) -> bool {
+        self.units.iter().all(|(u, _)| *u == Unit::None)
+    }
+    /// Check if this UnitSet is the percent unit.
+    pub fn is_percent(&self) -> bool {
+        self.units == [(Unit::Percent, 1)]
+    }
+
+    /// Check if this UnitSet is compatible with another UnitSet.
+    pub fn is_compatible(&self, other: &Self) -> bool {
+        use std::collections::BTreeMap;
+        let dim = |t: &Self| {
+            t.units.iter().fold(
+                BTreeMap::<_, i8>::new(),
+                |mut a, (unit, power)| {
+                    *a.entry(unit.dimension()).or_insert(0) += *power;
+                    a
+                },
+            )
+        };
+        self.is_none() || other.is_none() || dim(self) == dim(other)
+    }
+
+    /// Get a scaling factor to convert this unit to another unit.
+    ///
+    /// Returns None if the units are of different dimension.
+    pub fn scale_to(&self, other: &UnitSet) -> Option<Number> {
+        if let [(u, 1)] = other.units.as_slice() {
+            self.scale_to_unit(u)
+        } else if other.is_none() {
+            self.scale_to_unit(&Unit::None)
+        } else {
+            // TODO: Lots of complicated cases ...
+            None
+        }
+    }
+    /// Get a scaling factor to convert this unit to another unit.
+    ///
+    /// Returns None if the units are of different dimension.
+    pub fn scale_to_unit(&self, other: &Unit) -> Option<Number> {
+        if let [(u, 1)] = self.units.as_slice() {
+            u.scale_to(other)
+        } else if self.is_none() {
+            Unit::None.scale_to(other)
+        } else {
+            // TODO: Handle e.g. em*% as em.
+            None
+        }
+    }
+
+    /// Simplify this unit set, returning a scaling factor.
+    pub fn simplify(&mut self) -> Number {
+        let mut factor = one();
+        if self.units.len() > 1 {
+            for i in 1..(self.units.len()) {
+                let (a, b) = self.units.split_at_mut(i);
+                let (au, ap) = a.last_mut().unwrap();
+                for (bu, bp) in b {
+                    if let Some(f) = bu.scale_to(au) {
+                        factor = factor * f.powi(i32::from(*bp));
+                        *ap += *bp;
+                        *bp = 0;
+                    }
+                }
+            }
+        }
+        self.units.retain(|(_u, p)| *p != 0);
+        factor
+    }
+}
+
+impl Div for &UnitSet {
+    type Output = UnitSet;
+    fn div(self, rhs: Self) -> Self::Output {
+        let mut result = self.clone();
+        'rhs: for (ru, rp) in &rhs.units {
+            for (lu, lp) in &mut result.units {
+                if lu == ru {
+                    *lp -= rp;
+                    continue 'rhs;
+                }
+            }
+            result.units.push((ru.clone(), -rp));
+        }
+        result.units.retain(|(_u, p)| *p != 0);
+        result
+    }
+}
+impl Mul for &UnitSet {
+    type Output = UnitSet;
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut result = self.clone();
+        'rhs: for (ru, rp) in &rhs.units {
+            for (lu, lp) in &mut result.units {
+                if lu == ru {
+                    *lp += rp;
+                    continue 'rhs;
+                }
+            }
+            result.units.push((ru.clone(), *rp));
+        }
+        result.units.retain(|(_u, p)| *p != 0);
+        result
+    }
+}
+
+impl From<Unit> for UnitSet {
+    fn from(unit: Unit) -> Self {
+        UnitSet {
+            units: if unit == Unit::None {
+                vec![]
+            } else {
+                vec![(unit, 1)]
+            },
+        }
+    }
+}
+
+impl Display for UnitSet {
+    fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(((u, p), rest)) = &self.units.split_first() {
+            u.fmt(out)?;
+            if *p != 1 {
+                write!(out, "^{}", p)?;
+            }
+            for (u, p) in *rest {
+                out.write_str(if *p > 0 { "*" } else { "/" })?;
+                u.fmt(out)?;
+                if p.abs() != 1 {
+                    write!(out, "^{}", p.abs())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,5 +1,5 @@
 use rsass::sass::{Function, Name};
-use rsass::value::{Number, Numeric, Rgba, Unit};
+use rsass::value::{Number, Numeric, Rgba};
 use rsass::*;
 use std::sync::Arc;
 
@@ -73,9 +73,9 @@ fn function_with_args() {
                     .get("b")?
                     .numeric_value()
                     .map_err(|v| Error::badarg("number", &v))?;
-                if a.unit == b.unit || b.unit == Unit::None {
+                if a.unit == b.unit || b.unit.is_none() {
                     Ok(Numeric::new(avg(a.value, b.value), a.unit).into())
-                } else if a.unit == Unit::None {
+                } else if a.unit.is_none() {
                     Ok(Numeric::new(avg(a.value, b.value), b.unit).into())
                 } else {
                     Err(Error::BadArguments("Incopatible args".into()))

--- a/tests/spec/core_functions/math/mod.rs
+++ b/tests/spec/core_functions/math/mod.rs
@@ -95,7 +95,6 @@ mod abs {
         }
     }
     #[test]
-    #[ignore] // unexepected error
     fn preserves_units() {
         assert_eq!(
             rsass(
@@ -626,7 +625,6 @@ mod ceil {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn preserves_units() {
         assert_eq!(
             rsass(
@@ -907,7 +905,6 @@ mod comparable {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn to_inverse() {
             assert_eq!(
                 rsass(
@@ -1193,7 +1190,6 @@ mod floor {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn preserves_units() {
         assert_eq!(
             rsass(
@@ -2173,7 +2169,6 @@ mod round {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn preserves_units() {
         assert_eq!(
             rsass(
@@ -2868,7 +2863,6 @@ mod unit {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn multiple_numerators() {
         assert_eq!(
             rsass(
@@ -2929,7 +2923,6 @@ mod unit {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn single() {
             assert_eq!(
                 rsass(
@@ -2945,7 +2938,6 @@ mod unit {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn one_denominator() {
         assert_eq!(
             rsass(
@@ -2980,7 +2972,6 @@ mod unitless {
     #[allow(unused)]
     use super::rsass;
     #[test]
-    #[ignore] // unexepected error
     fn denominator() {
         assert_eq!(
             rsass(
@@ -3033,7 +3024,6 @@ mod unitless {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn numerator_and_denominator() {
         assert_eq!(
             rsass(

--- a/tests/spec/core_functions/meta/mod.rs
+++ b/tests/spec/core_functions/meta/mod.rs
@@ -3205,7 +3205,6 @@ mod type_of {
         #[allow(unused)]
         use super::rsass;
         #[test]
-        #[ignore] // wrong result
         fn unit() {
             assert_eq!(
                 rsass(

--- a/tests/spec/libsass/mod.rs
+++ b/tests/spec/libsass/mod.rs
@@ -333,7 +333,6 @@ mod color_functions;
 
 // From "sass-spec/spec/libsass/conversions.hrx"
 #[test]
-#[ignore] // wrong result
 fn conversions() {
     assert_eq!(
         rsass(

--- a/tests/spec/libsass/units/conversion/mod.rs
+++ b/tests/spec/libsass/units/conversion/mod.rs
@@ -4,7 +4,6 @@ use super::rsass;
 
 // From "sass-spec/spec/libsass/units/conversion/angle.hrx"
 #[test]
-#[ignore] // wrong result
 fn angle() {
     assert_eq!(
         rsass(
@@ -117,7 +116,6 @@ fn angle() {
 
 // From "sass-spec/spec/libsass/units/conversion/frequency.hrx"
 #[test]
-#[ignore] // wrong result
 fn frequency() {
     assert_eq!(
         rsass(
@@ -158,7 +156,6 @@ fn frequency() {
 
 // From "sass-spec/spec/libsass/units/conversion/resolution.hrx"
 #[test]
-#[ignore] // wrong result
 fn resolution() {
     assert_eq!(
         rsass(
@@ -229,7 +226,6 @@ fn resolution() {
 
 // From "sass-spec/spec/libsass/units/conversion/size.hrx"
 #[test]
-#[ignore] // wrong result
 fn size() {
     assert_eq!(
         rsass(
@@ -462,7 +458,6 @@ fn size() {
 
 // From "sass-spec/spec/libsass/units/conversion/time.hrx"
 #[test]
-#[ignore] // wrong result
 fn time() {
     assert_eq!(
         rsass(

--- a/tests/spec/libsass_closed_issues/mod.rs
+++ b/tests/spec/libsass_closed_issues/mod.rs
@@ -11874,7 +11874,6 @@ fn issue_77() {
 
 // From "sass-spec/spec/libsass-closed-issues/issue_783"
 #[test]
-#[ignore] // wrong result
 fn issue_783() {
     assert_eq!(
         rsass(


### PR DESCRIPTION
This makes e.g. `abs(-7px / 4em) * 1em` evaluate correctly, to `1.75px`.

Also correct the `dpi`/`dpcm`/`dppx` conversion factors, which were bogus.