### PR TITLE
Parse `.css` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ project adheres to
 
 ## Unreleased
 
+### Breaking changes
+
 * Update minimum supported rust version to 1.49.0 (from 1.45.2).
+* `SourceFile.parse()` now returns a `Result<Parsed>` rahter than a
+  `Result<Vec<sass::Item>>`, and `Format::write_root` now takes a
+  `Parsed` (PR #140).
+
+### Improvements
+
+* Rsass can now parse (some) plain css as well as scss.  Css files can
+  be referenced in `@use` and `@import` directives, as well as in the
+  `meta.load-css` mixin (PR #140).
 * Make the `calc(...)` function signal an error when args are known to
   be invalid css (PR #138).
 * Change `map.deep-merge` to match recent change in dart sass.

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -110,9 +110,10 @@ impl fmt::Display for CallArgs {
             .positional
             .iter()
             .map(|v| format!("{}", v.format(Default::default())));
-        let named = self.named.iter().map(|(k, v)| {
-            format!("${}: {}", k, v.format(Default::default()))
-        });
+        let named = self
+            .named
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v.format(Default::default())));
         let t = pos.chain(named).collect::<Vec<_>>().join(", ");
         write!(out, "{}", t)
     }

--- a/src/css/comment.rs
+++ b/src/css/comment.rs
@@ -1,0 +1,48 @@
+use crate::output::CssBuf;
+use std::cmp::Ordering;
+
+/// A comment in a css file.
+pub struct Comment(String);
+
+impl<T: Into<String>> From<T> for Comment {
+    fn from(t: T) -> Comment {
+        Comment(t.into())
+    }
+}
+
+impl Comment {
+    /// Write this comment to a css output buffer.
+    pub fn write(&self, buf: &mut CssBuf) {
+        let indent = buf.indent_level();
+        let existing = self
+            .0
+            .lines()
+            .skip(1)
+            .map(|s| {
+                let i = s.bytes().take_while(|b| *b == b' ').count();
+                if s.as_bytes().get(i).unwrap_or(&b'*') == &b'*' {
+                    i
+                } else {
+                    i.saturating_sub(2)
+                }
+            })
+            .min()
+            .unwrap_or(indent);
+
+        buf.add_str("/*");
+        match indent.cmp(&existing) {
+            Ordering::Greater => {
+                let start = buf.format().get_indent(indent - existing);
+                buf.add_str(&self.0.replace('\n', start));
+            }
+            Ordering::Less => {
+                let start = buf.format().get_indent(existing - indent - 1);
+                buf.add_str(&self.0.replace(start, "\n"));
+            }
+            Ordering::Equal => {
+                buf.add_str(&self.0);
+            }
+        }
+        buf.add_str("*/");
+    }
+}

--- a/src/css/comment.rs
+++ b/src/css/comment.rs
@@ -2,6 +2,7 @@ use crate::output::CssBuf;
 use std::cmp::Ordering;
 
 /// A comment in a css file.
+#[derive(Clone, Debug)]
 pub struct Comment(String);
 
 impl<T: Into<String>> From<T> for Comment {
@@ -12,7 +13,7 @@ impl<T: Into<String>> From<T> for Comment {
 
 impl Comment {
     /// Write this comment to a css output buffer.
-    pub fn write(&self, buf: &mut CssBuf) {
+    pub(crate) fn write(&self, buf: &mut CssBuf) {
         let indent = buf.indent_level();
         let existing = self
             .0
@@ -29,6 +30,7 @@ impl Comment {
             .min()
             .unwrap_or(indent);
 
+        buf.do_indent_no_nl();
         buf.add_str("/*");
         match indent.cmp(&existing) {
             Ordering::Greater => {
@@ -43,6 +45,6 @@ impl Comment {
                 buf.add_str(&self.0);
             }
         }
-        buf.add_str("*/");
+        buf.add_one("*/\n", "*/");
     }
 }

--- a/src/css/item.rs
+++ b/src/css/item.rs
@@ -1,0 +1,118 @@
+use super::{Comment, CssString, Property, Rule, Value};
+use crate::output::CssBuf;
+use std::io::{self, Write};
+
+/// A top-level item in a css file.
+#[derive(Clone, Debug)]
+pub enum Item {
+    /// A comment
+    Comment(Comment),
+    /// A css import statement
+    Import(Import),
+    /// A css rule.
+    Rule(Rule),
+    /// An `@` rule, e.g. `@media ... { ... }`
+    AtRule(String, String, Vec<AtRuleBodyItem>),
+}
+
+impl Item {
+    pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
+        match self {
+            Item::Comment(comment) => comment.write(buf),
+            Item::Import(import) => import.write(buf)?,
+            Item::Rule(rule) => rule.write(buf)?,
+            Item::AtRule(name, args, body) => {
+                write!(buf, "@{}", name)?;
+                if !args.is_empty() {
+                    write!(buf, " {}", args)?;
+                }
+                buf.start_block();
+                for item in body {
+                    item.write(buf)?;
+                }
+                buf.end_block();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<Comment> for Item {
+    fn from(comment: Comment) -> Item {
+        Item::Comment(comment)
+    }
+}
+impl From<Import> for Item {
+    fn from(import: Import) -> Item {
+        Item::Import(import)
+    }
+}
+impl From<Rule> for Item {
+    fn from(rule: Rule) -> Item {
+        Item::Rule(rule)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AtRuleBodyItem {
+    Import(Import),
+    Comment(Comment),
+    Rule(Rule),
+    Property(Property),
+}
+impl AtRuleBodyItem {
+    pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
+        match self {
+            AtRuleBodyItem::Import(import) => import.write(buf)?,
+            AtRuleBodyItem::Comment(comment) => comment.write(buf),
+            AtRuleBodyItem::Rule(rule) => rule.write(buf)?,
+            AtRuleBodyItem::Property(property) => property.write(buf),
+        }
+        Ok(())
+    }
+}
+impl From<Rule> for AtRuleBodyItem {
+    fn from(rule: Rule) -> Self {
+        AtRuleBodyItem::Rule(rule)
+    }
+}
+impl From<Comment> for AtRuleBodyItem {
+    fn from(rule: Comment) -> Self {
+        AtRuleBodyItem::Comment(rule)
+    }
+}
+impl From<Import> for AtRuleBodyItem {
+    fn from(rule: Import) -> Self {
+        AtRuleBodyItem::Import(rule)
+    }
+}
+impl From<Property> for AtRuleBodyItem {
+    fn from(rule: Property) -> Self {
+        AtRuleBodyItem::Property(rule)
+    }
+}
+
+/// An `@import` rule in css.
+#[derive(Clone, Debug)]
+pub struct Import {
+    name: CssString,
+    args: Value,
+}
+
+impl Import {
+    /// Create a new `@import`.
+    pub fn new(name: CssString, args: Value) -> Self {
+        Import { name, args }
+    }
+
+    /// Write this comment to a css output buffer.
+    pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
+        buf.do_indent_no_nl();
+        write!(buf, "@import {}", self.name)?;
+        if !self.args.is_null() {
+            write!(buf, " {}", self.args.format(buf.format()))?;
+        }
+        buf.add_one(";\n", ";");
+        Ok(())
+    }
+}

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -1,6 +1,7 @@
 //! Types for css values and rules.
 mod call_args;
 mod comment;
+mod item;
 mod rule;
 mod selectors;
 mod string;
@@ -10,7 +11,8 @@ mod valueformat;
 
 pub use self::call_args::CallArgs;
 pub use self::comment::Comment;
-pub use self::rule::{BodyItem, Import, Rule};
+pub use self::item::{Import, Item};
+pub use self::rule::{BodyItem, Property, Rule};
 pub use self::selectors::{BadSelector, Selector, SelectorPart, Selectors};
 pub use self::string::CssString;
 pub use self::value::{Value, ValueMap, ValueToMapError};

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -1,5 +1,6 @@
 //! Types for css values and rules.
 mod call_args;
+mod comment;
 mod rule;
 mod selectors;
 mod string;
@@ -8,7 +9,8 @@ mod value;
 mod valueformat;
 
 pub use self::call_args::CallArgs;
-pub use self::rule::{BodyItem, Rule};
+pub use self::comment::Comment;
+pub use self::rule::{BodyItem, Import, Rule};
 pub use self::selectors::{BadSelector, Selector, SelectorPart, Selectors};
 pub use self::string::CssString;
 pub use self::value::{Value, ValueMap, ValueToMapError};

--- a/src/css/rule.rs
+++ b/src/css/rule.rs
@@ -1,4 +1,4 @@
-use super::{Comment, CssString, Selectors, Value};
+use super::{Comment, CssString, Import, Selectors, Value};
 use crate::output::CssBuf;
 use std::io::{self, Write};
 
@@ -6,6 +6,7 @@ use std::io::{self, Write};
 ///
 /// A rule binds [`Selectors`] to a body of [`BodyItem`]s (mainly
 /// properties with [`Value`]s).
+#[derive(Clone, Debug)]
 pub struct Rule {
     pub(crate) selectors: Selectors,
     pub(crate) body: Vec<BodyItem>,
@@ -23,17 +24,11 @@ impl Rule {
     pub fn push(&mut self, item: BodyItem) {
         self.body.push(item)
     }
-}
 
-impl Rule {
     /// Write this rule to a css output buffer.
-    pub fn write(&self, buf: &mut CssBuf, skip_nl: bool) -> io::Result<()> {
+    pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
         if !self.body.is_empty() {
-            if skip_nl {
-                buf.do_indent_no_nl();
-            } else {
-                buf.do_indent();
-            }
+            buf.do_indent_no_nl();
             if buf.format().is_compressed() {
                 write!(buf, "{:#}", self.selectors)?;
             } else {
@@ -50,11 +45,12 @@ impl Rule {
 }
 
 /// Something that may exist inside a rule.
+#[derive(Clone, Debug)]
 pub enum BodyItem {
     /// An `@import` statement with a name and args.
     Import(Import),
     /// A property declaration with a name and a value.
-    Property(String, Value),
+    Property(Property),
     /// A property declaration with a name and a value.
     CustomProperty(String, CssString),
     /// A comment
@@ -63,65 +59,80 @@ pub enum BodyItem {
 
 impl BodyItem {
     /// Write this item to a css output buffer.
-    pub fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
-        buf.do_indent();
+    pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
         match self {
-            BodyItem::Import(ref import) => import.write(buf),
-            BodyItem::Property(ref name, ref val) => write!(
-                buf,
-                "{}:{}{};",
-                name,
-                if buf.format().is_compressed() {
-                    ""
-                } else {
-                    " "
-                },
-                val.format(buf.format()).to_string().replace('\n', " "),
-            ),
-            BodyItem::CustomProperty(ref name, ref val) => write!(
-                buf,
-                "{}:{}{};",
-                name,
-                if val.quotes().is_none() || buf.format().is_compressed() {
-                    ""
-                } else {
-                    " "
-                },
-                val,
-            ),
-            BodyItem::Comment(ref c) => {
-                c.write(buf);
-                Ok(())
+            BodyItem::Comment(c) => c.write(buf),
+            BodyItem::Import(import) => import.write(buf)?,
+            BodyItem::Property(property) => property.write(buf),
+            BodyItem::CustomProperty(ref name, ref val) => {
+                buf.do_indent_no_nl();
+                write!(
+                    buf,
+                    "{}:{}{}",
+                    name,
+                    if val.quotes().is_none() || buf.format().is_compressed()
+                    {
+                        ""
+                    } else {
+                        " "
+                    },
+                    val,
+                )?;
+                buf.add_one(";\n", ";");
             }
         }
-    }
-}
-
-/// An `@import` rule in css.
-pub struct Import {
-    name: CssString,
-    args: Value,
-}
-
-impl Import {
-    /// Create a new `@import`.
-    pub fn new(name: CssString, args: Value) -> Self {
-        Import { name, args }
-    }
-
-    /// Write this comment to a css output buffer.
-    pub fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
-        write!(buf, "@import {}", self.name)?;
-        if !self.args.is_null() {
-            write!(buf, " {}", self.args.format(buf.format()))?;
-        }
-        buf.add_one(";\n", ";");
         Ok(())
     }
 }
 
+impl From<Comment> for BodyItem {
+    fn from(comment: Comment) -> BodyItem {
+        BodyItem::Comment(comment)
+    }
+}
 impl From<Import> for BodyItem {
     fn from(import: Import) -> BodyItem {
         BodyItem::Import(import)
+    }
+}
+impl From<Property> for BodyItem {
+    fn from(property: Property) -> BodyItem {
+        BodyItem::Property(property)
+    }
+}
+
+/// A css property; a name and [Value].
+#[derive(Clone, Debug)]
+pub struct Property {
+    name: String,
+    value: Value,
+}
+
+impl Property {
+    /// Create a new Property.
+    pub fn new(name: String, value: Value) -> Self {
+        Property { name, value }
+    }
+    /// Return this property but with a prefix.
+    ///
+    /// The prefix is separated from the old name with a dash.
+    pub fn prefix(self, prefix: &str) -> Self {
+        Property {
+            name: format!("{}-{}", prefix, self.name),
+            value: self.value,
+        }
+    }
+    pub(crate) fn write(&self, buf: &mut CssBuf) {
+        buf.do_indent_no_nl();
+        buf.add_str(&self.name);
+        buf.add_one(": ", ":");
+        buf.add_str(
+            &self
+                .value
+                .format(buf.format())
+                .to_string()
+                .replace('\n', " "),
+        );
+        buf.add_one(";\n", ";");
     }
 }

--- a/src/css/rule.rs
+++ b/src/css/rule.rs
@@ -1,4 +1,6 @@
-use super::{CssString, Selectors, Value};
+use super::{Comment, CssString, Selectors, Value};
+use crate::output::CssBuf;
+use std::io::{self, Write};
 
 /// A css rule.
 ///
@@ -21,20 +23,105 @@ impl Rule {
     pub fn push(&mut self, item: BodyItem) {
         self.body.push(item)
     }
-    /// Add an import statement to the body of this rule.
-    pub fn add_import(&mut self, name: CssString, args: Value) {
-        self.body.push(BodyItem::Import(name, args))
+}
+
+impl Rule {
+    /// Write this rule to a css output buffer.
+    pub fn write(&self, buf: &mut CssBuf, skip_nl: bool) -> io::Result<()> {
+        if !self.body.is_empty() {
+            if skip_nl {
+                buf.do_indent_no_nl();
+            } else {
+                buf.do_indent();
+            }
+            if buf.format().is_compressed() {
+                write!(buf, "{:#}", self.selectors)?;
+            } else {
+                write!(buf, "{}", self.selectors)?;
+            }
+            buf.start_block();
+            for item in &self.body {
+                item.write(buf)?;
+            }
+            buf.end_block();
+        }
+        Ok(())
     }
 }
 
 /// Something that may exist inside a rule.
 pub enum BodyItem {
     /// An `@import` statement with a name and args.
-    Import(CssString, Value),
+    Import(Import),
     /// A property declaration with a name and a value.
     Property(String, Value),
     /// A property declaration with a name and a value.
     CustomProperty(String, CssString),
     /// A comment
-    Comment(String),
+    Comment(Comment),
+}
+
+impl BodyItem {
+    /// Write this item to a css output buffer.
+    pub fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
+        buf.do_indent();
+        match self {
+            BodyItem::Import(ref import) => import.write(buf),
+            BodyItem::Property(ref name, ref val) => write!(
+                buf,
+                "{}:{}{};",
+                name,
+                if buf.format().is_compressed() {
+                    ""
+                } else {
+                    " "
+                },
+                val.format(buf.format()).to_string().replace('\n', " "),
+            ),
+            BodyItem::CustomProperty(ref name, ref val) => write!(
+                buf,
+                "{}:{}{};",
+                name,
+                if val.quotes().is_none() || buf.format().is_compressed() {
+                    ""
+                } else {
+                    " "
+                },
+                val,
+            ),
+            BodyItem::Comment(ref c) => {
+                c.write(buf);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// An `@import` rule in css.
+pub struct Import {
+    name: CssString,
+    args: Value,
+}
+
+impl Import {
+    /// Create a new `@import`.
+    pub fn new(name: CssString, args: Value) -> Self {
+        Import { name, args }
+    }
+
+    /// Write this comment to a css output buffer.
+    pub fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
+        write!(buf, "@import {}", self.name)?;
+        if !self.args.is_null() {
+            write!(buf, " {}", self.args.format(buf.format()))?;
+        }
+        buf.add_one(";\n", ";");
+        Ok(())
+    }
+}
+
+impl From<Import> for BodyItem {
+    fn from(import: Import) -> BodyItem {
+        BodyItem::Import(import)
+    }
 }

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -47,6 +47,7 @@ pub trait FileContext: Sized + std::fmt::Debug {
             &|base, name| format!("{}_{}.import.scss", base, name),
             &|base, name| format!("{}{}/index.scss", base, name),
             &|base, name| format!("{}{}/_index.scss", base, name),
+            &|base, name| format!("{}{}.css", base, name),
         ];
         // Note: Should a "full stack" of bases be used here?
         // Or is this fine?
@@ -81,6 +82,7 @@ pub trait FileContext: Sized + std::fmt::Debug {
                 &|base, name| format!("{}_{}.scss", base, name),
                 &|base, name| format!("{}{}/index.scss", base, name),
                 &|base, name| format!("{}{}/_index.scss", base, name),
+                &|base, name| format!("{}{}.css", base, name),
             ],
         )? {
             let source = SourceName::load_css(path, from);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@
 //! improving.
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
-use std::path::Path;
 
 pub mod css;
 mod error;
@@ -53,10 +52,12 @@ pub use crate::error::Error;
 pub use crate::file_context::{FileContext, FsFileContext};
 use crate::output::Format;
 pub use crate::parser::{
-    parse_scss_data, parse_value_data, ParseError, SourceFile, SourceName,
-    SourcePos,
+    parse_scss_data, parse_value_data, ParseError, Parsed, SourceFile,
+    SourceName, SourcePos,
 };
 pub use crate::variablescope::{Scope, ScopeError, ScopeRef};
+
+use std::path::Path;
 
 /// Parse a scss value from a buffer and write its css representation
 /// in the given format.
@@ -100,8 +101,8 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 /// ```
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
-    let items = parse_scss_data(input)?;
-    format.write_root(&items, ScopeRef::new_global(format), &file_context)
+    let items = Parsed::Scss(parse_scss_data(input)?);
+    format.write_root(items, ScopeRef::new_global(format), &file_context)
 }
 
 /// Parse a file of scss data and write css in the given style.
@@ -129,7 +130,6 @@ pub fn compile_scss_path(
     format: Format,
 ) -> Result<Vec<u8>, Error> {
     let file_context = FsFileContext::new();
-    let source = file_context.file(path)?;
-    let items = source.parse()?;
-    format.write_root(&items, ScopeRef::new_global(format), &file_context)
+    let source = file_context.file(path)?.parse()?;
+    format.write_root(source, ScopeRef::new_global(format), &file_context)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,10 +82,9 @@ impl Args {
             if let Some(include_path) = &self.load_path {
                 file_context.push_path(include_path.as_ref());
             }
-            let source = file_context.file(name.as_ref())?;
-            let items = source.parse()?;
+            let source = file_context.file(name.as_ref())?.parse()?;
             let result = format.write_root(
-                &items,
+                source,
                 ScopeRef::new_global(format),
                 &file_context,
             )?;

--- a/src/output/cssbuf.rs
+++ b/src/output/cssbuf.rs
@@ -1,30 +1,24 @@
 use super::Format;
-use crate::css::{BodyItem, CssString, Rule, Value};
-use crate::value::Quotes;
+use crate::css::Import;
 use crate::{Error, ScopeRef};
-use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 
 /// A [CssBuf] for imports, that also keeps track of loaded modules.
 pub struct CssHead {
-    buf: CssBuf,
+    imports: Vec<Import>,
     modules: BTreeMap<String, ScopeRef>,
 }
 
 impl CssHead {
-    pub fn new(format: Format) -> Self {
+    pub fn new() -> Self {
         CssHead {
-            buf: CssBuf::new(format),
+            imports: Default::default(),
             modules: Default::default(),
         }
     }
-    pub fn add_import(
-        &mut self,
-        name: CssString,
-        args: Value,
-    ) -> Result<(), Error> {
-        self.buf.add_import(name, args)
+    pub fn add_import(&mut self, import: Import) {
+        self.imports.push(import)
     }
 
     pub fn load_module<Init>(
@@ -44,13 +38,17 @@ impl CssHead {
     }
 
     pub fn merge_imports(&mut self, other: Self) {
-        self.buf.buf.extend_from_slice(&other.buf.buf);
+        self.imports.extend(other.imports);
     }
 
     pub fn combine_final(&self, body: CssBuf) -> Vec<u8> {
+        let mut buf = CssBuf::new_as(&body);
+        for i in &self.imports {
+            i.write(&mut buf).unwrap();
+        }
         let mut result = vec![];
-        let compressed = self.buf.format.is_compressed();
-        if !self.buf.is_ascii() || !body.is_ascii() {
+        let compressed = body.format.is_compressed();
+        if !buf.is_ascii() || !body.is_ascii() {
             if compressed {
                 // U+FEFF is byte order mark, used to show encoding.
                 result.extend_from_slice("\u{feff}".as_bytes());
@@ -58,8 +56,8 @@ impl CssHead {
                 result.extend_from_slice(b"@charset \"UTF-8\";\n");
             }
         }
-        result.extend_from_slice(&self.buf.buf);
-        result.extend_from_slice(&body.buf);
+        result.extend(buf.buf);
+        result.extend(body.buf);
         if compressed && result.last() == Some(&b';') {
             result.pop();
         }
@@ -73,7 +71,7 @@ impl CssHead {
 pub struct CssBuf {
     buf: Vec<u8>,
     format: Format,
-    indent: usize,
+    pub(crate) indent: usize,
     separate: bool,
 }
 
@@ -95,114 +93,29 @@ impl CssBuf {
             separate: false,
         }
     }
-
-    pub fn write_rule(
-        &mut self,
-        rule: &Rule,
-        skip_nl: bool,
-    ) -> io::Result<()> {
-        if !rule.body.is_empty() {
-            if skip_nl {
-                self.do_indent_no_nl();
-            } else {
-                self.do_indent();
-            }
-            if self.format.is_compressed() {
-                write!(self.buf, "{:#}{{", rule.selectors)?;
-            } else {
-                write!(self.buf, "{} {{", rule.selectors)?;
-            }
-            self.indent += 2;
-            self.write_body_items(&rule.body)?;
-            self.indent -= 2;
-            self.do_indent();
-            self.add_one("}\n", "}");
-        }
-        Ok(())
+    pub(crate) fn format(&self) -> Format {
+        self.format
+    }
+    pub(crate) fn indent_level(&self) -> usize {
+        self.indent
     }
 
-    pub fn write_body_items(&mut self, items: &[BodyItem]) -> io::Result<()> {
-        for item in items {
-            self.do_indent();
-            match item {
-                BodyItem::Import(ref name, ref args) => {
-                    write!(&mut self.buf, "@import {}", name)?;
-                    if !args.is_null() {
-                        write!(
-                            &mut self.buf,
-                            " {}",
-                            args.format(self.format)
-                        )?;
-                    }
-                    self.add_one(";\n", ";");
-                }
-                BodyItem::Property(ref name, ref val) => write!(
-                    self.buf,
-                    "{}:{}{};",
-                    name,
-                    if self.format.is_compressed() { "" } else { " " },
-                    val.format(self.format).to_string().replace('\n', " "),
-                )?,
-                BodyItem::CustomProperty(ref name, ref val) => write!(
-                    self.buf,
-                    "{}:{}{};",
-                    name,
-                    if val.quotes() != Quotes::None
-                        && !self.format.is_compressed()
-                    {
-                        " "
-                    } else {
-                        ""
-                    },
-                    val,
-                )?,
-                BodyItem::Comment(ref c) => {
-                    let indent = self.indent;
-                    let existing = c
-                        .lines()
-                        .skip(1)
-                        .map(|s| s.bytes().take_while(|b| *b == b' ').count())
-                        .min()
-                        .unwrap_or(indent);
-
-                    self.add_str("/*");
-                    match indent.cmp(&existing) {
-                        Ordering::Greater => {
-                            let start =
-                                self.format.get_indent(indent - existing);
-                            self.add_str(&c.replace('\n', start));
-                        }
-                        Ordering::Less => {
-                            let start =
-                                self.format.get_indent(existing - indent - 1);
-                            self.add_str(&c.replace(start, "\n"));
-                        }
-                        Ordering::Equal => {
-                            self.add_str(c);
-                        }
-                    }
-                    self.add_str("*/");
-                }
-            }
-        }
+    pub fn start_block(&mut self) {
+        self.add_one(" {", "{");
+        self.indent += 2;
+    }
+    pub fn end_block(&mut self) {
         if self.format.is_compressed() && self.buf.last() == Some(&b';') {
             self.buf.pop();
         }
-        Ok(())
+        self.indent -= 2;
+        self.do_indent();
+        self.add_one("}\n", "}");
     }
 
-    pub fn add_import(
-        &mut self,
-        name: CssString,
-        args: Value,
-    ) -> Result<(), Error> {
+    pub fn add_import(&mut self, import: Import) -> Result<(), Error> {
         self.do_indent_no_nl();
-        write!(&mut self.buf, "@import {}", name)?;
-        if !args.is_null() {
-            write!(&mut self.buf, " {}", args.format(self.format))?;
-        }
-        self.add_one(";\n", ";");
-        Ok(())
+        Ok(import.write(self)?)
     }
 
     pub fn do_separate(&mut self) {

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -42,7 +42,7 @@ impl Format {
         globals: ScopeRef,
         file_context: &impl FileContext,
     ) -> Result<Vec<u8>, Error> {
-        let mut head = CssHead::new(*self);
+        let mut head = CssHead::new();
         let mut body = CssBuf::new(*self);
         handle_body(
             items,

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,9 +1,8 @@
 use super::cssbuf::{CssBuf, CssHead};
-use super::transform::handle_body;
+use super::transform::handle_parsed;
 use super::Style;
 use crate::file_context::FileContext;
-use crate::sass::Item;
-use crate::{Error, ScopeRef};
+use crate::{Error, Parsed, ScopeRef};
 
 /// Specifies the format for outputing css.
 ///
@@ -38,13 +37,13 @@ impl Format {
     /// in the sass file.
     pub fn write_root(
         &self,
-        items: &[Item],
+        items: Parsed,
         globals: ScopeRef,
         file_context: &impl FileContext,
     ) -> Result<Vec<u8>, Error> {
         let mut head = CssHead::new();
         let mut body = CssBuf::new(*self);
-        handle_body(
+        handle_parsed(
             items,
             &mut head,
             None,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,5 +4,6 @@ mod format;
 mod style;
 mod transform;
 
+pub(crate) use cssbuf::CssBuf;
 pub use format::{Format, Formatted};
 pub use style::Style;

--- a/src/parser/css/mod.rs
+++ b/src/parser/css/mod.rs
@@ -1,4 +1,122 @@
+mod rule;
 mod selectors;
 mod strings;
+mod values;
 
 pub(crate) use self::selectors::{selector, selector_part, selectors};
+
+use super::{util::opt_spacelike, PResult, Span};
+use crate::css::{Comment, Import, Item, Value};
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag, tag_no_case};
+use nom::combinator::{
+    all_consuming, into, map, map_res, not, opt, peek, recognize,
+};
+use nom::multi::{fold_many0, many0, many_till};
+use nom::sequence::{delimited, preceded, terminated};
+use std::str::from_utf8;
+
+pub fn file(input: Span) -> PResult<Vec<Item>> {
+    preceded(
+        alt((
+            tag("\u{feff}".as_bytes()),
+            tag_no_case(b"@charset \"UTF-8\";\n"),
+            tag_no_case(b"@charset \"ASCII\";\n"),
+            tag(""),
+        )),
+        map(
+            many_till(
+                preceded(opt_spacelike, top_level_item),
+                all_consuming(opt_spacelike),
+            ),
+            |(v, _eof)| v,
+        ),
+    )(input)
+}
+
+fn top_level_item(input: Span) -> PResult<Item> {
+    let (rest, start) = alt((tag("@"), tag("/*"), tag("")))(input)?;
+    match *start.fragment() {
+        b"/*" => into(comment)(input),
+        b"@" => {
+            let (input, name) = strings::css_string(rest)?;
+            if name == "import" {
+                into(import2)(input)
+            } else {
+                let (input, args) = map_res(media_args, |s| {
+                    std::str::from_utf8(s.fragment())
+                })(input)?;
+                let (input, body) = preceded(
+                    opt_spacelike,
+                    alt((
+                        delimited(
+                            terminated(tag("{"), opt_spacelike),
+                            many0(terminated(
+                                alt((
+                                    into(comment),
+                                    into(preceded(tag("@import"), import2)),
+                                    into(rule::rule),
+                                    into(rule::property),
+                                )),
+                                opt_spacelike,
+                            )),
+                            tag("}"),
+                        ),
+                        map(tag(";"), |_| Vec::new()),
+                    )),
+                )(input)?;
+                Ok((input, Item::AtRule(name, args.trim().to_string(), body)))
+            }
+        }
+        _ => into(rule::rule)(input),
+    }
+}
+
+fn import2(input: Span) -> PResult<Import> {
+    map(
+        delimited(
+            opt_spacelike,
+            strings::css_string_any,
+            // TODO: Media arguments!
+            opt(terminated(opt_spacelike, tag(";"))),
+        ),
+        |uri| Import::new(uri, Value::Null),
+    )(input)
+}
+
+fn media_args(input: Span) -> PResult<Span> {
+    recognize(preceded(
+        is_not("()/{}"),
+        opt(terminated(
+            delimited(tag("("), media_args, tag(")")),
+            media_args,
+        )),
+    ))(input)
+}
+
+pub fn comment(input: Span) -> PResult<Comment> {
+    into(preceded(tag("/*"), comment2))(input)
+}
+
+pub fn comment2(input: Span) -> PResult<String> {
+    terminated(
+        fold_many0(
+            alt((
+                map_res(is_not("*\r\n\u{c}"), |s: Span| {
+                    from_utf8(s.fragment())
+                }),
+                map(
+                    alt((tag("\r\n"), tag("\n"), tag("\r"), tag("\u{c}"))),
+                    |_| "\n",
+                ),
+                map(terminated(tag("*"), peek(not(tag("/")))), |_| "*"),
+            )),
+            String::new,
+            |mut acc, add| {
+                acc.push_str(add);
+                acc
+            },
+        ),
+        tag("*/"),
+    )(input)
+}

--- a/src/parser/css/rule.rs
+++ b/src/parser/css/rule.rs
@@ -1,0 +1,50 @@
+use std::str::from_utf8;
+
+use super::super::util::opt_spacelike;
+use super::super::{PResult, Span};
+use super::{comment, import2, selectors, strings, values};
+use crate::css::{BodyItem, Property, Rule};
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{into, map, opt};
+use nom::multi::many_till;
+use nom::sequence::{pair, preceded, terminated};
+
+pub fn rule(input: Span) -> PResult<Rule> {
+    map(
+        pair(
+            terminated(selectors, terminated(tag("{"), opt_spacelike)),
+            many_till(terminated(body_item, opt_spacelike), tag("}")),
+        ),
+        |(selectors, (body, _))| Rule { selectors, body },
+    )(input)
+}
+
+fn body_item(input: Span) -> PResult<BodyItem> {
+    alt((
+        into(comment),
+        into(preceded(tag("@import"), import2)),
+        into(property),
+    ))(input)
+}
+
+pub fn property(input: Span) -> PResult<Property> {
+    map(
+        pair(
+            terminated(property_name, terminated(tag(":"), opt_spacelike)),
+            terminated(values::any, opt(tag(";"))),
+        ),
+        |(name, val)| Property::new(name, val),
+    )(input)
+}
+
+fn property_name(input: Span) -> PResult<String> {
+    map(
+        pair(alt((tag("*"), tag(":"), tag(""))), strings::css_string),
+        |(pre, main)| {
+            let mut main = main;
+            main.insert_str(0, from_utf8(pre.fragment()).unwrap());
+            main
+        },
+    )(input)
+}

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -1,0 +1,117 @@
+use super::strings;
+use super::{opt_spacelike, PResult, Span};
+use crate::css::{CallArgs, Value};
+use crate::parser::value::number;
+use crate::value::ListSeparator;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{opt, peek};
+use nom::multi::{fold_many0, many0};
+use nom::sequence::{delimited, pair, preceded, terminated};
+
+pub fn any(input: Span) -> PResult<Value> {
+    let (input, first) = slash_list(input)?;
+    let (input, list) = fold_many0(
+        preceded(
+            delimited(opt_spacelike, tag(","), opt_spacelike),
+            slash_list,
+        ),
+        move || vec![first.clone()],
+        |mut list: Vec<Value>, item| {
+            list.push(item);
+            list
+        },
+    )(input)?;
+    Ok((
+        input,
+        if list.len() == 1 {
+            list.into_iter().next().unwrap()
+        } else {
+            Value::List(list, Some(ListSeparator::Comma), false)
+        },
+    ))
+}
+pub fn slash_list(input: Span) -> PResult<Value> {
+    let (input, first) = space_list(input)?;
+    let (input, list) = fold_many0(
+        preceded(
+            delimited(opt_spacelike, tag("/"), opt_spacelike),
+            space_list,
+        ),
+        move || vec![first.clone()],
+        |mut list: Vec<Value>, item| {
+            list.push(item);
+            list
+        },
+    )(input)?;
+    Ok((
+        input,
+        if list.len() == 1 {
+            list.into_iter().next().unwrap()
+        } else {
+            Value::List(list, Some(ListSeparator::Slash), false)
+        },
+    ))
+}
+pub fn space_list(input: Span) -> PResult<Value> {
+    let (input, first) = single(input)?;
+    let (input, list) = fold_many0(
+        preceded(opt_spacelike, single),
+        move || vec![first.clone()],
+        |mut list: Vec<Value>, item| {
+            list.push(item);
+            list
+        },
+    )(input)?;
+    Ok((
+        input,
+        if list.len() == 1 {
+            list.into_iter().next().unwrap()
+        } else {
+            Value::List(list, Some(ListSeparator::Space), false)
+        },
+    ))
+}
+
+fn single(input: Span) -> PResult<Value> {
+    if let Ok((rest, num)) = number(input) {
+        return Ok((rest, num.into()));
+    }
+    let (rest, string) = strings::css_string_any(input)?;
+    if let Ok((rest, args)) = delimited(
+        terminated(tag("("), opt_spacelike),
+        opt(terminated(call_args, opt_spacelike)),
+        tag(")"),
+    )(rest)
+    {
+        Ok((
+            rest,
+            Value::Call(string.to_string(), args.unwrap_or_default()),
+        ))
+    } else {
+        Ok((rest, string.into()))
+    }
+}
+
+fn call_args(input: Span) -> PResult<CallArgs> {
+    let (rest, named) = many0(pair(
+        terminated(
+            strings::css_string,
+            delimited(opt_spacelike, tag("="), opt_spacelike),
+        ),
+        terminated(
+            single,
+            alt((terminated(tag(","), opt_spacelike), peek(tag(")")))),
+        ),
+    ))(input)?;
+    let named = named
+        .into_iter()
+        .map(|(name, val)| (name.into(), val))
+        .collect();
+    let (rest, positional) = many0(terminated(
+        single,
+        alt((terminated(tag(","), opt_spacelike), peek(tag(")")))),
+    ))(rest)?;
+
+    Ok((rest, CallArgs { positional, named }))
+}

--- a/src/parser/css_function.rs
+++ b/src/parser/css_function.rs
@@ -8,7 +8,7 @@ use crate::value::Operator;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case};
 use nom::character::complete::multispace0;
-use nom::combinator::{map, not, peek, value};
+use nom::combinator::{into, map, not, peek, value};
 use nom::sequence::{delimited, preceded, terminated, tuple};
 
 pub fn css_function(input: Span) -> PResult<Value> {
@@ -78,7 +78,7 @@ fn single_value(input: Span) -> PResult<Value> {
         value(Value::True, tag("true")),
         value(Value::False, tag("false")),
         value(Value::HereSelector, tag("&")),
-        number,
+        into(number),
         variable,
         value(Value::Null, tag("null")),
         special_function,

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -14,7 +14,7 @@ use nom::bytes::complete::{tag, tag_no_case};
 use nom::character::complete::{
     alphanumeric1, multispace0, multispace1, one_of,
 };
-use nom::combinator::{map, map_res, not, opt, peek, recognize, value};
+use nom::combinator::{into, map, map_res, not, opt, peek, recognize, value};
 use nom::multi::{fold_many0, fold_many1, many0, many_m_n, separated_list1};
 use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 use num_traits::Zero;
@@ -239,7 +239,7 @@ fn simple_value(input: Span) -> PResult<Value> {
         value(Value::HereSelector, tag("&")),
         unicode_range,
         bracket_list,
-        number,
+        into(number),
         variable,
         hex_color,
         value(Value::Null, tag("null")),
@@ -305,7 +305,7 @@ fn sign_prefix(input: Span) -> PResult<Option<&[u8]>> {
         .map(|(r, s)| (r, s.map(|s| *s.fragment())))
 }
 
-pub fn number(input: Span) -> PResult<Value> {
+pub fn number(input: Span) -> PResult<Numeric> {
     map(
         tuple((
             sign_prefix,
@@ -317,7 +317,7 @@ pub fn number(input: Span) -> PResult<Value> {
             unit,
         )),
         |(sign, num, unit)| {
-            Value::Numeric(Numeric::new(
+            Numeric::new(
                 if sign == Some(b"-") {
                     // Only f64-based Number can represent negative zero.
                     if num.is_zero() {
@@ -329,7 +329,7 @@ pub fn number(input: Span) -> PResult<Value> {
                     num
                 },
                 unit,
-            ))
+            )
         },
     )(input)
 }

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -355,3 +355,9 @@ impl Value {
         }
     }
 }
+
+impl From<Numeric> for Value {
+    fn from(num: Numeric) -> Self {
+        Value::Numeric(num)
+    }
+}

--- a/src/spectest/testrunner.rs
+++ b/src/spectest/testrunner.rs
@@ -140,9 +140,8 @@ impl TestRunner {
 
     fn rsass(&self, input: &str) -> Result<Vec<u8>, Error> {
         let name = SourceName::root("input.scss");
-        let items = SourceFile::read(&mut input.as_bytes(), name)?.parse()?;
         self.format.write_root(
-            &items,
+            SourceFile::read(&mut input.as_bytes(), name)?.parse()?,
             ScopeRef::new_global(self.format),
             &self.file_context,
         )

--- a/tests/basic/misc.css
+++ b/tests/basic/misc.css
@@ -1,0 +1,17 @@
+/* Some raw css for testing. */
+@media screen and (min-width: 42em) {
+    /* Do this for wide viewports */
+    div.something {
+        display: flex;
+    }
+}
+@font-face {
+    font-family: Cocanut;
+    font-style: regular;
+    font-weight: regular;
+    src: local("Cocanut.otf"), url("cocanut.otf");
+}
+#foo {
+    /* Draw a border on this. */
+    border: solid 1px black;
+}

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -404,6 +404,66 @@ fn minmax_length_units() {
     );
 }
 
+#[test]
+fn use_raw_css() {
+    assert_eq!(
+        rsass(b"@use 'tests/basic/misc.css'").unwrap(),
+        "/* Some raw css for testing. */\
+         \n@media screen and (min-width: 42em) {\
+         \n  /* Do this for wide viewports */\
+         \n  div.something {\n    display: flex;\n  }\
+         \n}\
+         \n@font-face {\
+         \n  font-family: Cocanut;\n  font-style: regular;\
+         \n  font-weight: regular;\
+         \n  src: local(\"Cocanut.otf\"), url(\"cocanut.otf\");\
+         \n}\
+         \n#foo {\n  /* Draw a border on this. */\
+         \n  border: solid 1px black;\n}\n"
+    );
+}
+#[test]
+fn import_raw_css() {
+    assert_eq!(
+        rsass(b"@import 'tests/basic/misc.css'").unwrap(),
+        "/* Some raw css for testing. */\
+         \n@media screen and (min-width: 42em) {\
+         \n  /* Do this for wide viewports */\
+         \n  div.something {\n    display: flex;\n  }\
+         \n}\
+         \n@font-face {\
+         \n  font-family: Cocanut;\n  font-style: regular;\
+         \n  font-weight: regular;\
+         \n  src: local(\"Cocanut.otf\"), url(\"cocanut.otf\");\
+         \n}\
+         \n#foo {\n  /* Draw a border on this. */\
+         \n  border: solid 1px black;\n}\n"
+    );
+}
+
+#[test]
+fn load_raw_css() {
+    assert_eq!(
+        rsass(
+            b"@use 'sass:meta';\
+              \n@include meta.load-css('tests/basic/misc.css');"
+        )
+        .unwrap(),
+        "/* Some raw css for testing. */\
+         \n@media screen and (min-width: 42em) {\
+         \n  /* Do this for wide viewports */\
+         \n  div.something {\n    display: flex;\n  }\
+         \n}\
+         \n@font-face {\
+         \n  font-family: Cocanut;\n  font-style: regular;\
+         \n  font-weight: regular;\
+         \n  src: local(\"Cocanut.otf\"), url(\"cocanut.otf\");\
+         \n}\
+         \n#foo {\n  /* Draw a border on this. */\
+         \n  border: solid 1px black;\n}\n"
+    );
+}
+
 fn check_value(input: &str, expected: &str) {
     assert_eq!(
         String::from_utf8(

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 
 #[test]
 fn simple_value() {
-    let parsed = parse_scss_data(b"p { color: $color }").unwrap();
+    let parsed =
+        Parsed::Scss(parse_scss_data(b"p { color: $color }").unwrap());
     let format = output::Format {
         style: output::Style::Compressed,
         precision: 5,
@@ -15,7 +16,7 @@ fn simple_value() {
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format.write_root(&parsed, scope, &file_context).unwrap()
+            format.write_root(parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{color:#000}\n"
@@ -38,11 +39,12 @@ fn simple_function() {
             Arc::new(|_| Ok(css::Value::scalar(42))),
         ),
     );
-    let parsed = parse_scss_data(b"p { x: get_answer(); }").unwrap();
+    let parsed =
+        Parsed::Scss(parse_scss_data(b"p { x: get_answer(); }").unwrap());
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format.write_root(&parsed, scope, &file_context).unwrap()
+            format.write_root(parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{x:42}\n"
@@ -83,7 +85,8 @@ fn function_with_args() {
             }),
         ),
     );
-    let parsed = parse_scss_data(b"p { x: halfway(10, 18); }").unwrap();
+    let parsed =
+        Parsed::Scss(parse_scss_data(b"p { x: halfway(10, 18); }").unwrap());
     let format = output::Format {
         style: output::Style::Compressed,
         precision: 5,
@@ -91,7 +94,7 @@ fn function_with_args() {
     let file_context = FsFileContext::new();
     assert_eq!(
         String::from_utf8(
-            format.write_root(&parsed, scope, &file_context).unwrap()
+            format.write_root(parsed, scope, &file_context).unwrap()
         )
         .unwrap(),
         "p{x:14}\n"

--- a/tests/spec/css/plain/boolean_operations.rs
+++ b/tests/spec/css/plain/boolean_operations.rs
@@ -7,7 +7,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n"),

--- a/tests/spec/css/plain/calculation.rs
+++ b/tests/spec/css/plain/calculation.rs
@@ -10,7 +10,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // unexepected error
 fn function() {
     let runner = runner().with_cwd("function");
     assert_eq!(
@@ -43,7 +42,7 @@ fn parentheses() {
     );
 }
 #[test]
-#[ignore] // unexepected error
+#[ignore] // wrong result
 fn simplified() {
     let runner = runner().with_cwd("simplified");
     assert_eq!(

--- a/tests/spec/css/plain/custom_properties.rs
+++ b/tests/spec/css/plain/custom_properties.rs
@@ -13,7 +13,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn arbitrary_tokens() {
     let runner = runner().with_cwd("arbitrary_tokens");
     assert_eq!(
@@ -24,7 +24,6 @@ fn arbitrary_tokens() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn color() {
     let runner = runner().with_cwd("color");
     assert_eq!(
@@ -35,7 +34,6 @@ fn color() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn identifier() {
     let runner = runner().with_cwd("identifier");
     assert_eq!(
@@ -46,7 +44,7 @@ fn identifier() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn nested() {
     let runner = runner().with_cwd("nested");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/calculation.rs
+++ b/tests/spec/css/plain/error/expression/calculation.rs
@@ -41,7 +41,7 @@ fn line_noise() {
     );
 }
 #[test]
-#[ignore] // wrong error
+#[ignore] // missing error
 fn namespaced_function() {
     let runner = runner().with_cwd("namespaced_function");
     assert_eq!(
@@ -71,7 +71,7 @@ fn variable() {
     );
 }
 #[test]
-#[ignore] // wrong error
+#[ignore] // missing error
 fn wrong_args() {
     let runner = runner().with_cwd("wrong_args");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/function.rs
+++ b/tests/spec/css/plain/error/expression/function.rs
@@ -15,7 +15,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn built_in() {
     let runner = runner().with_cwd("built_in");
     assert_eq!(
@@ -30,7 +30,7 @@ fn built_in() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn keyword_arguments() {
     let runner = runner().with_cwd("keyword_arguments");
     assert_eq!(
@@ -45,7 +45,7 @@ fn keyword_arguments() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn variable_arguments() {
     let runner = runner().with_cwd("variable_arguments");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/interpolation.rs
+++ b/tests/spec/css/plain/error/expression/interpolation.rs
@@ -10,7 +10,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn calc() {
     let runner = runner().with_cwd("calc");
     assert_eq!(
@@ -25,7 +25,7 @@ fn calc() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn identifier() {
     let runner = runner().with_cwd("identifier");
     assert_eq!(
@@ -55,7 +55,7 @@ fn quoted_string() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn standalone() {
     let runner = runner().with_cwd("standalone");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/list.rs
+++ b/tests/spec/css/plain/error/expression/list.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn empty() {
     let runner = runner().with_cwd("empty");
     assert_eq!(
@@ -23,7 +23,7 @@ fn empty() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn empty_comma() {
     let runner = runner().with_cwd("empty_comma");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/map.rs
+++ b/tests/spec/css/plain/error/expression/map.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err("@import \'plain\'"),

--- a/tests/spec/css/plain/error/expression/operation.rs
+++ b/tests/spec/css/plain/error/expression/operation.rs
@@ -19,7 +19,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn addition() {
     let runner = runner().with_cwd("addition");
     assert_eq!(
@@ -34,7 +34,7 @@ fn addition() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn equals() {
     let runner = runner().with_cwd("equals");
     assert_eq!(
@@ -49,7 +49,7 @@ fn equals() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn greater_than() {
     let runner = runner().with_cwd("greater_than");
     assert_eq!(
@@ -64,7 +64,7 @@ fn greater_than() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn greater_than_or_equal() {
     let runner = runner().with_cwd("greater_than_or_equal");
     assert_eq!(
@@ -94,7 +94,7 @@ fn less_than() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn less_than_or_equal() {
     let runner = runner().with_cwd("less_than_or_equal");
     assert_eq!(
@@ -124,7 +124,7 @@ fn modulo() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn multiplication() {
     let runner = runner().with_cwd("multiplication");
     assert_eq!(
@@ -139,7 +139,7 @@ fn multiplication() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn not_equals() {
     let runner = runner().with_cwd("not_equals");
     assert_eq!(

--- a/tests/spec/css/plain/error/expression/parent_selector.rs
+++ b/tests/spec/css/plain/error/expression/parent_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err("@import \'plain\'"),

--- a/tests/spec/css/plain/error/expression/parentheses.rs
+++ b/tests/spec/css/plain/error/expression/parentheses.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err("@import \'plain\'"),

--- a/tests/spec/css/plain/error/expression/variable.rs
+++ b/tests/spec/css/plain/error/expression/variable.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn declaration() {
     let runner = runner().with_cwd("declaration");
     assert_eq!(
@@ -23,7 +23,7 @@ fn declaration() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test_use() {
     let runner = runner().with_cwd("use");
     assert_eq!(

--- a/tests/spec/css/plain/error/statement.rs
+++ b/tests/spec/css/plain/error/statement.rs
@@ -89,7 +89,7 @@ mod at_rule {
     }
 
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn at_root() {
         let runner = runner().with_cwd("at_root");
         assert_eq!(
@@ -104,7 +104,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn content() {
         let runner = runner().with_cwd("content");
         assert_eq!(
@@ -119,7 +119,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn debug() {
         let runner = runner().with_cwd("debug");
         assert_eq!(
@@ -149,7 +149,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn error() {
         let runner = runner().with_cwd("error");
         assert_eq!(
@@ -164,7 +164,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn extend() {
         let runner = runner().with_cwd("extend");
         assert_eq!(
@@ -194,7 +194,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn function() {
         let runner = runner().with_cwd("function");
         assert_eq!(
@@ -230,7 +230,7 @@ mod at_rule {
         }
 
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn interpolated() {
             let runner = runner().with_cwd("interpolated");
             assert_eq!(
@@ -245,7 +245,7 @@ mod at_rule {
             );
         }
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn multi() {
             let runner = runner().with_cwd("multi");
             assert_eq!(
@@ -260,7 +260,6 @@ mod at_rule {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn nested() {
             let runner = runner().with_cwd("nested");
             assert_eq!(
@@ -272,7 +271,7 @@ mod at_rule {
         }
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn include() {
         let runner = runner().with_cwd("include");
         assert_eq!(
@@ -287,7 +286,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn interpolation() {
         let runner = runner().with_cwd("interpolation");
         assert_eq!(
@@ -317,7 +316,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn test_return() {
         let runner = runner().with_cwd("return");
         assert_eq!(
@@ -332,7 +331,7 @@ mod at_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn warn() {
         let runner = runner().with_cwd("warn");
         assert_eq!(
@@ -390,7 +389,7 @@ mod style_rule {
         }
 
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn custom_property() {
             let runner = runner().with_cwd("custom_property");
             assert_eq!(
@@ -405,7 +404,7 @@ mod style_rule {
             );
         }
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn declaration() {
             let runner = runner().with_cwd("declaration");
             assert_eq!(
@@ -420,7 +419,7 @@ mod style_rule {
             );
         }
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn selector() {
             let runner = runner().with_cwd("selector");
             assert_eq!(
@@ -436,7 +435,7 @@ mod style_rule {
         }
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn nested() {
         let runner = runner().with_cwd("nested");
         assert_eq!(
@@ -451,7 +450,7 @@ mod style_rule {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn nested_property() {
         let runner = runner().with_cwd("nested_property");
         assert_eq!(

--- a/tests/spec/css/plain/functions.rs
+++ b/tests/spec/css/plain/functions.rs
@@ -15,7 +15,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn alpha() {
     let runner = runner().with_cwd("alpha");
     assert_eq!(
@@ -26,7 +25,6 @@ fn alpha() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn defined_elsewhere() {
     let runner = runner().with_cwd("defined_elsewhere");
     assert_eq!(
@@ -38,7 +36,6 @@ fn defined_elsewhere() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn grayscale() {
     let runner = runner().with_cwd("grayscale");
     assert_eq!(
@@ -49,7 +46,6 @@ fn grayscale() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn hsl() {
     let runner = runner().with_cwd("hsl");
     assert_eq!(
@@ -60,7 +56,6 @@ fn hsl() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn hsla() {
     let runner = runner().with_cwd("hsla");
     assert_eq!(
@@ -71,7 +66,6 @@ fn hsla() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn invert() {
     let runner = runner().with_cwd("invert");
     assert_eq!(
@@ -82,7 +76,6 @@ fn invert() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn rgb() {
     let runner = runner().with_cwd("rgb");
     assert_eq!(
@@ -93,7 +86,6 @@ fn rgb() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn rgba() {
     let runner = runner().with_cwd("rgba");
     assert_eq!(
@@ -104,7 +96,6 @@ fn rgba() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn saturate() {
     let runner = runner().with_cwd("saturate");
     assert_eq!(

--- a/tests/spec/css/plain/hacks.rs
+++ b/tests/spec/css/plain/hacks.rs
@@ -9,7 +9,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n"),

--- a/tests/spec/css/plain/import/css_before_index.rs
+++ b/tests/spec/css/plain/import/css_before_index.rs
@@ -8,7 +8,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \'other\';\n"),

--- a/tests/spec/css/plain/import/in_css.rs
+++ b/tests/spec/css/plain/import/in_css.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n"),

--- a/tests/spec/css/plain/null.rs
+++ b/tests/spec/css/plain/null.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n"),

--- a/tests/spec/css/plain/single_equals.rs
+++ b/tests/spec/css/plain/single_equals.rs
@@ -9,7 +9,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n"),

--- a/tests/spec/css/supports/nesting.rs
+++ b/tests/spec/css/supports/nesting.rs
@@ -58,7 +58,6 @@ mod media {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn top() {
         assert_eq!(
             runner().ok("@media screen {\
@@ -90,7 +89,6 @@ fn style_rule() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn supports() {
     assert_eq!(
         runner().ok("@supports (a: b) {\

--- a/tests/spec/directives/import/error/not_found.rs
+++ b/tests/spec/directives/import/error/not_found.rs
@@ -31,7 +31,7 @@ fn directory_dot_import() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn no_extension() {
     let runner = runner().with_cwd("no_extension");
     assert_eq!(

--- a/tests/spec/directives/test_use/error/load.rs
+++ b/tests/spec/directives/test_use/error/load.rs
@@ -327,7 +327,7 @@ fn missing() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn no_extension() {
     let runner = runner().with_cwd("no_extension");
     assert_eq!(

--- a/tests/spec/directives/test_use/load.rs
+++ b/tests/spec/directives/test_use/load.rs
@@ -159,7 +159,7 @@ mod precedence {
         );
     }
     #[test]
-    #[ignore] // unexepected error
+    #[ignore] // wrong result
     fn sass_before_css() {
         let runner = runner().with_cwd("sass_before_css");
         assert_eq!(

--- a/tests/spec/non_conformant/scss/media/nesting/retained.rs
+++ b/tests/spec/non_conformant/scss/media/nesting/retained.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/tests/spec/testrunner.rs
+++ b/tests/spec/testrunner.rs
@@ -140,9 +140,8 @@ impl TestRunner {
 
     fn rsass(&self, input: &str) -> Result<Vec<u8>, Error> {
         let name = SourceName::root("input.scss");
-        let items = SourceFile::read(&mut input.as_bytes(), name)?.parse()?;
         self.format.write_root(
-            &items,
+            SourceFile::read(&mut input.as_bytes(), name)?.parse()?,
             ScopeRef::new_global(self.format),
             &self.file_context,
         )


### PR DESCRIPTION
Add in-memory representation of some more css data, and use a separate parser when parsing css.

- [x] Allow css files in `@use` directives.
- [x] Allow css files in `@import` directives.
- [x] Allow css files in the `meta.load-css` mixin.
- [x] Parse rules in css files
- [x] Parse `@import` statements in css files.
- [x] Parse other `@`-rules (`@media` etc) in css files.
- [x] Parse comments in css files.