### PR TITLE
Support undecided sepators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ project adheres to
 ### Breaking changes
 
 * `value::Unit` has a new alternative.
+* The `List` alternative in `sass::Value` and `css::Value` is modified.
 
 ### Improvements
 
 * Handle unknown units.  PR #101.
+* List can be undecided between beeing comma-separated and beeing
+  space-separated.  PR #102.
 
 
 ## Release 0.20.0 - 2021-03-25

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -55,8 +55,11 @@ impl CallArgs {
                     }
                 }
                 if let Some(last) = v.pop() {
-                    if let Value::List(vv, ListSeparator::Space, false) =
-                        &last
+                    if let Value::List(
+                        vv,
+                        Some(ListSeparator::Space),
+                        false,
+                    ) = &last
                     {
                         match &vv[..] {
                             [Value::List(vv, _, _), Value::Literal(mark, Quotes::None)]

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -18,7 +18,7 @@ pub enum Value {
     /// A string literal.
     Literal(String, Quotes),
     /// A comma- or space separated list of values, with or without brackets.
-    List(Vec<Value>, ListSeparator, bool),
+    List(Vec<Value>, Option<ListSeparator>, bool),
     /// A Numeric value is a rational value with a Unit (which may be
     /// Unit::None) and flags.
     ///
@@ -214,7 +214,7 @@ impl Value {
                 .map(|&(ref k, ref v)| {
                     Value::List(
                         vec![k.clone(), v.clone()],
-                        ListSeparator::Space,
+                        Some(ListSeparator::Space),
                         false,
                     )
                 })

--- a/src/css/valueformat.rs
+++ b/src/css/valueformat.rs
@@ -54,8 +54,9 @@ impl<'a> Display for Formatted<'a, Value> {
                         let needs_paren = match *v {
                             Value::List(ref v, inner, false) => {
                                 ((brackets || introspect)
-                                    && (sep == ListSeparator::Space
-                                        || inner == ListSeparator::Comma))
+                                    && (sep != Some(ListSeparator::Comma)
+                                        || inner
+                                            == Some(ListSeparator::Comma)))
                                     && !(introspect && v.len() < 2)
                             }
                             _ => false,
@@ -69,7 +70,7 @@ impl<'a> Display for Formatted<'a, Value> {
                     .collect::<Vec<_>>();
                 let t = if self.format.is_introspection()
                     && t.len() == 1
-                    && sep == ListSeparator::Comma
+                    && sep == Some(ListSeparator::Comma)
                 {
                     if self.format.is_introspection() && !brackets {
                         format!("({},)", t[0])
@@ -78,14 +79,14 @@ impl<'a> Display for Formatted<'a, Value> {
                     }
                 } else {
                     t.join(match sep {
-                        ListSeparator::Comma => {
+                        Some(ListSeparator::Comma) => {
                             if self.format.is_compressed() {
                                 ","
                             } else {
                                 ", "
                             }
                         }
-                        ListSeparator::Space => " ",
+                        _ => " ",
                     })
                 };
                 if brackets {
@@ -138,16 +139,20 @@ impl<'a> Display for Formatted<'a, Value> {
                     if i > 0 {
                         out.write_str(", ")?;
                     }
-                    if matches!(k, Value::List(_, ListSeparator::Comma, _))
-                        && self.format.is_introspection()
+                    if matches!(
+                        k,
+                        Value::List(_, Some(ListSeparator::Comma), _)
+                    ) && self.format.is_introspection()
                     {
                         write!(out, "({})", k.format(self.format))?;
                     } else {
                         write!(out, "{}", k.format(self.format))?;
                     }
                     out.write_str(": ")?;
-                    if matches!(v, Value::List(_, ListSeparator::Comma, _))
-                        && self.format.is_introspection()
+                    if matches!(
+                        v,
+                        Value::List(_, Some(ListSeparator::Comma), _)
+                    ) && self.format.is_introspection()
                     {
                         write!(out, "({})", v.format(self.format))?;
                     } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -388,7 +388,7 @@ fn media_args(input: Span) -> IResult<Span, Value> {
                 if args.len() == 1 {
                     args.into_iter().next().unwrap()
                 } else {
-                    Value::List(args, ListSeparator::Space, false)
+                    Value::List(args, Some(ListSeparator::Space), false)
                 }
             },
         ),
@@ -398,7 +398,7 @@ fn media_args(input: Span) -> IResult<Span, Value> {
         if args.len() == 1 {
             args.into_iter().next().unwrap()
         } else {
-            Value::List(args, ListSeparator::Comma, false)
+            Value::List(args, Some(ListSeparator::Comma), false)
         },
     ))
 }
@@ -727,7 +727,7 @@ fn test_mixin_declaration() {
                 "foo-bar".into(),
                 Value::List(
                     vec![string("baz"), Value::Variable("x".into())],
-                    ListSeparator::Space,
+                    Some(ListSeparator::Space),
                     false,
                 ),
             )],
@@ -789,7 +789,7 @@ fn test_property_2() {
             "background-position".into(),
             Value::List(
                 vec![percentage(90), percentage(50)],
-                ListSeparator::Space,
+                Some(ListSeparator::Space),
                 false,
             ),
         ),
@@ -817,7 +817,7 @@ fn test_variable_declaration_global() {
             name: "y".into(),
             val: Value::List(
                 vec![string("some"), string("value")],
-                ListSeparator::Space,
+                Some(ListSeparator::Space),
                 false,
             ),
             default: false,
@@ -834,7 +834,7 @@ fn test_variable_declaration_default() {
             name: "y".into(),
             val: Value::List(
                 vec![string("some"), string("value")],
-                ListSeparator::Space,
+                Some(ListSeparator::Space),
                 false,
             ),
             default: true,

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -32,7 +32,7 @@ pub fn value_expression(input: Span) -> IResult<Span, Value> {
         if result.len() == 1 && trail.is_empty() {
             result.into_iter().next().unwrap()
         } else {
-            Value::List(result, ListSeparator::Comma, false)
+            Value::List(result, Some(ListSeparator::Comma), false)
         },
     ))
 }
@@ -63,7 +63,7 @@ pub fn space_list(input: Span) -> IResult<Span, Value> {
         if list.len() == 1 {
             list.into_iter().next().unwrap()
         } else {
-            Value::List(list, ListSeparator::Space, false)
+            Value::List(list, Some(ListSeparator::Space), false)
         },
     ))
 }
@@ -83,7 +83,7 @@ pub fn simple_space_list(input: Span) -> IResult<Span, Value> {
         if list.len() == 1 {
             list.into_iter().next().unwrap()
         } else {
-            Value::List(list, ListSeparator::Space, false)
+            Value::List(list, Some(ListSeparator::Space), false)
         },
     ))
 }
@@ -222,7 +222,7 @@ fn colon(input: Span) -> IResult<Span, Span> {
 fn fallback_in_paren(input: Span) -> IResult<Span, Value> {
     alt((
         map(value_expression, |v| Value::Paren(Box::new(v), false)),
-        value(Value::List(vec![], ListSeparator::Space, false), tag("")),
+        value(Value::List(vec![], None, false), tag("")),
     ))(input)
 }
 
@@ -293,10 +293,8 @@ fn bracket_list(input: Span) -> IResult<Span, Value> {
             Some(Value::List(list, sep, false)) => {
                 Value::List(list, sep, true)
             }
-            Some(single) => {
-                Value::List(vec![single], ListSeparator::Space, true)
-            }
-            None => Value::List(vec![], ListSeparator::Space, true),
+            Some(single) => Value::List(vec![single], None, true),
+            None => Value::List(vec![], None, true),
         },
     ))
 }
@@ -548,7 +546,7 @@ mod test {
             Paren(
                 Box::new(List(
                     vec![Literal("rod".into()), Literal("bloe".into())],
-                    ListSeparator::Space,
+                    Some(ListSeparator::Space),
                     false,
                 )),
                 false,
@@ -563,7 +561,7 @@ mod test {
             Paren(
                 Box::new(List(
                     vec![Literal("rod".into()), Literal("bloe".into())],
-                    ListSeparator::Comma,
+                    Some(ListSeparator::Comma),
                     false,
                 )),
                 false,
@@ -577,7 +575,7 @@ mod test {
             "rod, bloe;",
             List(
                 vec![Literal("rod".into()), Literal("bloe".into())],
-                ListSeparator::Comma,
+                Some(ListSeparator::Comma),
                 false,
             ),
         )
@@ -590,7 +588,7 @@ mod test {
             Paren(
                 Box::new(List(
                     vec![Literal("rod".into()), Literal("bloe".into())],
-                    ListSeparator::Comma,
+                    Some(ListSeparator::Comma),
                     false,
                 )),
                 false,
@@ -604,7 +602,7 @@ mod test {
             "rod, bloe, ;",
             List(
                 vec![Literal("rod".into()), Literal("bloe".into())],
-                ListSeparator::Comma,
+                Some(ListSeparator::Comma),
                 false,
             ),
         )
@@ -659,7 +657,7 @@ mod test {
                     Value::scalar(2),
                     Value::scalar(3),
                 ],
-                ListSeparator::Space,
+                Some(ListSeparator::Space),
                 false,
             ),
         )
@@ -707,7 +705,7 @@ mod test {
             "[foo bar];",
             List(
                 vec![Literal("foo".into()), Literal("bar".into())],
-                ListSeparator::Space,
+                Some(ListSeparator::Space),
                 true,
             ),
         )
@@ -719,7 +717,7 @@ mod test {
             "[foo, bar];",
             List(
                 vec![Literal("foo".into()), Literal("bar".into())],
-                ListSeparator::Comma,
+                Some(ListSeparator::Comma),
                 true,
             ),
         )
@@ -727,7 +725,7 @@ mod test {
 
     #[test]
     fn parse_bracket_empty_array() {
-        check_expr("[];", List(vec![], ListSeparator::Space, true))
+        check_expr("[];", List(vec![], None, true))
     }
 
     #[test]

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -63,7 +63,11 @@ impl FormalArgs {
                         .collect();
                     argscope.define(
                         name.clone(),
-                        &css::Value::List(args, ListSeparator::Comma, false),
+                        &css::Value::List(
+                            args,
+                            Some(ListSeparator::Comma),
+                            false,
+                        ),
                     );
                 } else {
                     return Err(ArgsError::TooMany(n, args.len()));
@@ -80,11 +84,7 @@ impl FormalArgs {
                         } else if i + 1 == self.0.len() && self.is_varargs() {
                             argscope.define(
                                 name.clone(),
-                                &css::Value::List(
-                                    vec![],
-                                    ListSeparator::Space,
-                                    false,
-                                ),
+                                &css::Value::List(vec![], None, false),
                             )
                         } else {
                             return Err(ArgsError::Missing(name.clone()));

--- a/src/sass/functions/color/rgb.rs
+++ b/src/sass/functions/color/rgb.rs
@@ -110,7 +110,7 @@ fn to_channel(v: &Value, name: Name) -> Result<Option<Rational>, Error> {
 pub fn preserve_call(
     fn_name: &str,
     vec: Vec<Value>,
-    sep: ListSeparator,
+    sep: Option<ListSeparator>,
     bracketed: bool,
 ) -> Value {
     Value::Call(

--- a/src/sass/functions/map.rs
+++ b/src/sass/functions/map.rs
@@ -95,7 +95,7 @@ pub fn create_module() -> Scope {
     });
     def!(f, keys(map), |s| {
         let map = get_map(s, name!(map))?;
-        Ok(Value::List(map.keys(), ListSeparator::Comma, false))
+        Ok(Value::List(map.keys(), Some(ListSeparator::Comma), false))
     });
     def_va!(f, merge(map1, map2), |s| {
         let mut map1 = get_map(s, name!(map1))?;
@@ -144,7 +144,7 @@ pub fn create_module() -> Scope {
     def_va!(f, set(map, args), set);
     def!(f, values(map), |s| {
         let map = get_map(s, name!(map))?;
-        Ok(Value::List(map.values(), ListSeparator::Comma, false))
+        Ok(Value::List(map.values(), Some(ListSeparator::Comma), false))
     });
     f
 }

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -74,15 +74,15 @@ impl Selectors {
                         .split_whitespace()
                         .map(|p| Value::Literal(p.to_string(), Quotes::None))
                         .collect(),
-                    ListSeparator::Space,
+                    Some(ListSeparator::Space),
                     false,
                 )
             })
             .collect::<Vec<_>>();
         let sep = if content.len() == 1 {
-            ListSeparator::Space
+            None
         } else {
-            ListSeparator::Comma
+            Some(ListSeparator::Comma)
         };
         Value::List(content, sep, false)
     }

--- a/src/value/operator.rs
+++ b/src/value/operator.rs
@@ -115,7 +115,7 @@ impl Operator {
                 (a @ Value::UnicodeRange(..), b @ Value::Literal(..)) => {
                     Some(Value::List(
                         vec![a, Value::UnaryOp(Operator::Minus, Box::new(b))],
-                        ListSeparator::Space,
+                        Some(ListSeparator::Space),
                         false,
                     ))
                 }

--- a/tests/spec/core_functions/list/join/empty.rs
+++ b/tests/spec/core_functions/list/join/empty.rs
@@ -47,7 +47,6 @@ mod both {
     }
     mod space {
         #[test]
-        #[ignore] // wrong result
         fn first() {
             assert_eq!(
                 crate::rsass(
@@ -69,7 +68,6 @@ mod both {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn last() {
             assert_eq!(
                 crate::rsass(
@@ -92,7 +90,6 @@ mod both {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn undecided() {
         assert_eq!(
         crate::rsass(
@@ -134,7 +131,6 @@ mod first {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn space() {
         assert_eq!(
             crate::rsass(
@@ -213,7 +209,6 @@ mod map {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn undecided() {
             assert_eq!(
                 crate::rsass(
@@ -267,7 +262,6 @@ mod map {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn undecided() {
             assert_eq!(
                 crate::rsass(

--- a/tests/spec/core_functions/list/join/single.rs
+++ b/tests/spec/core_functions/list/join/single.rs
@@ -18,7 +18,6 @@ mod both {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn last() {
             assert_eq!(
                 crate::rsass(
@@ -114,7 +113,6 @@ mod first {
     }
     mod undecided {
         #[test]
-        #[ignore] // wrong result
         fn and_comma() {
             assert_eq!(
                 crate::rsass(

--- a/tests/spec/core_functions/list/utils.rs
+++ b/tests/spec/core_functions/list/utils.rs
@@ -35,7 +35,6 @@ mod real_separator {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn space() {
             assert_eq!(
                 crate::rsass(
@@ -115,7 +114,6 @@ mod real_separator {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn undecided() {
             assert_eq!(
                 crate::rsass(


### PR DESCRIPTION
A list can have "undecided" separator, which affects how it will combine with other lists.