### PR TITLE
Improve error formatting code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ project adheres to
 * The sass `Value::Variable` and `Item::VariableDeclaration` variants
   now holds a `Name` rather than just a `String` for the variable name.
   Also, both now holds a `SourcePos`.
+* `Error::error` now takes an `Into<String>` argument (PR #151).
 
 ### Improvements
 
@@ -44,8 +45,13 @@ project adheres to
 * The css `var(...)` function is now parsed as a proper function, and not
   as a special string (PR #147).
 * The null value can be quoted as an empty string (PR #147).
+* Make `Debug` formatting of `rsass::Error` look like the `Display` output,
+  but without the "Error: " prefix. This makes the error display correctly
+  if returned from a main function.  This also removed the "Error: " prefix
+  from a lot of message strings (PR #151).
 * In error message, don't show ellipses for consecutive lines (PR #147).
 * Somtimes a trailing comma in argument lists is preserved (PR #147).
+* Simplified `main` of the command-line by returning a `Result` (PR #151).
 * Update sass-spec test suite to 2022-06-21.
 * Some cleanups.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,9 @@ use rsass::{
 };
 use std::io::{stdout, Write};
 use std::path::PathBuf;
-use std::process::exit;
 
-fn main() {
-    match Args::parse().run() {
-        Ok(()) => (),
-        Err(err) => {
-            eprintln!("{}", err);
-            exit(1);
-        }
-    }
+fn main() -> Result<(), Error> {
+    Args::parse().run()
 }
 
 #[derive(Parser)]

--- a/src/output/transform.rs
+++ b/src/output/transform.rs
@@ -74,8 +74,7 @@ fn handle_item(
             {
                 if !with.is_empty() {
                     return Err(Error::BadCall(
-                        "Error: Built-in modules can\'t be configured."
-                            .into(),
+                        "Built-in modules can\'t be configured.".into(),
                         pos.clone(),
                         None,
                     ));
@@ -117,7 +116,7 @@ fn handle_item(
                     })?
             } else {
                 return Err(Error::BadCall(
-                    "Error: Can't find stylesheet to import.".into(),
+                    "Can't find stylesheet to import.".into(),
                     pos.clone(),
                     None,
                 ));
@@ -130,8 +129,7 @@ fn handle_item(
             {
                 if !with.is_empty() {
                     return Err(Error::BadCall(
-                        "Error: Built-in modules can\'t be configured."
-                            .into(),
+                        "Built-in modules can\'t be configured.".into(),
                         pos.clone(),
                         None,
                     ));
@@ -221,7 +219,7 @@ fn handle_item(
                         || x.is_css_url())
                     {
                         return Err(Error::BadCall(
-                            "Error: Can't find stylesheet to import.".into(),
+                            "Can't find stylesheet to import.".into(),
                             pos.clone(),
                             None,
                         ));
@@ -360,7 +358,7 @@ fn handle_item(
                 })?;
             } else {
                 return Err(Error::BadCall(
-                    "Error: Undefined mixin.".into(),
+                    "Undefined mixin.".into(),
                     pos.clone(),
                     None,
                 ));

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -159,7 +159,7 @@ impl fmt::Display for ArgsError {
         match self {
             ArgsError::TooManyPos(n, m) => write!(
                 out,
-                "Error: Only {} positional argument{} allowed, but {} {} passed.",
+                "Only {} positional argument{} allowed, but {} {} passed.",
                 n,
                 if *n != 1 { "s" } else { "" },
                 m,
@@ -167,17 +167,17 @@ impl fmt::Display for ArgsError {
             ),
             ArgsError::TooMany(n, m) => write!(
                 out,
-                "Error: Only {} argument{} allowed, but {} {} passed.",
+                "Only {} argument{} allowed, but {} {} passed.",
                 n,
                 if *n != 1 { "s" } else { "" },
                 m,
                 if *m != 1 { "were" } else { "was" },
             ),
             ArgsError::Missing(name) => {
-                write!(out, "Error: Missing argument ${}.", name)
+                write!(out, "Missing argument ${}.", name)
             }
             ArgsError::Unexpected(name) => {
-                write!(out, "Error: No argument named ${}.", name)
+                write!(out, "No argument named ${}.", name)
             }
             ArgsError::Eval(e) => e.fmt(out),
         }

--- a/src/sass/functions/color/mod.rs
+++ b/src/sass/functions/color/mod.rs
@@ -183,7 +183,7 @@ fn bad_arg(err: ArgsError, name: &Name, args: &FormalArgs) -> Error {
 
 fn not_in_module(nm: &Name, col: &Value, an: &Name, av: &Value) -> Error {
     Error::S(format!(
-        "Error: The function {0}() isn\'t in the sass:color module.\n\
+        "The function {0}() isn\'t in the sass:color module.\n\
          \nRecommendation: color.adjust({1}, ${2}: {3})\n\
          \nMore info: https://sass-lang.com/documentation/functions/color#{0}",
         nm,

--- a/src/sass/functions/meta.rs
+++ b/src/sass/functions/meta.rs
@@ -111,7 +111,7 @@ pub fn create_module() -> Scope {
             } else if let Some(f) = get_function(s, module, name.value())? {
                 Ok(Value::Function(name.value().into(), Some(f)))
             } else {
-                Err(Error::S(format!("Error: Function not found: {}", name)))
+                Err(Error::S(format!("Function not found: {}", name)))
             }
         }
     );

--- a/src/sass/mixin.rs
+++ b/src/sass/mixin.rs
@@ -73,7 +73,7 @@ impl MixinDecl {
                     .map_err(|e| e.decl_called(call_pos2, pos))?;
                 let call_pos2 = call_pos.clone();
                 let url = get_string(&argscope, name!(url)).map_err(|e| {
-                    Error::BadCall(e.to_string(), call_pos2, None)
+                    Error::BadCall(format!("{:?}", e), call_pos2, None)
                 })?;
                 let call_pos2 = call_pos.clone();
                 let with = get_opt_map(&argscope, name!(with))
@@ -85,7 +85,7 @@ impl MixinDecl {
                     } else {
                         return Err(Error::BadCall(
                             format!(
-                                "Error: Built-in module {} can't be configured.",
+                                "Built-in module {} can't be configured.",
                                 url.value()
                             ),
                             call_pos.clone(),
@@ -98,7 +98,7 @@ impl MixinDecl {
                     .find_file_use(url.value(), call_pos.clone())?
                     .ok_or_else(|| {
                         Error::BadCall(
-                            "Error: Can't find stylesheet to import.".into(),
+                            "Can't find stylesheet to import.".into(),
                             call_pos2,
                             None,
                         )
@@ -160,10 +160,10 @@ pub(crate) fn get_opt_map(
             .try_into()
             .map_err(|e| match e {
                 ValueToMapError::Root(err) => {
-                    format!("Error: ${}: {}", name, err)
+                    format!("${}: {}", name, err)
                 }
                 ValueToMapError::Key(err) => {
-                    format!("Error: ${} key: {}", name, err)
+                    format!("${} key: {}", name, err)
                 }
             })
             .map(Some),

--- a/src/sass/value.rs
+++ b/src/sass/value.rs
@@ -149,12 +149,11 @@ impl Value {
                                 Some(decl),
                             ),
                             Error::Invalid(Invalid::AtError(msg), _) => {
-                                let msg = format!("Error: {}", msg);
                                 Error::BadCall(msg, pos.clone(), None)
                             }
                             e => {
                                 let pos = pos.clone().opt_in_calc();
-                                Error::BadCall(e.to_string(), pos, None)
+                                Error::BadCall(format!("{:?}", e), pos, None)
                             }
                         });
                     }

--- a/tests/spec/main.rs
+++ b/tests/spec/main.rs
@@ -1,5 +1,5 @@
 //! Tests auto-converted from "sass-spec/spec"
-//! version 50ee810b, 2022-06-21 17:35:49 -0700.
+//! version dcff661e, 2022-07-06 13:41:49 -0700.
 //! See <https://github.com/sass/sass-spec> for source material.\n
 //! The following tests are excluded from conversion:
 //! ["core_functions/selector/extend", "core_functions/selector/is_superselector", "core_functions/selector/unify", "directives/extend", "libsass-todo-issues/issue_221262.hrx", "libsass-todo-issues/issue_221292.hrx", "libsass/unicode-bom/utf-16-big", "libsass/unicode-bom/utf-16-little", "non_conformant/scss/huge.hrx", "non_conformant/scss/multiline-var.hrx"]


### PR DESCRIPTION
Make `Debug` formatting of `rsass::Error` look like the `Display`
output, but without the "Error: " prefix.  This makes the error
display correctly if returned from a `main` function.

This also puts the "Error: " prefix in one single place, rather than
repeating it in error messages all over the codebase.