### PR TITLE
Replace `rand` with `fastrand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ num-bigint = { version = "0.4.0", default-features = false, features = ["std"] }
 num-integer = "0.1.42"
 num-rational = { version = "0.4.0", default-features = false }
 num-traits = "^0.2.0"
-rand = "0.8.0"
+fastrand = "1.4"
 structopt = { version = "0.3.9", features = ["wrap_help"], optional = true }
 deunicode = { version = "1.0", optional = true }
 hrx-get = { version = "0.1", optional = true }

--- a/src/sass/functions/math.rs
+++ b/src/sass/functions/math.rs
@@ -6,7 +6,6 @@ use crate::css::Value;
 use crate::output::Format;
 use crate::sass::Name;
 use crate::value::{Number, Numeric, Quotes, Rational, Unit, UnitSet};
-use rand::{thread_rng, Rng};
 use std::cmp::Ordering;
 use std::f64::consts::{E, PI};
 
@@ -290,7 +289,7 @@ fn find_extreme_inner(
 }
 
 fn intrand(lim: i64) -> i64 {
-    thread_rng().gen_range(0..lim)
+    fastrand::i64(0..lim)
 }
 
 fn diff_units_msg(


### PR DESCRIPTION
This has the advantage of removing a total of about 8 dependencies and adds support for wasm browser environments.