### PR TITLE
Make the global scope of a context acessible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,15 @@ project adheres to
   from top-level into the `input` module (PR #150).
 * The `parse_value_data` function is removed.  Please create a `SourceFile`
   and use the `parse` method on that instead (PR #150).
+* The `Format::write_root` method are removed, `Context::transform`
+  should be used instad (PR #152).
 
 ### Improvements
 
+* `input::Context` is the new main interface to rsass.
+  Create a context suitable for how files should be loaded, configure it
+  with an output format and optionally extend the global scope before
+  calling `Context::transform` with an input file (PR #151, PR #152).
 * The `@content` can have arguments when declaring and calling a mixin
   (PR #146).
 * Variable declartions can be scoped (like `module.$var = value`).  Some

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,9 @@ pub fn compile_value(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
 /// )
 /// ```
 pub fn compile_scss(input: &[u8], format: Format) -> Result<Vec<u8>, Error> {
-    let input = input::SourceFile::scss_bytes(input, SourceName::root("-"));
-    FsContext::for_cwd().transform(input, format)
+    FsContext::for_cwd().with_format(format).transform(
+        input::SourceFile::scss_bytes(input, SourceName::root("-")),
+    )
 }
 
 /// Parse a file of scss data and write css in the given style.
@@ -126,5 +127,5 @@ pub fn compile_scss_path(
     format: Format,
 ) -> Result<Vec<u8>, Error> {
     let (context, source) = FsContext::for_path(path)?;
-    context.transform(source, format)
+    context.with_format(format).transform(source)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ impl Args {
             if let Some(include_path) = &self.load_path {
                 context.push_path(include_path.as_ref());
             }
-            let result = context.transform(source, format)?;
+            let result = context.with_format(format).transform(source)?;
             stdout().write_all(&result)?;
         }
         Ok(())

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,8 +1,4 @@
-use super::cssbuf::{CssBuf, CssHead};
-use super::transform::handle_parsed;
 use super::Style;
-use crate::input::{Context, Loader};
-use crate::{Error, Parsed, ScopeRef};
 
 /// Specifies the format for outputing css.
 ///
@@ -31,27 +27,6 @@ impl Format {
     /// Return true if this is an introspection format.
     pub fn is_introspection(&self) -> bool {
         self.style == Style::Introspection
-    }
-    /// Write a slice of sass items in this format.
-    /// The `file_context` is needed if there are `@import` statements
-    /// in the sass file.
-    pub fn write_root(
-        &self,
-        items: Parsed,
-        globals: ScopeRef,
-        file_context: &mut Context<impl Loader>,
-    ) -> Result<Vec<u8>, Error> {
-        let mut head = CssHead::new();
-        let mut body = CssBuf::new(*self);
-        handle_parsed(
-            items,
-            &mut head,
-            None,
-            &mut body,
-            globals,
-            file_context,
-        )?;
-        Ok(head.combine_final(body))
     }
 
     /// Get a newline followed by len spaces, unles self is compressed.

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,6 +4,8 @@ mod format;
 mod style;
 mod transform;
 
-pub(crate) use cssbuf::CssBuf;
 pub use format::{Format, Formatted};
 pub use style::Style;
+
+pub(crate) use cssbuf::{CssBuf, CssHead};
+pub(crate) use transform::handle_parsed;

--- a/src/output/transform.rs
+++ b/src/output/transform.rs
@@ -1,5 +1,5 @@
 //! This module provides `handle_body` (and internally `handle_item`),
-//! that does most of the work for [`super::Format::write_root`].
+//! that does most of the work for [`crate::input::Context::transform`].
 
 // https://github.com/rust-lang/rust-clippy/issues/7846
 // https://users.rust-lang.org/t/using-an-option-mut-t-in-a-loop-clippy-complains/72481/2

--- a/src/spectest/testrunner.rs
+++ b/src/spectest/testrunner.rs
@@ -132,6 +132,8 @@ impl TestRunner {
     fn rsass(&self, input: &str) -> Result<Vec<u8>, Error> {
         let name = SourceName::root("input.scss");
         let file = SourceFile::read(&mut input.as_bytes(), name)?;
-        Context::for_loader(self.loader.clone()).transform(file, self.format)
+        Context::for_loader(self.loader.clone())
+            .with_format(self.format)
+            .transform(file)
     }
 }

--- a/tests/spec/testrunner.rs
+++ b/tests/spec/testrunner.rs
@@ -132,6 +132,8 @@ impl TestRunner {
     fn rsass(&self, input: &str) -> Result<Vec<u8>, Error> {
         let name = SourceName::root("input.scss");
         let file = SourceFile::read(&mut input.as_bytes(), name)?;
-        Context::for_loader(self.loader.clone()).transform(file, self.format)
+        Context::for_loader(self.loader.clone())
+            .with_format(self.format)
+            .transform(file)
     }
 }


### PR DESCRIPTION
This makes `Context`, it's configuration methods and the `transform` method the main interface into rsass.