### PR TITLE
Refactor errors some more.

### DIFF
--- a/src/css/call_args.rs
+++ b/src/css/call_args.rs
@@ -2,7 +2,6 @@ use super::{is_not, Value};
 use crate::ordermap::OrderMap;
 use crate::sass::{ArgsError, Name};
 use crate::value::ListSeparator;
-use crate::Error;
 use std::default::Default;
 use std::fmt;
 
@@ -21,7 +20,7 @@ impl CallArgs {
     /// Create args from a Value.
     ///
     /// The value may be a list of arguments or a single argument.
-    pub fn from_value(v: Value) -> Result<Self, Error> {
+    pub fn from_value(v: Value) -> Result<Self, String> {
         match v {
             Value::ArgList(args) => Ok(args),
             Value::List(v, Some(ListSeparator::Comma), false) => {
@@ -53,14 +52,14 @@ impl CallArgs {
     pub(crate) fn add_from_value_map(
         &mut self,
         map: OrderMap<Value, Value>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), String> {
         for (k, v) in map {
             match k {
                 Value::Null => self.positional.push(v),
                 Value::Literal(s) => {
                     self.named.insert(s.value().into(), v);
                 }
-                x => return Err(Error::error(is_not(&x, "a string"))),
+                x => return Err(is_not(&x, "a string")),
             }
         }
         Ok(())

--- a/src/css/selectors.rs
+++ b/src/css/selectors.rs
@@ -630,14 +630,6 @@ impl fmt::Display for BadSelector {
         }
     }
 }
-impl From<BadSelector> for crate::Error {
-    fn from(e: BadSelector) -> crate::Error {
-        match e {
-            BadSelector::Parse(e) => e.into(),
-            e => crate::Error::error(e.to_string()),
-        }
-    }
-}
 impl From<ParseError> for BadSelector {
     fn from(e: ParseError) -> Self {
         BadSelector::Parse(e)

--- a/src/error.rs
+++ b/src/error.rs
@@ -175,6 +175,14 @@ impl From<LoadError> for Error {
     }
 }
 
+// FIXME: This is temporary and should be removed before merge!
+impl From<String> for Error {
+    fn from(msg: String) -> Self {
+        Error::error(msg)
+    }
+}
+
+
 /// Something invalid.
 ///
 /// Should be combined with a position to get an [Error].

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,27 +1,29 @@
 use crate::input::LoadError;
 use crate::parser::{ParseError, SourcePos};
-use crate::sass::{ArgsError, Name};
 use crate::value::RangeError;
 use crate::ScopeError;
 use std::convert::From;
 use std::{fmt, io};
 
-/// Most functions in rsass that returns a Result uses this Error type.
+/// Many functions in rsass that returns a Result uses this Error type.
+///
+/// Other errors in rsass, such as [`CallError`][crate::sass::CallError] or
+/// [`Invalid`] can be converted to this Error type, often with
+/// a method providing some context rather than with just an `Into`
+/// implementation.
+/// E.g. [`CallError::called_from`][crate::sass::CallError::called_from]
+/// also takes a [`SourcePos`] and a function name, defining the call
+/// that went wrong.
 pub enum Error {
-    /// An IO error encoundered on a specific path
+    /// Failed to load a file.
     Input(LoadError),
     /// An IO error without specifying a path.
     ///
     /// This is (probably) an error writing output.
     IoError(io::Error),
-    /// A bad call to a builtin function, with call- and optionally
-    /// declaration position.
+    /// A failed function call, with call- and optionally declaration
+    /// position.
     BadCall(String, SourcePos, Option<SourcePos>),
-    /// An illegal value for a specific parameter.
-    BadArgument(Name, String),
-    /// The pos here is the function declaration.
-    /// This error will be wrapped in a BadCall, giving the pos of the call.
-    BadArguments(ArgsError, SourcePos),
     /// Tried to import file at pos while already importing it at pos.
     ///
     /// The bool is true for a used module and false for an import.
@@ -58,9 +60,6 @@ impl fmt::Debug for Error {
         match *self {
             Error::S(ref s) => write!(out, "{}", s),
             Error::Input(ref load) => load.fmt(out),
-            Error::BadArgument(ref name, ref problem) => {
-                write!(out, "${}: {}", name, problem)
-            }
             Error::ParseError(ref err) => fmt::Display::fmt(err, out),
             Error::ImportLoop(ref module, ref pos, ref oldpos) => {
                 if *module {
@@ -106,8 +105,7 @@ impl fmt::Debug for Error {
                 pos.show(out)
             }
             Error::BadRange(ref err) => err.fmt(out),
-            // fallback
-            ref x => write!(out, "{:?}", x),
+            Error::IoError(ref err) => err.fmt(out),
         }
     }
 }
@@ -175,18 +173,11 @@ impl From<LoadError> for Error {
     }
 }
 
-// FIXME: This is temporary and should be removed before merge!
-impl From<String> for Error {
-    fn from(msg: String) -> Self {
-        Error::error(msg)
-    }
-}
-
-
 /// Something invalid.
 ///
 /// Should be combined with a position to get an [Error].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Invalid {
     /// Tried to declare a function with a forbidden name.
     FunctionName,
@@ -198,19 +189,26 @@ pub enum Invalid {
     MixinInControl,
     /// Mixins may not contain function declarations.
     FunctionInMixin,
-    /// Functions may not be declared in control directives
+    /// Functions may not be declared in control directives.
     FunctionInControl,
+    /// Duplicate argument.
+    DuplicateArgument,
+    /// Positional arguments must come before keyword arguments.
+    PositionalArgAfterNamed,
     /// Some invalid scope operation.
     InScope(ScopeError),
     /// An `@error` reached.
     AtError(String),
 }
+
 impl Invalid {
-    /// Combine this with a position to get a proper error.
+    /// Combine this with a position to get an [`Error`].
     pub fn at(self, pos: SourcePos) -> Error {
         Error::Invalid(self, pos)
     }
 }
+
+impl std::error::Error for Invalid {}
 
 impl fmt::Display for Invalid {
     fn fmt(&self, out: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -228,6 +226,11 @@ impl fmt::Display for Invalid {
             }
             Invalid::FunctionInControl => {
                 "Functions may not be declared in control directives."
+                    .fmt(out)
+            }
+            Invalid::DuplicateArgument => "Duplicate argument.".fmt(out),
+            Invalid::PositionalArgAfterNamed => {
+                "Positional arguments must come before keyword arguments."
                     .fmt(out)
             }
             Invalid::InScope(err) => err.fmt(out),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub mod sass;
 pub mod value;
 mod variablescope;
 
-pub use crate::error::Error;
+pub use crate::error::{Error, Invalid};
 pub use crate::parser::{parse_value_data, ParseError, SourcePos};
 pub use crate::variablescope::{Scope, ScopeError, ScopeRef};
 

--- a/src/sass/formal_args.rs
+++ b/src/sass/formal_args.rs
@@ -1,4 +1,4 @@
-use super::{Call, Name, Value};
+use super::{Call, CallError, Name, Value};
 use crate::{css, Error, ScopeError, ScopeRef, SourcePos};
 use std::fmt;
 
@@ -138,18 +138,10 @@ pub enum ArgsError {
 
 impl ArgsError {
     /// This argument error happend for args declared at the given pos.
-    pub fn declared_at(self, pos: &SourcePos) -> Error {
+    pub fn declared_at(self, pos: &SourcePos) -> CallError {
         match self {
-            ArgsError::Eval(e) => *e,
-            ae => Error::BadArguments(ae, pos.clone()),
-        }
-    }
-    /// This argument error happened while calling for `call` a function
-    /// declared at `decl` position.
-    pub fn decl_called(self, call: SourcePos, decl: SourcePos) -> Error {
-        match self {
-            ArgsError::Eval(e) => *e,
-            ae => Error::BadCall(ae.to_string(), call, Some(decl)),
+            ArgsError::Eval(e) => CallError::Wrap(e),
+            ae => CallError::Args(ae, pos.clone()),
         }
     }
 }
@@ -192,13 +184,5 @@ impl From<Error> for ArgsError {
 impl From<ScopeError> for ArgsError {
     fn from(e: ScopeError) -> ArgsError {
         Error::from(e).into()
-    }
-}
-
-// Note: this is only for some special cases, normally the "context"
-// of a function declaration pos is required.
-impl From<ArgsError> for Error {
-    fn from(e: ArgsError) -> Error {
-        Error::S(e.to_string())
     }
 }

--- a/src/sass/functions/call_error.rs
+++ b/src/sass/functions/call_error.rs
@@ -1,0 +1,83 @@
+use super::{ArgsError, Name};
+use crate::css::BadSelector;
+use crate::parser::SourcePos;
+use crate::{Error, Invalid, ScopeError};
+use std::fmt;
+
+/// An error in calling a function.
+#[derive(Debug)]
+pub enum CallError {
+    /// Something invalid while executing call.
+    Invalid(Invalid),
+    /// An illegal value for a specific parameter.
+    BadArgument(Name, String),
+    /// An error matching arguments.  The position is the declaration.
+    Args(ArgsError, SourcePos),
+    /// An error happened during execution of the call.
+    Wrap(Box<Error>),
+}
+
+impl CallError {
+    /// A generic error message inside a function.
+    ///
+    /// This is like using an `@error` statement inside a
+    /// sass-implemented function.
+    pub fn msg<S: ToString>(msg: S) -> Self {
+        CallError::Invalid(Invalid::AtError(msg.to_string()))
+    }
+
+    /// Map this error to a [`crate::Error`].
+    pub fn called_from(self, call_pos: &SourcePos, name: &str) -> Error {
+        match self {
+            CallError::Invalid(Invalid::AtError(msg)) => {
+                Error::BadCall(msg, call_pos.clone().opt_in_calc(), None)
+            }
+            CallError::Invalid(err) => {
+                Error::BadCall(format!("{:?}", err), call_pos.clone(), None)
+            }
+            CallError::BadArgument(name, problem) => Error::BadCall(
+                format!("${}: {}", name, problem),
+                call_pos.clone(),
+                None,
+            ),
+            CallError::Args(ArgsError::Eval(err), _decl) => *err,
+            CallError::Args(err, decl) => Error::BadCall(
+                err.to_string(),
+                if decl.is_builtin() {
+                    call_pos.clone()
+                } else {
+                    call_pos.in_call(name)
+                },
+                Some(decl),
+            ),
+            CallError::Wrap(err) => *err,
+        }
+    }
+}
+impl std::error::Error for CallError {}
+
+impl From<ScopeError> for CallError {
+    fn from(err: ScopeError) -> Self {
+        CallError::Invalid(Invalid::InScope(err))
+    }
+}
+impl From<Invalid> for CallError {
+    fn from(err: Invalid) -> Self {
+        CallError::Invalid(err)
+    }
+}
+impl From<BadSelector> for CallError {
+    fn from(e: BadSelector) -> CallError {
+        CallError::msg(e)
+    }
+}
+impl From<Error> for CallError {
+    fn from(e: Error) -> CallError {
+        CallError::Wrap(Box::new(e))
+    }
+}
+impl fmt::Display for CallError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error: {:?}", self)
+    }
+}

--- a/src/sass/functions/color/channels.rs
+++ b/src/sass/functions/color/channels.rs
@@ -1,7 +1,6 @@
-use super::is_special;
+use super::{is_special, CallError};
 use crate::css::Value;
 use crate::value::ListSeparator;
-use crate::Error;
 use std::convert::TryFrom;
 
 /// Channels data is either four values of parsable data, or one value
@@ -118,28 +117,28 @@ pub enum ChaError {
 }
 
 impl ChaError {
-    pub fn conv(self, names: &[&'static str; 3]) -> Error {
+    pub fn conv(self, names: &[&'static str; 3]) -> CallError {
         match self {
             Self::Bracketed => {
-                Error::error("$channels must be an unbracketed list.")
+                CallError::msg("$channels must be an unbracketed list.")
             }
             Self::BadSep => {
-                Error::error("$channels must be a space-separated list.")
+                CallError::msg("$channels must be a space-separated list.")
             }
             Self::Missing0 => {
-                Error::error(format!("Missing element ${}.", names[0]))
+                CallError::msg(format!("Missing element ${}.", names[0]))
             }
             Self::Missing1 => {
-                Error::error(format!("Missing element ${}.", names[1]))
+                CallError::msg(format!("Missing element ${}.", names[1]))
             }
             Self::Missing2 => {
-                Error::error(format!("Missing element ${}.", names[2]))
+                CallError::msg(format!("Missing element ${}.", names[2]))
             }
-            Self::BadNum(n) => Error::error(format!(
+            Self::BadNum(n) => CallError::msg(format!(
                 "Only 3 elements allowed, but {} were passed.",
                 n
             )),
-            Self::SlashBadNum(n) => Error::error(format!(
+            Self::SlashBadNum(n) => CallError::msg(format!(
                 "Only 2 slash-separated elements allowed, but {} {} passed.",
                 n,
                 if n == 1 { "was" } else { "were" },

--- a/src/sass/functions/selector.rs
+++ b/src/sass/functions/selector.rs
@@ -1,4 +1,4 @@
-use super::{check, get_checked, Error, FunctionMap};
+use super::{check, get_checked, CallError, FunctionMap};
 use crate::css::{BadSelector, Selectors, Value};
 use crate::sass::Name;
 use crate::Scope;
@@ -29,7 +29,7 @@ pub fn create_module() -> Scope {
     f
 }
 
-fn get_selectors(s: &Scope, name: Name) -> Result<Vec<Selectors>, Error> {
+fn get_selectors(s: &Scope, name: Name) -> Result<Vec<Selectors>, CallError> {
     Ok(get_checked(s, name, check::va_list_nonempty)?
         .into_iter()
         .map(|v| v.try_into())

--- a/src/sass/functions/string.rs
+++ b/src/sass/functions/string.rs
@@ -1,6 +1,5 @@
-use super::{get_integer, get_string, Error, FunctionMap};
+use super::{get_checked, get_integer, get_string, CallError, FunctionMap};
 use crate::css::{CssString, Value};
-use crate::sass::functions::get_checked;
 use crate::Scope;
 use lazy_static::lazy_static;
 use std::cmp::min;
@@ -66,7 +65,10 @@ pub fn create_module() -> Scope {
                 st.chars().skip(start_at).take(end_at - start_at).collect();
             Ok(CssString::new(part, string.quotes()).into())
         } else {
-            Err(Error::S(format!("Bad indexes: {}..{}", start_at, end_at)))
+            Err(CallError::msg(format!(
+                "Bad indexes: {}..{}",
+                start_at, end_at
+            )))
         }
     });
     def!(f, to_upper_case(string), |s| {

--- a/src/sass/mod.rs
+++ b/src/sass/mod.rs
@@ -24,7 +24,7 @@ mod value;
 pub use self::call_args::CallArgs;
 pub use self::callable::{Call, Callable, Closure};
 pub use self::formal_args::{ArgsError, FormalArgs};
-pub use self::functions::{get_global_module, Function};
+pub use self::functions::{get_global_module, CallError, Function};
 pub use self::item::{Expose, Item, UseAs};
 pub use self::mixin::{Mixin, MixinDecl};
 pub use self::name::Name;

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -1,9 +1,8 @@
 //! A scope is something that contains variable values.
 use crate::css::{CssString, Selectors, Value};
-use crate::error::Invalid;
 use crate::output::Format;
 use crate::sass::{Expose, Function, Item, MixinDecl, Name, UseAs};
-use crate::{Error, SourcePos};
+use crate::{Error, Invalid, SourcePos};
 use arc_swap::ArcSwapOption;
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
@@ -374,7 +373,7 @@ impl Scope {
         &self,
         names: &[Name],
         value: Value,
-    ) -> Result<(), Error> {
+    ) -> Result<(), ScopeError> {
         if names.len() == 1 {
             Ok(self.define(names[0].clone(), value)?)
         } else {

--- a/tests/rust_functions.rs
+++ b/tests/rust_functions.rs
@@ -1,6 +1,6 @@
 use rsass::input::{FsContext, SourceFile, SourceName};
 use rsass::output::{Format, Style};
-use rsass::sass::{FormalArgs, Function, Name};
+use rsass::sass::{CallError, FormalArgs, Function, Name};
 use rsass::value::{Number, Numeric, Rgba};
 use rsass::*;
 use std::sync::Arc;
@@ -61,7 +61,7 @@ fn function_with_args() -> Result<(), Error> {
             ]),
             Arc::new(|s| {
                 let a = s.get(&"a".into())?.numeric_value().map_err(|v| {
-                    Error::BadArgument(
+                    CallError::BadArgument(
                         "a".into(),
                         format!(
                             "{} is not a number",
@@ -70,7 +70,7 @@ fn function_with_args() -> Result<(), Error> {
                     )
                 })?;
                 let b = s.get(&"b".into())?.numeric_value().map_err(|v| {
-                    Error::BadArgument(
+                    CallError::BadArgument(
                         "b".into(),
                         format!(
                             "{} is not a number",
@@ -83,7 +83,7 @@ fn function_with_args() -> Result<(), Error> {
                 } else if a.unit.is_none() {
                     Ok(Numeric::new(avg(a.value, b.value), b.unit).into())
                 } else {
-                    Err(Error::error("Incopatible args."))
+                    Err(CallError::msg("Incopatible args."))
                 }
             }),
         ),


### PR DESCRIPTION
Inside a function implementation, errors ends up as `CallError`. This can be combined with a call position to yield a `crate::Error`.
