### PR TITLE
Parse numbers directly as Number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ project adheres to
 * Fix issue #98: overflow in rational number arithmetic.
 * Allow `@at-root` at document root.
 * Boolean operators is truly lazy, e.g. `false and f($x)` does not call `f`.
+* Refactored number parsing to use overflowing rationals. PR #100.
 * Test suite sass-spec updated to 2021-03-02.
 
 Thanks to @alvra for reporting #98.

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -152,7 +152,7 @@ impl Mul<isize> for NumValue {
     type Output = Self;
     fn mul(self, rhs: isize) -> Self {
         match self {
-            NumValue::Rational(s) => (s * rhs).into(),
+            s @ NumValue::Rational(_) => s * NumValue::from(rhs),
             NumValue::BigRational(s) => (s * BigInt::from(rhs)).into(),
             NumValue::Float(s) => (s * (rhs as f64)).into(),
         }


### PR DESCRIPTION
No need to parse the first as isize-based limited numbers and then try again as bignum number when we can parse directly into Number which will handle any overflow.