### PR TITLE
Attempt more path improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ project adheres to
 
 ## Unreleased
 
+* Use platform-dependent `path.join` for putting the local part after
+  a base path, seems to make slash-separated strings ok as the joined
+  part.  (PR #144, issue #133)
 * Update sass-spec test suite to 2022-05-20.
+
+Thanks to @fasterthanlime for reporting and testing.
 
 
 ## Release 0.25.0

--- a/src/file_context.rs
+++ b/src/file_context.rs
@@ -1,4 +1,5 @@
 use crate::{Error, SourceFile, SourceName, SourcePos};
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 /// A file context manages finding and loading files.
@@ -55,15 +56,8 @@ pub trait FileContext: Sized + std::fmt::Debug {
         ];
         // Note: Should a "full stack" of bases be used here?
         // Or is this fine?
-        let base = from.file_url();
-        if let Some((path, mut file)) = base
-            .rfind('/')
-            .map(|p| base.split_at(p + 1).0)
-            .map(|base| {
-                do_find_file(self, &format!("{}{}", base, url), names)
-            })
-            .unwrap_or_else(|| do_find_file(self, url, names))?
-        {
+        let url = relative(from.file_url(), url);
+        if let Some((path, mut file)) = do_find_file(self, &url, names)? {
             let source = SourceName::imported(path, from);
             Ok(Some(SourceFile::read(&mut file, source)?))
         } else {
@@ -89,15 +83,8 @@ pub trait FileContext: Sized + std::fmt::Debug {
         ];
         // Note: Should a "full stack" of bases be used here?
         // Or is this fine?
-        let base = from.file_url();
-        if let Some((path, mut file)) = base
-            .rfind('/')
-            .map(|p| base.split_at(p + 1).0)
-            .map(|base| {
-                do_find_file(self, &format!("{}{}", base, url), names)
-            })
-            .unwrap_or_else(|| do_find_file(self, url, names))?
-        {
+        let url = relative(from.file_url(), url);
+        if let Some((path, mut file)) = do_find_file(self, &url, names)? {
             let source = SourceName::used(path, from);
             Ok(Some(SourceFile::read(&mut file, source)?))
         } else {
@@ -119,7 +106,16 @@ pub trait FileContext: Sized + std::fmt::Debug {
     ) -> Result<Option<(String, Self::File)>, Error>;
 }
 
-/// Find a file for `@use`
+/// Make a url relative to a given base.
+fn relative<'a>(base: &str, url: &'a str) -> Cow<'a, str> {
+    base.rfind('/')
+        .map(|p| base.split_at(p + 1).0)
+        .map(|base| format!("{}{}", base, url).into())
+        .unwrap_or_else(|| url.into())
+}
+
+/// Find a file in a given filecontext matching a url over a set of
+/// name rules.
 fn do_find_file<FC: FileContext>(
     ctx: &FC,
     url: &str,

--- a/tests/basic/defs/_foo.scss
+++ b/tests/basic/defs/_foo.scss
@@ -1,15 +1,9 @@
-$color: purple;
+$color: black !default;
 
 @function foo($v) {
     @if $v > 0 {
         @return $color;
     } @else {
         @return pink;
-    }
-}
-
-@mixin myem {
-    em {
-        color: foo(0);
     }
 }

--- a/tests/basic/defs/_index.scss
+++ b/tests/basic/defs/_index.scss
@@ -1,0 +1,8 @@
+$color: purple;
+@use foo with ($color: $color) as *;
+
+@mixin myem {
+    em {
+        color: foo(0);
+    }
+}


### PR DESCRIPTION
Work some more with paths as `Path` and use `join` for joining a local
name with the base paths.  The local parts are still strings that may
contain `/` as separator, but base is properly used as OS-native
paths.

May fix #143 ?