### PR TITLE
No longer handle `var` as a string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ project adheres to
   `FormalArgs` with a body (a `Vec<Item>`).  And `sass::Item::Content` now
   has a `CallArgs`.  Also, `MixinDeclImpl` is replaced with
   `sass::Closure`. (PR #146).
+* `sass::CallArgs::new()` has an additional `trailing_comma` boolean
+  argument (PR #147).
 * Remove deprecated methods `css::Value::integer_value()` and
   `Number::is_integer()`.
 
@@ -29,7 +31,11 @@ project adheres to
 * Allow interpolation in css min and max function arguments.
 * The url for `@use` and `@forward` must be quoted.
 * Some `@` rules are now forbidden in some places as they should (PR #145).
+* The css `var(...)` function is now parsed as a proper function, and not
+  as a special string (PR #147).
+* The null value can be quoted as an empty string (PR #147).
 * In error message, don't show ellipses for consecutive lines (PR #147).
+* Somtimes a trailing comma in argument lists is preserved (PR #147).
 * Update sass-spec test suite to 2022-06-21.
 
 Thanks to @fasterthanlime (again) for reporting the problem with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ project adheres to
 * Allow interpolation in css min and max function arguments.
 * The url for `@use` and `@forward` must be quoted.
 * Some `@` rules are now forbidden in some places as they should (PR #145).
+* In error message, don't show ellipses for consecutive lines (PR #147).
 * Update sass-spec test suite to 2022-06-21.
 
 Thanks to @fasterthanlime (again) for reporting the problem with

--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -14,6 +14,7 @@ pub struct CallArgs {
     pub(crate) positional: Vec<Value>,
     // Ordered for formattig.
     pub(crate) named: OrderMap<Name, Value>,
+    pub(crate) trailing_comma: bool,
 }
 
 impl CallArgs {
@@ -115,6 +116,10 @@ impl fmt::Display for CallArgs {
             .iter()
             .map(|(k, v)| format!("{}={}", k, v.format(Default::default())));
         let t = pos.chain(named).collect::<Vec<_>>().join(", ");
-        write!(out, "{}", t)
+        write!(out, "{}", t)?;
+        if self.trailing_comma {
+            write!(out, ", ")?;
+        }
+        Ok(())
     }
 }

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -17,4 +17,4 @@ pub use self::selectors::{BadSelector, Selector, SelectorPart, Selectors};
 pub use self::string::CssString;
 pub use self::value::{Value, ValueMap, ValueToMapError};
 
-pub(crate) use self::util::{is_function_name, is_not};
+pub(crate) use self::util::{is_calc_name, is_function_name, is_not};

--- a/src/css/util.rs
+++ b/src/css/util.rs
@@ -18,3 +18,7 @@ where
 pub fn is_function_name(s: &str) -> bool {
     s == "calc" || s == "clamp" || s == "max" || s == "min" || s == "var"
 }
+/// Return true iff s is a valid _css_ function name.
+pub fn is_calc_name(s: &str) -> bool {
+    s == "calc" || s == "clamp" || s == "max" || s == "min"
+}

--- a/src/css/util.rs
+++ b/src/css/util.rs
@@ -16,9 +16,12 @@ where
 
 /// Return true iff s is a valid _css_ function name.
 pub fn is_function_name(s: &str) -> bool {
-    s == "calc" || s == "clamp" || s == "max" || s == "min" || s == "var"
+    is_calc_name(s) || s == "var"
 }
-/// Return true iff s is a valid _css_ function name.
+
+/// Return true iff s is a valid _css_ calculation name.
+///
+/// That is, a css function name that is not `"var"`.
 pub fn is_calc_name(s: &str) -> bool {
     s == "calc" || s == "clamp" || s == "max" || s == "min"
 }

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -171,6 +171,9 @@ impl Value {
                         false,
                     )
                 }));
+                if args.trailing_comma {
+                    vec.push(Value::Null);
+                }
                 vec
             }
             Value::List(v, _, _) => v,

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -1,4 +1,4 @@
-use super::{is_function_name, is_not, CallArgs, CssString};
+use super::{is_calc_name, is_not, CallArgs, CssString};
 use crate::ordermap::OrderMap;
 use crate::output::{Format, Formatted};
 use crate::sass::Function;
@@ -61,9 +61,7 @@ impl Value {
     pub fn type_name(&self) -> &'static str {
         match *self {
             Value::ArgList(..) => "arglist",
-            Value::Call(ref name, _) if is_function_name(name) => {
-                "calculation"
-            }
+            Value::Call(ref name, _) if is_calc_name(name) => "calculation",
             Value::Call(..) => "string",
             Value::Color(..) => "color",
             Value::Literal(ref s) if s.is_css_calc() => "calculation",

--- a/src/error.rs
+++ b/src/error.rs
@@ -117,11 +117,16 @@ fn show_in_file2(
     second: &SourcePos,
     second_name: &str,
 ) -> fmt::Result {
-    write!(out, "    ,")?;
-    first.show_inner(out, 3, '=', first_name)?;
-    write!(out, "... |")?;
-    second.show_inner(out, 3, '^', second_name)?;
-    write!(out, "    '")?;
+    let ellipsis = first.line_no() + 1 < second.line_no();
+    let lnw = second.line_no().to_string().len();
+    let lnw = if ellipsis { std::cmp::max(3, lnw) } else { lnw };
+    writeln!(out, "{0:lnw$} ,", "", lnw = lnw)?;
+    first.show_inner(out, lnw, '=', first_name)?;
+    if ellipsis {
+        writeln!(out, "... |")?;
+    }
+    second.show_inner(out, lnw, '^', second_name)?;
+    write!(out, "{0:lnw$} '", "", lnw = lnw)?;
     Ok(())
 }
 

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -113,5 +113,12 @@ fn call_args(input: Span) -> PResult<CallArgs> {
         alt((terminated(tag(","), opt_spacelike), peek(tag(")")))),
     ))(rest)?;
 
-    Ok((rest, CallArgs { positional, named }))
+    Ok((
+        rest,
+        CallArgs {
+            positional,
+            named,
+            trailing_comma: false,
+        },
+    ))
 }

--- a/src/parser/pos.rs
+++ b/src/parser/pos.rs
@@ -117,7 +117,7 @@ impl SourcePos {
         what: &str,
     ) -> fmt::Result {
         let lnw = self.p.line_no.to_string().len();
-        write!(out, "{0:lnw$} ,{arrow}", "", arrow = arrow, lnw = lnw)?;
+        writeln!(out, "{0:lnw$} ,{arrow}", "", arrow = arrow, lnw = lnw)?;
         self.show_inner(out, lnw, marker, what)?;
         write!(out, "{0:lnw$} '", "", lnw = lnw)
     }
@@ -130,7 +130,7 @@ impl SourcePos {
     ) -> fmt::Result {
         writeln!(
             out,
-            "\n{ln:<lnw$} | {line}\
+            "{ln:<lnw$} | {line}\
              \n{0:lnw$} |{0:>lpos$}{mark}{what}",
             "",
             line = self.p.line,
@@ -172,6 +172,10 @@ impl SourcePos {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn line_no(&self) -> u32 {
+        self.p.line_no
     }
 
     /// If self is preceded (on same line) by `s`, include `s` in self.

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -31,6 +31,21 @@ pub fn sass_string(input: Span) -> PResult<SassString> {
     )(input)?;
     Ok((input, SassString::new(parts, Quotes::None)))
 }
+pub fn var_name(input: Span) -> PResult<SassString> {
+    let (input, _) = tag("--")(input)?;
+    let (input, parts) = fold_many0(
+        alt((
+            string_part_interpolation,
+            map(unquoted_part, StringPart::Raw),
+        )),
+        || vec![StringPart::Raw("--".into())],
+        |mut acc, item| {
+            acc.push(item);
+            acc
+        },
+    )(input)?;
+    Ok((input, SassString::new(parts, Quotes::None)))
+}
 
 pub fn custom_value(input: Span) -> PResult<SassString> {
     alt((
@@ -177,7 +192,6 @@ pub fn special_function_misc(input: Span) -> PResult<SassString> {
                         tag("element"),
                         tag("env"),
                         tag("expression"),
-                        tag("var"),
                     )),
                 )),
                 |_| (),

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -2,7 +2,7 @@ use super::css_function::css_function;
 use super::formalargs::call_args;
 use super::strings::{
     name, sass_string_dq, sass_string_ext, sass_string_sq,
-    special_function_misc, special_url,
+    special_function_misc, special_url, var_name,
 };
 use super::unit::unit;
 use super::util::{ignore_comments, opt_spacelike, spacelike2};
@@ -247,6 +247,7 @@ fn simple_value(input: Span) -> PResult<Value> {
         special_function,
         // Really ugly special case ... sorry.
         value(Value::Literal("-null".into()), tag("-null")),
+        map(var_name, Value::Literal),
         unary_op,
         function_call,
         // And a bunch of string variants

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -632,7 +632,8 @@ mod test {
             parse_call("foo(17);"),
             Ok((
                 "foo".into(),
-                CallArgs::new(vec![(None, Value::scalar(17))]).unwrap(),
+                CallArgs::new(vec![(None, Value::scalar(17))], false)
+                    .unwrap(),
                 ";".as_bytes(),
             )),
         );

--- a/src/sass/call_args.rs
+++ b/src/sass/call_args.rs
@@ -95,6 +95,7 @@ impl CallArgs {
                     css::Value::Null => (),
                     item => {
                         result.positional.push(item);
+                        result.trailing_comma = false;
                     }
                 },
                 Some(splat) => {

--- a/src/sass/functions/meta.rs
+++ b/src/sass/functions/meta.rs
@@ -2,7 +2,7 @@ use super::{
     check, get_checked, get_opt_check, get_string, is_not, looks_like_call,
     CheckedArg, Error, FunctionMap,
 };
-use crate::css::{CallArgs, CssString, Value};
+use crate::css::{is_calc_name, CallArgs, CssString, Value};
 use crate::sass::{Call, Function, MixinDecl};
 use crate::value::Quotes;
 use crate::{Format, Scope, ScopeRef};
@@ -19,7 +19,13 @@ pub fn create_module() -> Scope {
                 // TODO: Maybe allow a single numeric argument to be itself?
                 Ok(args.to_string().into())
             }
-            Value::Call(_, args) => Ok(args.into()),
+            Value::Call(name, args) => {
+                if is_calc_name(&name) {
+                    Ok(args.into())
+                } else {
+                    Ok(Value::Call(name, args))
+                }
+            }
             Value::Literal(s) if looks_like_call(&s) => {
                 let s = s.value();
                 let i = s.find('(').unwrap();

--- a/src/sass/functions/mod.rs
+++ b/src/sass/functions/mod.rs
@@ -196,7 +196,7 @@ lazy_static! {
             fn pre_calc(v: &Value) -> bool {
                 match v {
                     Value::Numeric(..) => true,
-                    Value::Call(ref name, _) => css::is_function_name(name),
+                    Value::Call(ref name, _) => css::is_calc_name(name),
                     Value::Literal(s) => s.is_css_calc(),
                     _ => false,
                 }

--- a/src/sass/functions/string.rs
+++ b/src/sass/functions/string.rs
@@ -1,5 +1,6 @@
 use super::{get_integer, get_string, Error, FunctionMap};
 use crate::css::{CssString, Value};
+use crate::sass::functions::get_checked;
 use crate::Scope;
 use lazy_static::lazy_static;
 use std::cmp::min;
@@ -8,7 +9,11 @@ use std::sync::Mutex;
 pub fn create_module() -> Scope {
     let mut f = Scope::builtin_module("sass:string");
     def!(f, quote(string), |s| {
-        Ok(get_string(s, name!(string))?.quote().into())
+        let arg = get_checked(s, name!(string), |v| match v {
+            Value::Null => Ok(CssString::from("")),
+            v => super::check::string(v),
+        })?;
+        Ok(arg.quote().into())
     });
     def!(f, index(string, substring), |s| {
         let string = get_string(s, name!(string))?;

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -101,6 +101,7 @@ impl Value {
                 if *expl
                     || v == css::Value::Null
                     || matches!(&v, css::Value::Literal(s) if s.is_css_fn())
+                    || matches!(&v, css::Value::Call(_, _))
                 {
                     css::Value::Paren(Box::new(v))
                 } else {

--- a/tests/spec/css/functions/var.rs
+++ b/tests/spec/css/functions/var.rs
@@ -171,7 +171,6 @@ mod error {
     }
 
     #[test]
-    #[ignore] // wrong error
     fn empty_after_keyword() {
         let runner = runner().with_cwd("empty_after_keyword");
         assert_eq!(

--- a/tests/spec/css/functions/var.rs
+++ b/tests/spec/css/functions/var.rs
@@ -74,7 +74,6 @@ mod css_function {
             }
 
             #[test]
-            #[ignore] // wrong result
             fn case_insensitive() {
                 let runner = runner().with_cwd("case_insensitive");
                 assert_eq!(
@@ -85,7 +84,6 @@ mod css_function {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn no_whitespace() {
                 let runner = runner().with_cwd("no_whitespace");
                 assert_eq!(
@@ -96,7 +94,6 @@ mod css_function {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn whitespace_after() {
                 let runner = runner().with_cwd("whitespace_after");
                 assert_eq!(
@@ -107,7 +104,6 @@ mod css_function {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn whitespace_around() {
                 let runner = runner().with_cwd("whitespace_around");
                 assert_eq!(
@@ -118,7 +114,6 @@ mod css_function {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn whitespace_before() {
                 let runner = runner().with_cwd("whitespace_before");
                 assert_eq!(
@@ -336,7 +331,6 @@ mod sass_function {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn doesnt_use_function_if_case_doesnt_match() {
             let runner =
                 runner().with_cwd("doesnt_use_function_if_case_doesnt_match");

--- a/tests/spec/css/functions/var.rs
+++ b/tests/spec/css/functions/var.rs
@@ -30,7 +30,6 @@ mod css_function {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn rest() {
             let runner = runner().with_cwd("rest");
             assert_eq!(
@@ -59,7 +58,6 @@ mod css_function {
         }
 
         #[test]
-        #[ignore] // wrong result
         fn dynamic() {
             let runner = runner().with_cwd("dynamic");
             assert_eq!(
@@ -98,6 +96,7 @@ mod css_function {
                 );
             }
             #[test]
+            #[ignore] // wrong result
             fn whitespace_after() {
                 let runner = runner().with_cwd("whitespace_after");
                 assert_eq!(
@@ -141,7 +140,6 @@ mod css_function {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn rest() {
             let runner = runner().with_cwd("rest");
             assert_eq!(
@@ -178,7 +176,7 @@ mod error {
     }
 
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn empty_after_keyword() {
         let runner = runner().with_cwd("empty_after_keyword");
         assert_eq!(
@@ -198,7 +196,7 @@ mod error {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn empty_second_before_third() {
         let runner = runner().with_cwd("empty_second_before_third");
         assert_eq!(
@@ -212,7 +210,7 @@ mod error {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn invalid_second_arg_syntax() {
         let runner = runner().with_cwd("invalid_second_arg_syntax");
         assert_eq!(

--- a/tests/spec/css/plain/import/conditions.rs
+++ b/tests/spec/css/plain/import/conditions.rs
@@ -342,7 +342,6 @@ mod supports {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn value() {
                 assert_eq!(
                     runner().ok("@import \"a.css\" supports(--a: b);\n"),

--- a/tests/spec/libsass_closed_issues/issue_2140.rs
+++ b/tests/spec/libsass_closed_issues/issue_2140.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("$red: red;\


### PR DESCRIPTION
It is a function, remove it from the special_function_misc
fallback handling.