### PR TITLE
Support `@forward`, improve `@use`.

### DIFF
--- a/src/output/cssbuf.rs
+++ b/src/output/cssbuf.rs
@@ -1,8 +1,73 @@
 use super::Format;
 use crate::css::{BodyItem, Rule};
 use crate::sass::SassString;
-use crate::Error;
+use crate::{Error, ScopeRef};
+use std::collections::BTreeMap;
 use std::io::{self, Write};
+
+/// A [CssBuf] for imports, that also keeps track of loaded modules.
+pub struct CssHead {
+    buf: CssBuf,
+    modules: BTreeMap<String, ScopeRef>,
+}
+
+impl CssHead {
+    pub fn new(format: Format) -> Self {
+        CssHead {
+            buf: CssBuf::new(format),
+            modules: Default::default(),
+        }
+    }
+    pub fn add_import(
+        &mut self,
+        name: SassString,
+        args: crate::css::Value,
+    ) -> Result<(), Error> {
+        self.buf.add_import(name, args)
+    }
+
+    pub fn load_module<Init>(
+        &mut self,
+        path: &str,
+        init: Init,
+    ) -> Result<ScopeRef, Error>
+    where
+        Init: FnOnce(&mut Self) -> Result<ScopeRef, Error>,
+    {
+        if let Some(loaded) = self.modules.get(path) {
+            return Ok(loaded.clone());
+        }
+        let module = init(self)?;
+        self.modules.insert(path.into(), module.clone());
+        Ok(module)
+    }
+
+    pub fn merge_imports(&mut self, other: Self) {
+        self.buf.buf.extend_from_slice(&other.buf.buf);
+    }
+
+    pub fn combine_final(&self, body: CssBuf) -> Vec<u8> {
+        let mut result = vec![];
+        let compressed = self.buf.format.is_compressed();
+        if !self.buf.is_ascii() || !body.is_ascii() {
+            if compressed {
+                // U+FEFF is byte order mark, used to show encoding.
+                result.extend_from_slice("\u{feff}".as_bytes());
+            } else {
+                result.extend_from_slice(b"@charset \"UTF-8\";\n");
+            }
+        }
+        result.extend_from_slice(&self.buf.buf);
+        result.extend_from_slice(&body.buf);
+        if compressed && result.last() == Some(&b';') {
+            result.pop();
+        }
+        if result.last().unwrap_or(&b'\n') != &b'\n' {
+            result.push(b'\n');
+        }
+        result
+    }
+}
 
 pub struct CssBuf {
     buf: Vec<u8>,
@@ -28,28 +93,6 @@ impl CssBuf {
             indent,
             separate: false,
         }
-    }
-
-    pub fn combine_final(head: Self, body: Self) -> Vec<u8> {
-        let mut result = vec![];
-        let compressed = head.format.is_compressed();
-        if !head.is_ascii() || !body.is_ascii() {
-            if compressed {
-                // U+FEFF is byte order mark, used to show encoding.
-                result.extend_from_slice("\u{feff}".as_bytes());
-            } else {
-                result.extend_from_slice(b"@charset \"UTF-8\";\n");
-            }
-        }
-        result.extend_from_slice(&head.buf);
-        result.extend_from_slice(&body.buf);
-        if compressed && result.last() == Some(&b';') {
-            result.pop();
-        }
-        if result.last().unwrap_or(&b'\n') != &b'\n' {
-            result.push(b'\n');
-        }
-        result
     }
 
     pub fn write_rule(

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,4 +1,4 @@
-use super::cssbuf::CssBuf;
+use super::cssbuf::{CssBuf, CssHead};
 use super::transform::handle_body;
 use super::Style;
 use crate::file_context::FileContext;
@@ -42,7 +42,7 @@ impl Format {
         globals: ScopeRef,
         file_context: &impl FileContext,
     ) -> Result<Vec<u8>, Error> {
-        let mut head = CssBuf::new(*self);
+        let mut head = CssHead::new(*self);
         let mut body = CssBuf::new(*self);
         handle_body(
             items,
@@ -52,7 +52,7 @@ impl Format {
             globals,
             file_context,
         )?;
-        Ok(CssBuf::combine_final(head, body))
+        Ok(head.combine_final(body))
     }
 
     /// Get a newline followed by len spaces, unles self is compressed.

--- a/src/parser/imports.rs
+++ b/src/parser/imports.rs
@@ -1,0 +1,174 @@
+//! Support for `@import`, `@use`, and `@forward`.
+use super::strings::{
+    name, sass_string, sass_string_dq, sass_string_sq, special_url,
+};
+use super::util::{ignore_comments, ignore_space, opt_spacelike};
+use super::value::space_list;
+use super::{media_args, Span};
+use crate::sass::{Expose, Item, Name, SassString, UseAs, Value};
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{all_consuming, map, opt, value};
+use nom::multi::{fold_many0, separated_list0};
+use nom::sequence::{delimited, pair, preceded, terminated, tuple};
+use nom::IResult;
+use nom_locate::position;
+use std::collections::BTreeSet;
+
+/// What follows the `@import` tag.
+pub fn import2(input: Span) -> IResult<Span, Item> {
+    map(
+        terminated(
+            tuple((
+                position,
+                separated_list0(
+                    comma,
+                    alt((
+                        sass_string_dq,
+                        sass_string_sq,
+                        special_url,
+                        sass_string,
+                    )),
+                ),
+                opt(media_args),
+            )),
+            preceded(
+                opt(ignore_space),
+                alt((tag(";"), all_consuming(tag("")))),
+            ),
+        ),
+        |(position, import, args)| {
+            Item::Import(import, args.unwrap_or(Value::Null), position.into())
+        },
+    )(input)
+}
+
+pub fn use2(input: Span) -> IResult<Span, Item> {
+    map(
+        terminated(
+            tuple((
+                terminated(any_sass_string, opt_spacelike),
+                opt(preceded(
+                    terminated(tag("with"), opt_spacelike),
+                    with_arg,
+                )),
+                opt(preceded(terminated(tag("as"), opt_spacelike), as_arg)),
+            )),
+            alt((tag(";"), all_consuming(tag("")))),
+        ),
+        |(s, w, n)| {
+            Item::Use(s, n.unwrap_or(UseAs::KeepName), w.unwrap_or_default())
+        },
+    )(input)
+}
+
+pub fn forward2(input: Span) -> IResult<Span, Item> {
+    let (mut input, path) =
+        terminated(any_sass_string, opt_spacelike)(input)?;
+    let mut found_as = None;
+    let mut expose = Expose::All;
+    let mut found_with = None;
+    while let Ok((rest, arg)) = terminated(name, opt_spacelike)(input) {
+        input = match arg.as_ref() {
+            "as" if found_as.is_none() => {
+                let (i, a) = as_arg(rest)?;
+                found_as = Some(a);
+                i
+            }
+            "hide" if expose == Expose::All => {
+                let (i, (funs, vars)) = exposed_names(rest)?;
+                expose = Expose::Hide(funs, vars);
+                i
+            }
+            "show" if expose == Expose::All => {
+                let (i, (funs, vars)) = exposed_names(rest)?;
+                expose = Expose::Show(funs, vars);
+                i
+            }
+            "with" if found_with.is_none() => {
+                let (i, w) = with_arg(rest)?;
+                found_with = Some(w);
+                i
+            }
+            _ => {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::MapRes,
+                )));
+            }
+        };
+    }
+    let (input, _) = alt((tag(";"), all_consuming(tag(""))))(input)?;
+    Ok((
+        input,
+        Item::Forward(
+            path,
+            found_as.unwrap_or(UseAs::Star),
+            expose,
+            found_with.unwrap_or_default(),
+        ),
+    ))
+}
+
+fn exposed_names(
+    input: Span,
+) -> IResult<Span, (BTreeSet<Name>, BTreeSet<Name>)> {
+    let mut funs = BTreeSet::new();
+    let mut vars = BTreeSet::new();
+    let mut one = pair(
+        map(opt(tag("$")), |v| v.is_some()),
+        map(terminated(name, opt_spacelike), Name::from),
+    );
+    let (input, (v, n)) = one(input)?;
+    if v { &mut vars } else { &mut funs }.insert(n);
+    fold_many0(
+        preceded(terminated(tag(","), opt_spacelike), one),
+        (funs, vars),
+        |(mut funs, mut vars), (v, n)| {
+            if v { &mut vars } else { &mut funs }.insert(n);
+            (funs, vars)
+        },
+    )(input)
+}
+
+fn as_arg(input: Span) -> IResult<Span, UseAs> {
+    terminated(
+        alt((
+            map(pair(name, opt(tag("*"))), |(name, s)| match s {
+                None => UseAs::Name(name),
+                Some(_) => UseAs::Prefix(name),
+            }),
+            value(UseAs::Star, tag("*")),
+        )),
+        opt_spacelike,
+    )(input)
+}
+
+fn with_arg(input: Span) -> IResult<Span, Vec<(Name, Value, bool)>> {
+    delimited(
+        terminated(tag("("), opt_spacelike),
+        separated_list0(
+            comma,
+            tuple((
+                delimited(
+                    tag("$"),
+                    map(name, Name::from),
+                    delimited(opt_spacelike, tag(":"), opt_spacelike),
+                ),
+                terminated(space_list, opt_spacelike),
+                map(opt(terminated(tag("!default"), opt_spacelike)), |o| {
+                    o.is_some()
+                }),
+            )),
+        ),
+        delimited(opt(comma), tag(")"), opt_spacelike),
+    )(input)
+}
+
+fn any_sass_string(input: Span) -> IResult<Span, SassString> {
+    alt((sass_string_dq, sass_string_sq, sass_string))(input)
+}
+
+fn comma(input: Span) -> IResult<Span, ()> {
+    map(terminated(tag(","), ignore_comments), |_| ())(input)
+}

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -22,7 +22,7 @@ mod value;
 pub use self::call_args::CallArgs;
 pub use self::formal_args::{ArgsError, FormalArgs};
 pub use self::functions::{get_global_module, Function};
-pub use self::item::{Item, UseAs};
+pub use self::item::{Expose, Item, UseAs};
 pub use self::mixin::Mixin;
 pub use self::name::Name;
 pub use self::string::{SassString, StringPart};

--- a/src/spectest/testrunner.rs
+++ b/src/spectest/testrunner.rs
@@ -63,20 +63,13 @@ impl FileContext for TestFileContext {
         &self,
         name: &str,
     ) -> Result<Option<(Self, String, Self::File)>, Error> {
-        let (cwd, lname) = name
-            .strip_prefix("../")
-            .map(|n| {
-                (
-                    self.cwd
-                        .trim_end_matches('/')
-                        .rfind('/')
-                        .map(|p| &self.cwd[..p])
-                        .unwrap_or(""),
-                    n,
-                )
-            })
-            .unwrap_or((&self.cwd, name));
-        let tname = url_join(&cwd, lname);
+        let mut cwd: &str = &self.cwd.trim_end_matches('/');
+        let mut lname = name;
+        while let Some(name) = lname.strip_prefix("../") {
+            cwd = cwd.rfind('/').map(|p| &self.cwd[..p]).unwrap_or("");
+            lname = name;
+        }
+        let tname = url_join(cwd, lname);
 
         if let Some(data) = self.mock.get(&tname) {
             return Ok(Some((

--- a/tests/spec/core_functions/meta/function_exists.rs
+++ b/tests/spec/core_functions/meta/function_exists.rs
@@ -88,7 +88,6 @@ mod different_module {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn test_as() {
             let runner = runner().with_cwd("as");
             assert_eq!(
@@ -104,7 +103,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn bare() {
             let runner = runner().with_cwd("bare");
             assert_eq!(
@@ -116,7 +114,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn hide() {
             let runner = runner().with_cwd("hide");
             assert_eq!(
@@ -132,7 +129,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn show() {
             let runner = runner().with_cwd("show");
             assert_eq!(

--- a/tests/spec/core_functions/meta/get_function/different_module.rs
+++ b/tests/spec/core_functions/meta/get_function/different_module.rs
@@ -87,7 +87,6 @@ mod through_forward {
     }
 
     #[test]
-    #[ignore] // unexepected error
     fn test_as() {
         let runner = runner().with_cwd("as");
         assert_eq!(
@@ -101,7 +100,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn bare() {
         let runner = runner().with_cwd("bare");
         assert_eq!(
@@ -113,7 +111,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn hide() {
         let runner = runner().with_cwd("hide");
         assert_eq!(
@@ -127,7 +124,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn show() {
         let runner = runner().with_cwd("show");
         assert_eq!(

--- a/tests/spec/core_functions/meta/global_variable_exists.rs
+++ b/tests/spec/core_functions/meta/global_variable_exists.rs
@@ -117,7 +117,6 @@ mod different_module {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn test_as() {
             let runner = runner().with_cwd("as");
             assert_eq!(
@@ -133,7 +132,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn bare() {
             let runner = runner().with_cwd("bare");
             assert_eq!(
@@ -145,7 +143,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn hide() {
             let runner = runner().with_cwd("hide");
             assert_eq!(
@@ -161,7 +158,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn show() {
             let runner = runner().with_cwd("show");
             assert_eq!(

--- a/tests/spec/core_functions/meta/keywords.rs
+++ b/tests/spec/core_functions/meta/keywords.rs
@@ -134,7 +134,7 @@ mod forwarded {
     }
 
     #[test]
-    #[ignore] // unexepected error
+    #[ignore] // wrong result
     fn call() {
         let runner = runner().with_cwd("call");
         assert_eq!(

--- a/tests/spec/core_functions/meta/mixin_exists.rs
+++ b/tests/spec/core_functions/meta/mixin_exists.rs
@@ -88,7 +88,6 @@ mod different_module {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn test_as() {
             let runner = runner().with_cwd("as");
             assert_eq!(
@@ -104,7 +103,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn bare() {
             let runner = runner().with_cwd("bare");
             assert_eq!(
@@ -116,7 +114,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn hide() {
             let runner = runner().with_cwd("hide");
             assert_eq!(
@@ -132,7 +129,6 @@ mod different_module {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn show() {
             let runner = runner().with_cwd("show");
             assert_eq!(

--- a/tests/spec/core_functions/meta/module_functions.rs
+++ b/tests/spec/core_functions/meta/module_functions.rs
@@ -262,7 +262,6 @@ mod through_forward {
     }
 
     #[test]
-    #[ignore] // unexepected error
     fn test_as() {
         let runner = runner().with_cwd("as");
         assert_eq!(
@@ -280,7 +279,6 @@ mod through_forward {
     );
     }
     #[test]
-    #[ignore] // unexepected error
     fn bare() {
         let runner = runner().with_cwd("bare");
         assert_eq!(
@@ -298,7 +296,6 @@ mod through_forward {
     );
     }
     #[test]
-    #[ignore] // unexepected error
     fn hide() {
         let runner = runner().with_cwd("hide");
         assert_eq!(
@@ -314,7 +311,6 @@ mod through_forward {
     );
     }
     #[test]
-    #[ignore] // unexepected error
     fn show() {
         let runner = runner().with_cwd("show");
         assert_eq!(

--- a/tests/spec/core_functions/meta/module_variables.rs
+++ b/tests/spec/core_functions/meta/module_variables.rs
@@ -284,7 +284,6 @@ mod through_forward {
     }
 
     #[test]
-    #[ignore] // wrong result
     fn test_as() {
         let runner = runner().with_cwd("as");
         assert_eq!(
@@ -297,7 +296,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn bare() {
         let runner = runner().with_cwd("bare");
         assert_eq!(
@@ -310,7 +308,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn hide() {
         let runner = runner().with_cwd("hide");
         assert_eq!(
@@ -323,7 +320,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn show() {
         let runner = runner().with_cwd("show");
         assert_eq!(

--- a/tests/spec/core_functions/meta/variable_exists.rs
+++ b/tests/spec/core_functions/meta/variable_exists.rs
@@ -196,7 +196,6 @@ mod through_forward {
     }
 
     #[test]
-    #[ignore] // wrong result
     fn test_as() {
         let runner = runner().with_cwd("as");
         assert_eq!(
@@ -212,7 +211,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn hide() {
         let runner = runner().with_cwd("hide");
         assert_eq!(
@@ -228,7 +226,6 @@ mod through_forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn show() {
         let runner = runner().with_cwd("show");
         assert_eq!(

--- a/tests/spec/core_functions/modules/general.rs
+++ b/tests/spec/core_functions/modules/general.rs
@@ -68,7 +68,6 @@ mod forward {
     }
 
     #[test]
-    #[ignore] // unexepected error
     fn test_as() {
         let runner = runner().with_cwd("as");
         assert_eq!(
@@ -80,7 +79,6 @@ mod forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn bare() {
         let runner = runner().with_cwd("bare");
         assert_eq!(
@@ -98,7 +96,6 @@ mod forward {
         }
 
         #[test]
-        #[ignore] // missing error
         fn hide() {
             let runner = runner().with_cwd("hide");
             assert_eq!(
@@ -133,7 +130,6 @@ mod forward {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn hide() {
         let runner = runner().with_cwd("hide");
         assert_eq!(
@@ -145,7 +141,6 @@ mod forward {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn show() {
         let runner = runner().with_cwd("show");
         assert_eq!(

--- a/tests/spec/directives/import/configuration.rs
+++ b/tests/spec/directives/import/configuration.rs
@@ -206,7 +206,6 @@ mod midstream_definition {
     }
 
     #[test]
-    #[ignore] // wrong result
     fn no_config() {
         let runner = runner().with_cwd("no_config");
         assert_eq!(

--- a/tests/spec/directives/test_use/css/order.rs
+++ b/tests/spec/directives/test_use/css/order.rs
@@ -39,7 +39,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn diamond() {
     let runner = runner().with_cwd("diamond");
     assert_eq!(
@@ -241,7 +240,6 @@ mod import_order {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn once() {
     let runner = runner().with_cwd("once");
     assert_eq!(
@@ -254,7 +252,6 @@ fn once() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn triangle() {
     let runner = runner().with_cwd("triangle");
     assert_eq!(

--- a/tests/spec/directives/test_use/with.rs
+++ b/tests/spec/directives/test_use/with.rs
@@ -64,7 +64,6 @@ mod core_module {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn forward() {
             let runner = runner().with_cwd("forward");
             assert_eq!(
@@ -128,7 +127,6 @@ mod multi_load {
     }
 
     #[test]
-    #[ignore] // unexepected error
     fn forward() {
         let runner = runner().with_cwd("forward");
         assert_eq!(
@@ -141,7 +139,6 @@ mod multi_load {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn transitive() {
         let runner = runner().with_cwd("transitive");
         assert_eq!(
@@ -162,7 +159,6 @@ mod multi_load {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn test_use() {
         let runner = runner().with_cwd("use");
         assert_eq!(
@@ -175,7 +171,6 @@ mod multi_load {
     }
 }
 #[test]
-#[ignore] // unexepected error
 fn multiple() {
     let runner = runner().with_cwd("multiple");
     assert_eq!(
@@ -303,7 +298,6 @@ mod through_forward {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn default() {
             let runner = runner().with_cwd("default");
             assert_eq!(
@@ -325,7 +319,7 @@ mod through_forward {
             );
         }
         #[test]
-        #[ignore] // unexepected error
+        #[ignore] // wrong result
         fn unconfigured() {
             let runner = runner().with_cwd("unconfigured");
             assert_eq!(
@@ -338,7 +332,6 @@ mod through_forward {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn with_unrelated_config() {
         let runner = runner().with_cwd("with_unrelated_config");
         assert_eq!(

--- a/tests/spec/testrunner.rs
+++ b/tests/spec/testrunner.rs
@@ -63,20 +63,13 @@ impl FileContext for TestFileContext {
         &self,
         name: &str,
     ) -> Result<Option<(Self, String, Self::File)>, Error> {
-        let (cwd, lname) = name
-            .strip_prefix("../")
-            .map(|n| {
-                (
-                    self.cwd
-                        .trim_end_matches('/')
-                        .rfind('/')
-                        .map(|p| &self.cwd[..p])
-                        .unwrap_or(""),
-                    n,
-                )
-            })
-            .unwrap_or((&self.cwd, name));
-        let tname = url_join(&cwd, lname);
+        let mut cwd: &str = &self.cwd.trim_end_matches('/');
+        let mut lname = name;
+        while let Some(name) = lname.strip_prefix("../") {
+            cwd = cwd.rfind('/').map(|p| &self.cwd[..p]).unwrap_or("");
+            lname = name;
+        }
+        let tname = url_join(cwd, lname);
 
         if let Some(data) = self.mock.get(&tname) {
             return Ok(Some((


### PR DESCRIPTION
Support most of `@forward` and `@use` with modules.  This includes support for `as`, `show`, and `hide`, and some support for `with`, though configuration can only be applied to the directly loaded module yet, not to modules used by it or forwarded into it.