### PR TITLE
Refactor error messages.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,7 @@ impl Error {
 
     /// A generic error message.
     pub fn error<T: AsRef<str>>(msg: T) -> Self {
-        Error::S(format!("Error: {}.", msg.as_ref()))
+        Error::S(format!("Error: {}", msg.as_ref()))
     }
 }
 
@@ -89,7 +89,7 @@ impl fmt::Display for Error {
                 write!(out, "Undefined variable: \"${}\"", name)
             }
             Error::BadArgument(ref name, ref problem) => {
-                write!(out, "Error: ${}: {}.", name, problem)
+                write!(out, "Error: ${}: {}", name, problem)
             }
             Error::ParseError(ref err) => err.fmt(out),
             Error::BadCall(ref msg, ref callpos, ref declpos) => {

--- a/src/output/transform.rs
+++ b/src/output/transform.rs
@@ -50,7 +50,7 @@ fn handle_item(
             {
                 if !with.is_empty() {
                     return Err(Error::error(
-                        "Built-in modules can\'t be configured",
+                        "Built-in modules can\'t be configured.",
                     ));
                 }
                 module
@@ -74,7 +74,7 @@ fn handle_item(
                                 module.define(name.clone(), &value);
                             } else {
                                 return Err(Error::error(
-                                    "The same variable may only be configured once",
+                                    "The same variable may only be configured once.",
                                 ));
                             }
                         }
@@ -105,7 +105,7 @@ fn handle_item(
             {
                 if !with.is_empty() {
                     return Err(Error::error(
-                        "Built-in modules can\'t be configured",
+                        "Built-in modules can\'t be configured.",
                     ));
                 }
                 module
@@ -129,7 +129,7 @@ fn handle_item(
                                 module.define(name.clone(), &value);
                             } else {
                                 return Err(Error::error(
-                                    "The same variable may only be configured once",
+                                    "The same variable may only be configured once.",
                                 ));
                             }
                         }

--- a/src/sass/call_args.rs
+++ b/src/sass/call_args.rs
@@ -32,7 +32,7 @@ impl CallArgs {
             } else if named.is_empty() || is_splat(&value).is_some() {
                 positional.push(value);
             } else {
-                return Err(Error::error("positional arg after named"));
+                return Err(Error::error("positional arg after named."));
             }
         }
         Ok(CallArgs { positional, named })
@@ -61,7 +61,7 @@ impl CallArgs {
                                 result.named.insert(name, value)
                             {
                                 return Err(Error::error(
-                                    "Duplicate argument",
+                                    "Duplicate argument.",
                                 ));
                             }
                         }

--- a/src/sass/functions/color/channels.rs
+++ b/src/sass/functions/color/channels.rs
@@ -117,26 +117,26 @@ impl ChaError {
     pub fn conv(self, names: &[&'static str; 3]) -> Error {
         match self {
             Self::Bracketed => {
-                Error::error("$channels must be an unbracketed list")
+                Error::error("$channels must be an unbracketed list.")
             }
             Self::BadSep => {
-                Error::error("$channels must be a space-separated list")
+                Error::error("$channels must be a space-separated list.")
             }
             Self::Missing0 => {
-                Error::error(format!("Missing element ${}", names[0]))
+                Error::error(format!("Missing element ${}.", names[0]))
             }
             Self::Missing1 => {
-                Error::error(format!("Missing element ${}", names[1]))
+                Error::error(format!("Missing element ${}.", names[1]))
             }
             Self::Missing2 => {
-                Error::error(format!("Missing element ${}", names[2]))
+                Error::error(format!("Missing element ${}.", names[2]))
             }
             Self::BadNum(n) => Error::error(format!(
-                "Only 3 elements allowed, but {} were passed",
+                "Only 3 elements allowed, but {} were passed.",
                 n
             )),
             Self::SlashBadNum(n) => Error::error(format!(
-                "Only 2 slash-separated elements allowed, but {} {} passed",
+                "Only 2 slash-separated elements allowed, but {} {} passed.",
                 n,
                 if n == 1 { "was" } else { "were" },
             )),

--- a/src/sass/functions/color/hsl.rs
+++ b/src/sass/functions/color/hsl.rs
@@ -1,8 +1,8 @@
 use super::channels::Channels;
 use super::{
     bad_arg, check_alpha, check_pct, check_pct_range, check_rational,
-    get_checked, get_color, get_opt_check, is_special, make_call, CheckedArg,
-    FunctionMap,
+    get_checked, get_color, get_opt_check, is_not, is_special, make_call,
+    CheckedArg, FunctionMap,
 };
 use crate::css::{CallArgs, Value};
 use crate::output::Format;
@@ -38,10 +38,7 @@ pub fn register(f: &mut Scope) {
             )
         }
         v @ Value::Numeric(..) => Ok(make_call("grayscale", vec![v])),
-        v => Err(Error::BadArgument(
-            name!(color),
-            format!("{} is not a color", v.format(Format::introspect()))
-        )),
+        v => Err(is_not(&v, "a color")).named(name!(color)),
     });
 }
 
@@ -176,7 +173,7 @@ fn hsla_from_values(
     if is_special(&h) || is_special(&s) || is_special(&l) || is_special(&a) {
         Ok(make_call(fn_name.as_ref(), vec![h, s, l, a]))
     } else if l == Value::Null {
-        Err(Error::error("Missing argument $lightness"))
+        Err(Error::error("Missing argument $lightness."))
     } else {
         Ok(Hsla::new(
             check_rational(h).named(name!(hue))?,

--- a/src/sass/functions/color/hwb.rs
+++ b/src/sass/functions/color/hwb.rs
@@ -1,6 +1,7 @@
 use super::hsl::percentage;
 use super::{
-    bad_arg, check, check_alpha, check_expl_pct, get_color, CheckedArg,
+    bad_arg, check, check_alpha, check_expl_pct, get_color, is_not,
+    CheckedArg,
 };
 use crate::css::{CallArgs, Value};
 use crate::output::Format;
@@ -61,17 +62,17 @@ fn hwb_from_channels(
 ) -> Result<(Value, Value, Value, Value), Error> {
     match v {
         Value::List(_, _, true) => {
-            Err(Error::error("$channels must be an unbracketed list"))
+            Err(Error::error("$channels must be an unbracketed list."))
         }
         Value::List(_, Some(ListSeparator::Comma), _) => {
-            Err(Error::error("$channels must be a space-separated list"))
+            Err(Error::error("$channels must be a space-separated list."))
         }
         Value::List(vec, s, p) => {
             use crate::value::Operator::Div;
             match vec.len() {
-                0 => Err(Error::error("Missing element $hue")),
-                1 => Err(Error::error("Missing element $whiteness")),
-                2 => Err(Error::error("Missing element $blackness")),
+                0 => Err(Error::error("Missing element $hue.")),
+                1 => Err(Error::error("Missing element $whiteness.")),
+                2 => Err(Error::error("Missing element $blackness.")),
                 3 => {
                     if let Value::BinOp(a, _, Div, _, b) = &vec[2] {
                         if let (Value::Numeric(..), Value::Numeric(..)) =
@@ -96,18 +97,18 @@ fn hwb_from_channels(
                     }
                 }
                 n => Err(Error::error(format!(
-                    "Only 3 elements allowed, but {} were passed",
+                    "Only 3 elements allowed, but {} were passed.",
                     n
                 ))),
             }
         }
-        _hue => Err(Error::error("Missing element $whiteness")),
+        _hue => Err(Error::error("Missing element $whiteness.")),
     }
 }
 
 fn badchannels(v: &Value) -> Error {
     Error::error(format!(
-        "Expected numeric channels, got \"hwb({})\"",
+        "Expected numeric channels, got \"hwb({})\".",
         v.format(Format::introspect()),
     ))
 }
@@ -117,9 +118,6 @@ fn check_hue(v: Value) -> Result<Rational, String> {
     if let Some(scaled) = vv.as_unit_def(Unit::Deg) {
         Ok(scaled.as_ratio()?)
     } else {
-        Err(format!(
-            "{} is not an angle",
-            vv.format(Format::introspect()),
-        ))
+        Err(is_not(&vv, "an angle"))
     }
 }

--- a/src/sass/functions/color/mod.rs
+++ b/src/sass/functions/color/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    check, expected_to, get_checked, get_opt_check, CheckedArg, Error,
-    FunctionMap,
+    check, expected_to, get_checked, get_opt_check, is_not, CheckedArg,
+    Error, FunctionMap,
 };
 use crate::css::{CallArgs, CssString, Value};
 use crate::output::Format;
@@ -64,9 +64,7 @@ fn get_color(s: &Scope, name: &'static str) -> Result<Color, Error> {
 fn check_color(v: Value) -> Result<Color, String> {
     match v {
         Value::Color(col, _) => Ok(col),
-        v => {
-            Err(format!("{} is not a color", v.format(Format::introspect())))
-        }
+        v => Err(is_not(&v, "a color")),
     }
 }
 

--- a/src/sass/functions/color/other.rs
+++ b/src/sass/functions/color/other.rs
@@ -22,7 +22,7 @@ pub fn register(f: &mut Scope) {
         let mut args = CallArgs::from_value(s.get("kwargs")?)?;
         if !args.positional.is_empty() {
             return Err(Error::error("Only one positional argument is allowed. \
-                                     All other arguments must be passed by name"));
+                                     All other arguments must be passed by name."));
         }
         let red = take_opt(&mut args, name!(red), check_channel_pm)?;
         let gre = take_opt(&mut args, name!(green), check_channel_pm)?;
@@ -36,33 +36,26 @@ pub fn register(f: &mut Scope) {
         args.check_no_named()?;
 
         if red.is_some() || gre.is_some() || blu.is_some() {
-            if bla.is_some() || whi.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HWB parameters"))
-            } else if hue.is_some() || sat.is_some() || lig.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HSL parameters"))
-            } else {
-                let rgba = rgba.to_rgba();
-                Ok(Rgba::new(
-                    opt_add(rgba.red(), red),
-                    opt_add(rgba.green(), gre),
-                    opt_add(rgba.blue(), blu),
-                    opt_add(rgba.alpha(), a_adj),
-                )
-                .into())
-            }
+            check_none(&[bla, whi], "RGB", "HWB")?;
+            check_none(&[hue, sat, lig], "RGB", "HSL")?;
+            let rgba = rgba.to_rgba();
+            Ok(Rgba::new(
+                opt_add(rgba.red(), red),
+                opt_add(rgba.green(), gre),
+                opt_add(rgba.blue(), blu),
+                opt_add(rgba.alpha(), a_adj),
+            )
+            .into())
         } else if bla.is_some() || whi.is_some() {
-            if sat.is_some() || lig.is_some() {
-                Err(Error::error("HSL parameters may not be passed along with HWB parameters"))
-            } else {
-                let hwba = rgba.to_hwba();
-                Ok(Hwba::new(
-                    opt_add(hwba.hue(), hue),
-                    opt_add(hwba.whiteness(), whi),
-                    opt_add(hwba.blackness(), bla),
-                    opt_add(hwba.alpha(), a_adj),
-                )
-                .into())
-            }
+            check_none(&[sat, lig], "HSL", "HWB")?;
+            let hwba = rgba.to_hwba();
+            Ok(Hwba::new(
+                opt_add(hwba.hue(), hue),
+                opt_add(hwba.whiteness(), whi),
+                opt_add(hwba.blackness(), bla),
+                opt_add(hwba.alpha(), a_adj),
+            )
+            .into())
         } else {
             let hsla = rgba.to_hsla();
             Ok(Hsla::new(
@@ -93,7 +86,7 @@ pub fn register(f: &mut Scope) {
         let mut args = CallArgs::from_value(s.get("kwargs")?)?;
         if !args.positional.is_empty() {
             return Err(Error::error("Only one positional argument is allowed. \
-                                     All other arguments must be passed by name"));
+                                     All other arguments must be passed by name."));
         }
         let red = take_opt(&mut args, name!(red), check_pct_expl_pm)?;
         let gre = take_opt(&mut args, name!(green), check_pct_expl_pm)?;
@@ -106,20 +99,16 @@ pub fn register(f: &mut Scope) {
         args.check_no_named()?;
 
         if red.is_some() || gre.is_some() || blu.is_some() {
-            if bla.is_some() || whi.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HWB parameters"))
-            } else if sat.is_some() || lig.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HSL parameters"))
-            } else {
-                let rgba = rgba.to_rgba();
-                Ok(Rgba::new(
-                    cmb(rgba.red(), red, ff),
-                    cmb(rgba.green(), gre, ff),
-                    cmb(rgba.blue(), blu, ff),
-                    cmb(rgba.alpha(), a_adj, one),
-                )
-                .into())
-            }
+            check_none(&[bla, whi], "RGB", "HWB")?;
+            check_none(&[sat, lig], "RGB", "HSL")?;
+            let rgba = rgba.to_rgba();
+            Ok(Rgba::new(
+                cmb(rgba.red(), red, ff),
+                cmb(rgba.green(), gre, ff),
+                cmb(rgba.blue(), blu, ff),
+                cmb(rgba.alpha(), a_adj, one),
+            )
+            .into())
         } else if bla.is_none() && whi.is_none() {
             let hsla = rgba.to_hsla();
             Ok(Hsla::new(
@@ -129,11 +118,8 @@ pub fn register(f: &mut Scope) {
                 cmb(hsla.alpha(), a_adj, one),
             )
             .into())
-        } else if sat.is_some() || lig.is_some() {
-            Err(Error::error(
-                "HSL parameters may not be passed along with HWB parameters",
-            ))
         } else {
+            check_none(&[sat, lig], "HSL", "HWB")?;
             let hwba = rgba.to_hwba();
             Ok(Hwba::new(
                 hwba.hue(),
@@ -164,7 +150,7 @@ pub fn register(f: &mut Scope) {
         let mut args = CallArgs::from_value(s.get("kwargs")?)?;
         if !args.positional.is_empty() {
             return Err(Error::error("Only one positional argument is allowed. \
-                                     All other arguments must be passed by name"));
+                                     All other arguments must be passed by name."));
         }
         let red = take_opt(&mut args, name!(red), check_channel_range)?;
         let gre = take_opt(&mut args, name!(green), check_channel_range)?;
@@ -179,20 +165,16 @@ pub fn register(f: &mut Scope) {
         args.check_no_named()?;
 
         if red.is_some() || gre.is_some() || blu.is_some() {
-            if hue.is_some() || sat.is_some() || lig.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HSL parameters"))
-            } else if bla.is_some() || whi.is_some() {
-                Err(Error::error("RGB parameters may not be passed along with HWB parameters"))
-            } else {
-                let rgba = rgba.to_rgba();
-                Ok(Rgba::new(
-                    red.unwrap_or_else(|| rgba.red()),
-                    gre.unwrap_or_else(|| rgba.green()),
-                    blu.unwrap_or_else(|| rgba.blue()),
-                    alp.unwrap_or_else(|| rgba.alpha()),
-                )
-                .into())
-            }
+            check_none(&[hue, sat, lig], "RGB", "HSL")?;
+            check_none(&[bla, whi], "RGB", "HWB")?;
+            let rgba = rgba.to_rgba();
+            Ok(Rgba::new(
+                red.unwrap_or_else(|| rgba.red()),
+                gre.unwrap_or_else(|| rgba.green()),
+                blu.unwrap_or_else(|| rgba.blue()),
+                alp.unwrap_or_else(|| rgba.alpha()),
+            )
+            .into())
         } else if bla.is_none() && whi.is_none() {
             let hsla = rgba.to_hsla();
             Ok(Hsla::new(
@@ -202,11 +184,8 @@ pub fn register(f: &mut Scope) {
                 alp.unwrap_or_else(|| hsla.alpha()),
             )
             .into())
-        } else if sat.is_some() || lig.is_some() {
-            Err(Error::error(
-                "HSL parameters may not be passed along with HWB parameters",
-            ))
         } else {
+            check_none(&[sat, lig], "HSL", "HWB")?;
             let hwba = rgba.to_hwba();
             Ok(Hwba::new(
                 hue.unwrap_or_else(|| hwba.hue()),
@@ -254,6 +233,21 @@ pub fn expose(m: &Scope, global: &mut FunctionMap) {
         (name!(transparentize), name!(fade_out)),
     ] {
         global.insert(gname.clone(), f.get_lfunction(lname));
+    }
+}
+
+fn check_none(
+    args: &[Option<Rational>],
+    kind: &str,
+    with_kind: &str,
+) -> Result<(), Error> {
+    if args.iter().all(|v| v.is_none()) {
+        Ok(())
+    } else {
+        Err(Error::error(format!(
+            "{} parameters may not be passed along with {} parameters.",
+            kind, with_kind
+        )))
     }
 }
 

--- a/src/sass/functions/color/rgb.rs
+++ b/src/sass/functions/color/rgb.rs
@@ -1,11 +1,10 @@
 use super::channels::Channels;
 use super::{
     bad_arg, check_alpha, check_channel, check_color, check_pct_range,
-    get_checked, get_color, is_special, make_call, CheckedArg, Error,
+    get_checked, get_color, is_not, is_special, make_call, CheckedArg, Error,
     FunctionMap,
 };
 use crate::css::{CallArgs, Value};
-use crate::output::Format;
 use crate::sass::{ArgsError, FormalArgs, Name};
 use crate::value::{Rational, Rgba};
 use crate::{Scope, ScopeRef};
@@ -77,14 +76,10 @@ pub fn register(f: &mut Scope) {
                         v @ Value::Numeric(..) => {
                             Ok(make_call("invert", vec![v]))
                         }
-                        v => Err(format!(
-                            "{} is not a color",
-                            v.format(Format::introspect())
-                        ))
-                        .named(name!(color)),
+                        v => Err(is_not(&v, "a color")).named(name!(color)),
                     }
                 } else {
-                    Err(Error::error("Only one argument may be passed to the plain-CSS invert() function"))
+                    Err(Error::error("Only one argument may be passed to the plain-CSS invert() function."))
                 }
             }
         }

--- a/src/sass/functions/list.rs
+++ b/src/sass/functions/list.rs
@@ -179,7 +179,8 @@ fn check_separator(v: Value) -> Result<Option<ListSeparator>, String> {
         "space" => Ok(Some(ListSeparator::Space)),
         "auto" => Ok(None),
         _ => {
-            Err("Must be \"space\", \"comma\", \"slash\", or \"auto\"".into())
+            Err("Must be \"space\", \"comma\", \"slash\", or \"auto\"."
+                .into())
         }
     }
 }
@@ -236,9 +237,9 @@ fn rust_index(n: i64, len: usize, name: Name) -> Result<usize, Error> {
         Ok((len as i64 + n) as usize)
     } else {
         let msg = if n == 0 {
-            "List index may not be 0".into()
+            "List index may not be 0.".into()
         } else {
-            format!("Invalid index {} for a list with {} elements", n, len)
+            format!("Invalid index {} for a list with {} elements.", n, len)
         };
         Err(Error::BadArgument(name, msg))
     }

--- a/src/sass/functions/map.rs
+++ b/src/sass/functions/map.rs
@@ -1,6 +1,5 @@
-use super::{get_checked, CheckedArg, Error, FunctionMap, Name};
+use super::{get_checked, is_not, CheckedArg, Error, FunctionMap, Name};
 use crate::css::{Value, ValueMap};
-use crate::output::Format;
 use crate::value::ListSeparator;
 use crate::{Scope, ScopeRef};
 use std::convert::TryInto;
@@ -109,7 +108,7 @@ pub fn create_module() -> Scope {
                     let map2 = values
                         .pop()
                         .ok_or_else(|| {
-                            Error::error("Expected $args to contain a key")
+                            Error::error("Expected $args to contain a key.")
                         })?
                         .try_into()
                         .named(name!(map2))?;
@@ -149,7 +148,7 @@ pub fn create_module() -> Scope {
                         map.remove(&key);
                     } else {
                         return Err(Error::error(
-                            "Argument $key was passed both by position and by name"
+                            "Argument $key was passed both by position and by name."
                         ));
                     }
                 }
@@ -207,10 +206,7 @@ impl TryInto<ValueMap> for Value {
             Value::Map(m) => Ok(m),
             // An empty map and an empty list looks the same
             Value::List(ref l, ..) if l.is_empty() => Ok(ValueMap::new()),
-            v => Err(format!(
-                "{} is not a map",
-                &v.format(Format::introspect())
-            )),
+            v => Err(is_not(&v, "a map")),
         }
     }
 }
@@ -291,7 +287,7 @@ fn set(s: &ScopeRef) -> Result<Value, Error> {
             };
             let key = args.named.remove(&"key".into());
             if key.is_none() && keys.is_none() && args.positional.is_empty() {
-                return Err(Error::error("Expected $args to contain a key"));
+                return Err(Error::error("Expected $args to contain a key."));
             }
             let value = args
                 .named
@@ -307,7 +303,7 @@ fn set(s: &ScopeRef) -> Result<Value, Error> {
                     }
                 })
                 .ok_or_else(|| {
-                    Error::error("Expected $args to contain a value")
+                    Error::error("Expected $args to contain a value.")
                 })?;
 
             let mut keys = match (keys, args.positional.is_empty()) {
@@ -315,7 +311,7 @@ fn set(s: &ScopeRef) -> Result<Value, Error> {
                 (None, _) => args.positional,
                 (Some(_), false) => {
                     return Err(Error::error(
-                        "Got $keys both by name and by position",
+                        "Got $keys both by name and by position.",
                     ))
                 }
             };
@@ -328,7 +324,7 @@ fn set(s: &ScopeRef) -> Result<Value, Error> {
             if let Some(value) = v.pop() {
                 Ok(Value::Map(set_inner(map, &v, value)?))
             } else {
-                Err(Error::error("Expected $args to contain a key"))
+                Err(Error::error("Expected $args to contain a key."))
             }
         }
         Value::Map(mut args) => {
@@ -341,11 +337,11 @@ fn set(s: &ScopeRef) -> Result<Value, Error> {
                 keys.push(key);
             }
             let value = args.remove(&"value".into()).ok_or_else(|| {
-                Error::error("Expected $args to contain a value")
+                Error::error("Expected $args to contain a value.")
             })?;
             Ok(Value::Map(set_inner(map, &keys, value)?))
         }
-        _ => Err(Error::error("Expected $args to contain a value")),
+        _ => Err(Error::error("Expected $args to contain a value.")),
     }
 }
 fn set_inner(
@@ -366,7 +362,7 @@ fn set_inner(
         map.insert(key.clone(), value);
         Ok(map)
     } else {
-        Err(Error::error("Expected $args to contain a value"))
+        Err(Error::error("Expected $args to contain a value."))
     }
 }
 

--- a/src/sass/functions/mod.rs
+++ b/src/sass/functions/mod.rs
@@ -302,7 +302,7 @@ where
     Formatted<'a, T>: std::fmt::Display,
 {
     format!(
-        "Expected {} to {}",
+        "Expected {} to {}.",
         Formatted {
             value,
             format: Format::introspect()
@@ -310,22 +310,33 @@ where
         cond,
     )
 }
+fn is_not<'a, T>(value: &'a T, expected: &str) -> String
+where
+    Formatted<'a, T>: std::fmt::Display,
+{
+    format!(
+        "{} is not {}.",
+        Formatted {
+            value,
+            format: Format::introspect()
+        },
+        expected,
+    )
+}
 
 mod check {
-    use super::expected_to;
+    use super::{expected_to, is_not};
     use crate::css::{CssString, Value};
-    use crate::output::Format;
     use crate::value::{Number, Numeric};
 
     pub fn numeric(v: Value) -> Result<Numeric, String> {
-        v.numeric_value().map_err(|v| {
-            format!("{} is not a number", v.format(Format::introspect()))
-        })
+        v.numeric_value().map_err(|v| is_not(&v, "a number"))
     }
     pub fn int(v: Value) -> Result<i64, String> {
-        numeric(v)?.value.into_integer().map_err(|v| {
-            format!("{} is not an int", v.format(Format::introspect()))
-        })
+        numeric(v)?
+            .value
+            .into_integer()
+            .map_err(|v| is_not(&v, "an int"))
     }
 
     pub fn unitless(v: Value) -> Result<Number, String> {
@@ -337,10 +348,9 @@ mod check {
         }
     }
     pub fn unitless_int(v: Value) -> Result<i64, String> {
-        let v0 = unitless(v)?;
-        v0.into_integer().map_err(|v| {
-            format!("{} is not an int", v.format(Format::introspect()))
-        })
+        unitless(v)?
+            .into_integer()
+            .map_err(|v| is_not(&v, "an int"))
     }
 
     pub fn string(v: Value) -> Result<CssString, String> {
@@ -349,10 +359,7 @@ mod check {
             Value::Call(name, args) => {
                 Ok(format!("{}({})", name, args).into())
             }
-            v => Err(format!(
-                "{} is not a string",
-                v.format(Format::introspect())
-            )),
+            v => Err(is_not(&v, "a string")),
         }
     }
 }

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -169,7 +169,7 @@ impl Value {
                     let k = k.do_evaluate(scope.clone(), arithmetic)?;
                     let v = v.do_evaluate(scope.clone(), arithmetic)?;
                     if items.insert(k, v).is_some() {
-                        return Err(Error::error("Duplicate key"));
+                        return Err(Error::error("Duplicate key."));
                     }
                 }
                 Ok(css::Value::Map(items))

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -453,11 +453,11 @@ impl<'a> Scope {
                 if let Some(f) = module.get_function(&name)? {
                     Ok(Some(f))
                 } else {
-                    Err(Error::error("Undefined function"))
+                    Err(Error::error("Undefined function."))
                 }
             } else {
                 return Err(Error::error(format!(
-                    "There is no module with the namespace {:?}",
+                    "There is no module with the namespace {:?}.",
                     modulename
                 )));
             }


### PR DESCRIPTION
Mainly move the period to end of each sentence, rather than "magically" appending it after errors.  Also create and use a `is_not` function for error messages of the form "actual is not expected".