### PR TITLE
struct CssString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ project adheres to
   contains a `SourcePos` for where it is declared.
 * The fields of `SourcePos` is now private.
 * The `name` of a `sass::Item::AtRule` is now a SassString.
+* PR #118: A `css::Value::Literal` now contains a `CssString` rather
+  than a `String` and a `Quotes`.  Evaluating a `SassString` also
+  returns a `CssString`.
 
 ### Improvements
 

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -56,8 +56,8 @@ impl CallArgs {
         for (k, v) in map {
             match k {
                 Value::Null => self.positional.push(v),
-                Value::Literal(s, _) => {
-                    self.named.insert(s.into(), v);
+                Value::Literal(s) => {
+                    self.named.insert(s.value().into(), v);
                 }
                 x => return Err(Error::bad_value("string", &x)),
             }

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -1,9 +1,11 @@
 //! Types for css values and rules.
 mod call_args;
 mod rule;
+mod string;
 mod value;
 mod valueformat;
 
 pub use self::call_args::CallArgs;
 pub use self::rule::{BodyItem, Rule};
+pub use self::string::CssString;
 pub use self::value::{Value, ValueMap};

--- a/src/css/string.rs
+++ b/src/css/string.rs
@@ -1,0 +1,174 @@
+use crate::value::Quotes;
+use std::convert::TryFrom;
+use std::fmt::{self, Write};
+
+/// A string in css.  May be quoted.
+#[derive(Clone, Debug, Eq, PartialOrd)]
+pub struct CssString {
+    value: String,
+    quotes: Quotes,
+}
+
+impl CssString {
+    /// Create a new CssString.
+    pub fn new(value: String, quotes: Quotes) -> Self {
+        CssString { value, quotes }
+    }
+    /// Unquote this string.
+    pub fn unquote(self) -> String {
+        if self.quotes.is_none() {
+            self.value
+        } else {
+            let mut result = String::new();
+            let mut iter = self.value.chars().peekable();
+            while let Some(c) = iter.next() {
+                if c == '\\' {
+                    let mut val: u32 = 0;
+                    let mut got_num = false;
+                    let nextchar = loop {
+                        match iter.peek() {
+                            Some(' ') if got_num => {
+                                iter.next();
+                                break (None);
+                            }
+                            Some(&c) => {
+                                if let Some(digit) = c.to_digit(16) {
+                                    val = val * 10 + digit;
+                                    got_num = true;
+                                    iter.next();
+                                } else if !got_num {
+                                    break (iter.next());
+                                } else {
+                                    break (None);
+                                }
+                            }
+                            _ => break (None),
+                        }
+                    };
+                    if got_num {
+                        // TODO: char::REPLACEMENT_CHARACTER from rust 1.52.0
+                        result
+                            .push(char::try_from(val).unwrap_or('\u{fffd}'));
+                    }
+                    match nextchar {
+                        Some('\n') => {
+                            result.push('\\');
+                            result.push('a');
+                        }
+                        Some(c) => {
+                            result.push(c);
+                        }
+                        None => (),
+                    }
+                } else {
+                    result.push(c)
+                }
+            }
+            result
+        }
+    }
+    /// If the value is name-like, make it unquoted.
+    pub fn opt_unquote(self) -> Self {
+        let mut chars = self.value.chars();
+        let t = chars.next()
+            .map(|c| c.is_alphabetic()) // first letter
+            .unwrap_or(false) // not empty
+            && chars.all(|c| c.is_alphanumeric() || c == '-');
+        CssString {
+            value: self.value,
+            quotes: if t { Quotes::None } else { self.quotes },
+        }
+    }
+    /// Quote this string
+    pub fn quote(self) -> Self {
+        let value = if self.quotes.is_none() {
+            self.value.replace('\\', "\\\\")
+        } else {
+            self.value
+        };
+        if value.contains('"') && !value.contains('\'') {
+            CssString {
+                value,
+                quotes: Quotes::Single,
+            }
+        } else {
+            CssString {
+                value,
+                quotes: Quotes::Double,
+            }
+        }
+    }
+    /// Adapt the kind of quotes as prefered for a css value.
+    pub fn pref_dquotes(self) -> Self {
+        let value = self.value;
+        let quotes = match self.quotes {
+            Quotes::Double
+                if value.contains('"') && !value.contains('\'') =>
+            {
+                Quotes::Single
+            }
+            Quotes::Single
+                if !value.contains('"') || value.contains('\'') =>
+            {
+                Quotes::Double
+            }
+            q => q,
+        };
+        CssString { value, quotes }
+    }
+    /// Return true if this is an empty unquoted string.
+    pub fn is_null(&self) -> bool {
+        self.value.is_empty() && self.quotes.is_none()
+    }
+    /// Access the string value
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+    /// Access the quotes
+    pub fn quotes(&self) -> Quotes {
+        self.quotes
+    }
+}
+
+impl From<String> for CssString {
+    fn from(value: String) -> CssString {
+        CssString {
+            value,
+            quotes: Quotes::None,
+        }
+    }
+}
+
+impl fmt::Display for CssString {
+    fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
+        let q = match self.quotes {
+            Quotes::None => return self.value.fmt(out),
+            Quotes::Double => '"',
+            Quotes::Single => '\'',
+        };
+        out.write_char(q)?;
+        for c in self.value.chars() {
+            if c == q {
+                out.write_char('\\')?;
+            }
+            out.write_char(c)?;
+        }
+        out.write_char(q)
+    }
+}
+
+impl PartialEq for CssString {
+    fn eq(&self, other: &Self) -> bool {
+        if self.quotes == other.quotes {
+            self.value == other.value
+        } else {
+            self.clone().unquote() == other.clone().unquote()
+        }
+    }
+}
+
+impl From<CssString> for crate::sass::Name {
+    fn from(s: CssString) -> Self {
+        s.value.into()
+    }
+}

--- a/src/css/valueformat.rs
+++ b/src/css/valueformat.rs
@@ -1,29 +1,13 @@
 use super::Value;
 use crate::output::Formatted;
-use crate::value::{ListSeparator, Operator, Quotes};
+use crate::value::{ListSeparator, Operator};
 use std::fmt::{self, Display, Write};
 
 impl<'a> Display for Formatted<'a, Value> {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         match *self.value {
             Value::Bang(ref s) => write!(out, "!{}", s),
-            Value::Literal(ref s, ref q) => match *q {
-                Quotes::None => write!(out, "{}", s),
-                Quotes::Double => {
-                    if s.contains('"') && !s.contains('\'') {
-                        write_sq(out, s)
-                    } else {
-                        write_dq(out, s)
-                    }
-                }
-                Quotes::Single => {
-                    if !s.contains('"') || s.contains('\'') {
-                        write_dq(out, s)
-                    } else {
-                        write_sq(out, s)
-                    }
-                }
-            },
+            Value::Literal(ref s) => s.fmt(out),
             Value::Function(ref n, ref _f) => {
                 let name = n
                     .chars()
@@ -172,25 +156,4 @@ impl<'a> Display for Formatted<'a, Value> {
             }
         }
     }
-}
-
-fn write_dq(out: &mut fmt::Formatter, s: &str) -> fmt::Result {
-    out.write_char('"')?;
-    for c in s.chars() {
-        if c == '"' {
-            out.write_char('\\')?;
-        }
-        out.write_char(c)?;
-    }
-    out.write_char('"')
-}
-fn write_sq(out: &mut fmt::Formatter, s: &str) -> fmt::Result {
-    out.write_char('\'')?;
-    for c in s.chars() {
-        if c == '\'' {
-            out.write_char('\\')?;
-        }
-        out.write_char(c)?;
-    }
-    out.write_char('\'')
 }

--- a/src/output/cssbuf.rs
+++ b/src/output/cssbuf.rs
@@ -1,6 +1,5 @@
 use super::Format;
-use crate::css::{BodyItem, Rule};
-use crate::sass::SassString;
+use crate::css::{BodyItem, CssString, Rule, Value};
 use crate::{Error, ScopeRef};
 use std::collections::BTreeMap;
 use std::io::{self, Write};
@@ -20,8 +19,8 @@ impl CssHead {
     }
     pub fn add_import(
         &mut self,
-        name: SassString,
-        args: crate::css::Value,
+        name: CssString,
+        args: Value,
     ) -> Result<(), Error> {
         self.buf.add_import(name, args)
     }
@@ -163,8 +162,8 @@ impl CssBuf {
 
     pub fn add_import(
         &mut self,
-        name: SassString,
-        args: crate::css::Value,
+        name: CssString,
+        args: Value,
     ) -> Result<(), Error> {
         self.do_indent_no_nl();
         write!(&mut self.buf, "@import {}", name)?;

--- a/src/sass/functions/color/mod.rs
+++ b/src/sass/functions/color/mod.rs
@@ -2,11 +2,11 @@ use super::{
     check, expected_to, get_checked, get_opt_check, CheckedArg, Error,
     FunctionMap,
 };
-use crate::css::{CallArgs, Value};
+use crate::css::{CallArgs, CssString, Value};
 use crate::output::Format;
 use crate::parser::SourcePos;
 use crate::sass::{ArgsError, FormalArgs, Name};
-use crate::value::{Color, Number, Numeric, Quotes, Rational, Unit};
+use crate::value::{Color, Number, Numeric, Rational, Unit};
 use crate::Scope;
 use num_traits::{one, zero, Signed};
 mod channels;
@@ -168,14 +168,16 @@ fn num2chan(v: &Numeric) -> Result<Rational, String> {
 fn is_special(v: &Value) -> bool {
     match v {
         Value::Call(..) => true,
-        Value::Literal(s, Quotes::None) if looks_like_call(s) => true,
+        Value::Literal(s) if looks_like_call(s) => true,
         Value::BinOp(..) => true,
         _ => false,
     }
 }
 
-fn looks_like_call(s: &str) -> bool {
-    s.contains('(') && s.ends_with(')')
+fn looks_like_call(s: &CssString) -> bool {
+    s.quotes().is_none()
+        && s.value().contains('(')
+        && s.value().ends_with(')')
 }
 
 fn make_call(name: &str, args: Vec<Value>) -> Value {

--- a/src/sass/functions/color/other.rs
+++ b/src/sass/functions/color/other.rs
@@ -5,7 +5,7 @@ use super::{
     FunctionMap, Name,
 };
 use crate::css::{CallArgs, Value};
-use crate::value::{Hsla, Hwba, Quotes, Rational, Rgba};
+use crate::value::{Hsla, Hwba, Rational, Rgba};
 use crate::Scope;
 use num_traits::{one, zero, Signed};
 
@@ -302,13 +302,13 @@ fn check_pct_opt_range(v: Value) -> Result<Rational, String> {
 
 fn ok_as_filterarg(v: &Value) -> bool {
     match v {
-        Value::Literal(ref s, Quotes::None) => {
+        Value::Literal(ref s) if s.quotes().is_none() => {
             use crate::parser::strings::unitname;
             use crate::parser::{code_span, util::opt_spacelike};
             use nom::bytes::complete::tag;
             use nom::sequence::tuple;
-            tuple((unitname, opt_spacelike, tag("=")))(code_span(s.as_ref()))
-                .is_ok()
+            let span = code_span(s.value().as_ref());
+            tuple((unitname, opt_spacelike, tag("=")))(span).is_ok()
         }
         Value::List(..) => true,
         _ => false,

--- a/src/sass/functions/math.rs
+++ b/src/sass/functions/math.rs
@@ -2,7 +2,7 @@ use super::{
     check, expected_to, get_checked, get_numeric, get_opt_check, get_va_list,
     Error, FunctionMap, Scope,
 };
-use crate::css::Value;
+use crate::css::{CssString, Value};
 use crate::output::Format;
 use crate::sass::Name;
 use crate::value::{Number, Numeric, Quotes, Rational, Unit, UnitSet};
@@ -191,7 +191,7 @@ pub fn create_module() -> Scope {
     def!(f, unit(number), |s| {
         let mut unit = get_numeric(s, "number")?.unit;
         unit.simplify();
-        Ok(Value::Literal(unit.to_string(), Quotes::Double))
+        Ok(CssString::new(unit.to_string(), Quotes::Double).into())
     });
 
     // - - - Other Functions - - -

--- a/src/sass/functions/mod.rs
+++ b/src/sass/functions/mod.rs
@@ -1,9 +1,9 @@
-use crate::css::{CallArgs, Value};
+use crate::css::{CallArgs, CssString, Value};
 use crate::error::Error;
 use crate::output::{Format, Formatted};
 use crate::parser::SourcePos;
 use crate::sass::{FormalArgs, Name};
-use crate::value::{ListSeparator, Numeric, Quotes};
+use crate::value::{ListSeparator, Numeric};
 use crate::{sass, Scope, ScopeRef};
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
@@ -282,10 +282,7 @@ fn get_integer(s: &Scope, name: Name) -> Result<i64, Error> {
     get_checked(s, name, check::unitless_int)
 }
 
-fn get_string(
-    s: &Scope,
-    name: &'static str,
-) -> Result<(String, Quotes), Error> {
+fn get_string(s: &Scope, name: &'static str) -> Result<CssString, Error> {
     get_checked(s, name.into(), check::string)
 }
 
@@ -316,9 +313,9 @@ where
 
 mod check {
     use super::expected_to;
-    use crate::css::Value;
+    use crate::css::{CssString, Value};
     use crate::output::Format;
-    use crate::value::{Number, Numeric, Quotes};
+    use crate::value::{Number, Numeric};
 
     pub fn numeric(v: Value) -> Result<Numeric, String> {
         v.numeric_value().map_err(|v| {
@@ -346,11 +343,11 @@ mod check {
         })
     }
 
-    pub fn string(v: Value) -> Result<(String, Quotes), String> {
+    pub fn string(v: Value) -> Result<CssString, String> {
         match v {
-            Value::Literal(s, q) => Ok((s, q)),
+            Value::Literal(s) => Ok(s),
             Value::Call(name, args) => {
-                Ok((format!("{}({})", name, args), Quotes::None))
+                Ok(format!("{}({})", name, args).into())
             }
             v => Err(format!(
                 "{} is not a string",

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -273,13 +273,13 @@ impl SelectorPart {
                 ref val,
                 ref modifier,
             } => Ok(SelectorPart::Attribute {
-                name: name.evaluate2(scope.clone())?,
+                name: name.evaluate(scope.clone())?.into(),
                 op: op.clone(),
-                val: val.evaluate_opt_unquote(scope)?,
+                val: val.evaluate(scope)?.opt_unquote().into(),
                 modifier: *modifier,
             }),
             SelectorPart::Simple(ref v) => {
-                Ok(SelectorPart::Simple(v.evaluate2(scope)?))
+                Ok(SelectorPart::Simple(v.evaluate(scope)?.into()))
             }
             SelectorPart::Pseudo { ref name, ref arg } => {
                 let arg = match &arg {
@@ -287,7 +287,7 @@ impl SelectorPart {
                     None => None,
                 };
                 Ok(SelectorPart::Pseudo {
-                    name: name.evaluate2(scope)?,
+                    name: name.evaluate(scope)?.into(),
                     arg,
                 })
             }
@@ -297,7 +297,7 @@ impl SelectorPart {
                     None => None,
                 };
                 Ok(SelectorPart::PseudoElement {
-                    name: name.evaluate2(scope)?,
+                    name: name.evaluate(scope)?.into(),
                     arg,
                 })
             }

--- a/src/value/operator.rs
+++ b/src/value/operator.rs
@@ -1,4 +1,4 @@
-use crate::css::Value;
+use crate::css::{CssString, Value};
 use crate::value::{ListSeparator, Numeric, Quotes};
 use std::fmt;
 
@@ -73,20 +73,30 @@ impl Operator {
                         None
                     }
                 }
-                (Value::Literal(a, Quotes::None), Value::Literal(b, _)) => {
-                    Some(Value::Literal(format!("{}{}", a, b), Quotes::None))
+                (Value::Literal(a), Value::Literal(b)) => {
+                    let val = format!("{}{}", a.value(), b.value());
+                    if a.quotes().is_none() {
+                        Some(CssString::new(val, Quotes::None).into())
+                    } else {
+                        Some(CssString::new(val, Quotes::Double).into())
+                    }
                 }
-                (Value::Literal(a, _), Value::Literal(b, _)) => Some(
-                    Value::Literal(format!("{}{}", a, b), Quotes::Double),
-                ),
-                (Value::Literal(a, q), b) => Some(Value::Literal(
-                    format!("{}{}", a, b.format(Default::default())),
-                    q,
-                )),
-                (a, Value::Literal(b, q)) => Some(Value::Literal(
-                    format!("{}{}", a.format(Default::default()), b),
-                    q,
-                )),
+                (Value::Literal(a), b) => {
+                    let join = format!(
+                        "{}{}",
+                        a.value(),
+                        b.format(Default::default())
+                    );
+                    Some(CssString::new(join, a.quotes()).into())
+                }
+                (a, Value::Literal(b)) => {
+                    let join = format!(
+                        "{}{}",
+                        a.format(Default::default()),
+                        b.value()
+                    );
+                    Some(CssString::new(join, b.quotes()).into())
+                }
                 _ => None,
             },
             Operator::Minus => match (a, b) {

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -1,6 +1,5 @@
 //! A scope is something that contains variable values.
-
-use crate::css::Value;
+use crate::css::{CssString, Value};
 use crate::output::Format;
 use crate::sass::{Expose, Function, Item, Mixin, Name, UseAs};
 use crate::selectors::Selectors;
@@ -252,7 +251,7 @@ impl<'a> Scope {
     }
     pub(crate) fn get_name(&self) -> String {
         match self.get_or_none(&Name::from_static("@scope_name@")) {
-            Some(Value::Literal(s, _q)) => s,
+            Some(Value::Literal(s)) => s.value().into(),
             _ => "".into(),
         }
     }
@@ -558,7 +557,7 @@ impl<'a> Scope {
         for (name, value) in &*self.functions.lock().unwrap() {
             let name = name.to_string();
             result.insert(
-                Value::Literal(name.clone(), Quotes::Double),
+                CssString::new(name.clone(), Quotes::Double).into(),
                 Value::Function(name, Some(value.clone())),
             );
         }
@@ -572,7 +571,7 @@ impl<'a> Scope {
         for (name, value) in &*self.variables.lock().unwrap() {
             if name != &Name::from_static("@scope_name@") {
                 result.insert(
-                    Value::Literal(name.to_string(), Quotes::Double),
+                    CssString::new(name.to_string(), Quotes::Double).into(),
                     value.clone(),
                 );
             }

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -427,7 +427,7 @@ fn rel() {
          \n  lt: false;\
          \n  lt: false;\
          \n  lt: false;\
-         \n}\n"
+         \n}\n",
     );
 }
 


### PR DESCRIPTION
A `css::Value::Literal` now contains a `CssString` rather than a `String` and a `Quotes`.  Evaluating a `SassString` also returns a `CssString`.