### PR TITLE
Refactor file handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ project adheres to
 
 ## Unreleased
 
+### Breaking changes
+
+* The functions `parse_scss_file` and `parse_scss_path` is removed.
+  Use `SourceFile` (maybe from a `FileContext`) instead (PR #132).
+* Some API changes (mayinly using `SourceFile` as return type) in
+  `FileContext` and `FsF ileContext` (PR #132).
+
+### Improvements
+
+* Refactor source file handling.  Instead of creating new FileContexts
+  wrapping the original for each file for searching for local paths in
+  that file, use the SourceName of the containing file to find local
+  paths (PR #132).
 * Detect `@import` loops.
 * Enable clippy in CI and fix some things it complained about (PR #128).
 * Update sass-spec test suite to 2022-02-24.

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -83,7 +83,7 @@ pub trait FileContext: Sized + std::fmt::Debug {
                 &|base, name| format!("{}{}/_index.scss", base, name),
             ],
         )? {
-            let source = SourceName::imported(path, from);
+            let source = SourceName::imported(path, from); // ???
             Ok(Some(SourceFile::read(&mut file, source)?))
         } else {
             Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@ pub use crate::error::Error;
 pub use crate::file_context::{FileContext, FsFileContext};
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_scss_file, parse_scss_path, parse_value_data,
-    ParseError, SourceName, SourcePos,
+    parse_scss_data, parse_value_data, ParseError, SourceFile, SourceName,
+    SourcePos,
 };
 pub use crate::variablescope::{Scope, ScopeRef};
 
@@ -129,7 +129,7 @@ pub fn compile_scss_path(
     format: Format,
 ) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
-    let (sub_context, path) = file_context.file(path);
-    let items = parse_scss_path(&path)?;
-    format.write_root(&items, ScopeRef::new_global(format), &sub_context)
+    let source = file_context.file(path)?;
+    let items = source.parse()?;
+    format.write_root(&items, ScopeRef::new_global(format), &file_context)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use rsass::{
     output::{Format, Style},
-    parse_scss_path, Error, FsFileContext, ScopeRef,
+    Error, FsFileContext, ScopeRef,
 };
 use std::io::{stdout, Write};
 use std::path::PathBuf;
@@ -82,12 +82,12 @@ impl Args {
             if let Some(include_path) = &self.load_path {
                 file_context.push_path(include_path.as_ref());
             }
-            let (sub_context, path) = file_context.file(name.as_ref());
-            let items = parse_scss_path(&path)?;
+            let source = file_context.file(name.as_ref())?;
+            let items = source.parse()?;
             let result = format.write_root(
                 &items,
                 ScopeRef::new_global(format),
-                &sub_context,
+                &file_context,
             )?;
             let out = stdout();
             out.lock().write_all(&result)?;

--- a/src/parser/pos.rs
+++ b/src/parser/pos.rs
@@ -178,6 +178,9 @@ impl SourcePos {
     pub(crate) fn same_file_as(&self, other: &Self) -> bool {
         self.p.file.name == other.p.file.name
     }
+    pub(crate) fn file_url(&self) -> &str {
+        &self.p.file.name
+    }
 }
 
 impl From<Span<'_>> for SourcePos {


### PR DESCRIPTION
### Breaking changes

* The functions `parse_scss_file` and `parse_scss_path` is removed. Use `SourceFile` (maybe from a `FileContext`) instead.
* Some API changes (mayinly using `SourceFile` as return type) in `FileContext` and `FsF ileContext`.

### Improvements

* Refactor source file handling.  Instead of creating new FileContexts wrapping the original for each file for searching for local paths in that file, use the SourceName of the containing file to find local paths.
