### PR TITLE
Refactor css output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ project adheres to
 * Moved the `SourcePos` type into the `input` module and converted it from
   keeping a copy of the relevant line to keeping a range with a (reference
   counted) `SourceFile` (PR #158).
+* Changed css creation from just writing to a text buffer to building
+  a tree representation of the css (and serialize it to text as a
+  final step) (PR #159).
 * Changed `css::Item::AtRule` to wrap the new type `css::AtRule`.
 * Changed handling of `hue` arguments to color functions, to allow
   different angle units, matching updates in sass-spec.

--- a/src/css/item.rs
+++ b/src/css/item.rs
@@ -13,6 +13,8 @@ pub enum Item {
     Rule(Rule),
     /// An `@` rule, e.g. `@media ... { ... }`
     AtRule(AtRule),
+    /// An extra newline for grouping (unless compressed format).
+    Separator,
 }
 
 impl Item {
@@ -22,6 +24,7 @@ impl Item {
             Item::Import(import) => import.write(buf)?,
             Item::Rule(rule) => rule.write(buf)?,
             Item::AtRule(atrule) => atrule.write(buf)?,
+            Item::Separator => buf.opt_nl(),
         }
         Ok(())
     }

--- a/src/css/value.rs
+++ b/src/css/value.rs
@@ -208,6 +208,10 @@ impl Value {
             format,
         }
     }
+    /// Format this value for error messages.
+    pub fn introspect(&self) -> Formatted<Value> {
+        self.format(Format::introspect())
+    }
 }
 
 /// Some Values are equal according to spec even with some

--- a/src/output/cssbuf.rs
+++ b/src/output/cssbuf.rs
@@ -1,97 +1,22 @@
 use super::Format;
-use crate::css::Import;
-use crate::{Error, ScopeRef};
-use std::collections::BTreeMap;
 use std::io::{self, Write};
-
-/// A [CssBuf] for imports, that also keeps track of loaded modules.
-pub struct CssHead {
-    imports: Vec<Import>,
-    modules: BTreeMap<String, ScopeRef>,
-}
-
-impl CssHead {
-    pub fn new() -> Self {
-        CssHead {
-            imports: Default::default(),
-            modules: Default::default(),
-        }
-    }
-    pub fn add_import(&mut self, import: Import) {
-        self.imports.push(import)
-    }
-
-    pub fn load_module<Init>(
-        &mut self,
-        path: &str,
-        init: Init,
-    ) -> Result<ScopeRef, Error>
-    where
-        Init: FnOnce(&mut Self) -> Result<ScopeRef, Error>,
-    {
-        if let Some(loaded) = self.modules.get(path) {
-            return Ok(loaded.clone());
-        }
-        let module = init(self)?;
-        self.modules.insert(path.into(), module.clone());
-        Ok(module)
-    }
-
-    pub fn merge_imports(&mut self, other: Self) {
-        self.imports.extend(other.imports);
-    }
-
-    pub fn combine_final(&self, body: CssBuf) -> Vec<u8> {
-        let mut buf = CssBuf::new_as(&body);
-        for i in &self.imports {
-            i.write(&mut buf).unwrap();
-        }
-        let mut result = vec![];
-        let compressed = body.format.is_compressed();
-        if !buf.is_ascii() || !body.is_ascii() {
-            if compressed {
-                // U+FEFF is byte order mark, used to show encoding.
-                result.extend_from_slice("\u{feff}".as_bytes());
-            } else {
-                result.extend_from_slice(b"@charset \"UTF-8\";\n");
-            }
-        }
-        result.extend(buf.buf);
-        result.extend(body.buf);
-        while result.last() == Some(&b'\n') {
-            result.pop();
-        }
-        if compressed && result.last() == Some(&b';') {
-            result.pop();
-        }
-        if !result.is_empty() {
-            result.push(b'\n');
-        }
-        result
-    }
-}
 
 pub struct CssBuf {
     buf: Vec<u8>,
     format: Format,
     indent: usize,
-    separate: bool,
 }
 
 impl CssBuf {
     pub fn new(format: Format) -> CssBuf {
-        CssBuf::_new(format, 0)
-    }
-    pub fn new_as(orig: &Self) -> CssBuf {
-        CssBuf::_new(orig.format, orig.indent)
-    }
-    fn _new(format: Format, indent: usize) -> CssBuf {
         CssBuf {
             buf: Vec::new(),
             format,
-            indent,
-            separate: false,
+            indent: 0,
         }
+    }
+    pub fn take(self) -> Vec<u8> {
+        self.buf
     }
     pub(crate) fn format(&self) -> Format {
         self.format
@@ -118,15 +43,6 @@ impl CssBuf {
         self.add_one("}\n", "}");
     }
 
-    pub fn do_separate(&mut self) {
-        if self.separate {
-            if !self.format.is_compressed() && !self.buf.is_empty() {
-                self.buf.push(b'\n');
-            }
-        } else {
-            self.separate = true;
-        }
-    }
     pub fn do_indent(&mut self) {
         self.add_str(self.format.get_indent(self.indent))
     }
@@ -137,19 +53,6 @@ impl CssBuf {
         }
     }
 
-    pub fn is_root_level(&self) -> bool {
-        self.indent == 0
-    }
-    pub fn is_empty(&self) -> bool {
-        self.buf.is_empty()
-    }
-    pub fn is_ascii(&self) -> bool {
-        self.buf.is_ascii()
-    }
-
-    pub fn join(&mut self, sub: Self) {
-        self.buf.extend_from_slice(&sub.buf);
-    }
     pub fn add_str(&mut self, sub: &str) {
         self.buf.extend_from_slice(sub.as_bytes())
     }
@@ -159,6 +62,14 @@ impl CssBuf {
         } else {
             normal
         })
+    }
+    pub fn opt_nl(&mut self) {
+        if !self.format.is_compressed()
+            && !self.buf.is_empty()
+            && !self.buf.ends_with(b"\n\n")
+        {
+            self.add_str("\n");
+        }
     }
 }
 

--- a/src/output/cssdata.rs
+++ b/src/output/cssdata.rs
@@ -1,0 +1,131 @@
+use super::cssdest::{AtRuleDest, CssDestination, NsRuleDest, RuleDest};
+use super::{CssBuf, Format};
+use crate::css::{Comment, CssString, Import, Item, Selectors, Value};
+use crate::{Error, Invalid, ScopeRef};
+use std::collections::BTreeMap;
+
+type Result<T, E = Invalid> = std::result::Result<T, E>;
+
+/// A holder for css data.
+pub struct CssData {
+    imports: Vec<Import>,
+    body: Vec<Item>,
+    modules: BTreeMap<String, ScopeRef>,
+}
+
+impl CssData {
+    pub fn new() -> Self {
+        CssData {
+            imports: Default::default(),
+            body: Default::default(),
+            modules: Default::default(),
+        }
+    }
+    pub fn into_iter(self) -> impl Iterator<Item = Item> {
+        self.imports.into_iter().map(Into::into).chain(self.body)
+    }
+    pub fn add_import(&mut self, import: Import) {
+        self.imports.push(import)
+    }
+
+    pub fn load_module<Init>(
+        &mut self,
+        path: &str,
+        init: Init,
+    ) -> Result<ScopeRef, Error>
+    where
+        Init: FnOnce(&mut Self) -> Result<ScopeRef, Error>,
+    {
+        if let Some(loaded) = self.modules.get(path) {
+            return Ok(loaded.clone());
+        }
+        let module = init(self)?;
+        self.modules.insert(path.into(), module.clone());
+        Ok(module)
+    }
+
+    pub fn into_buffer(self, format: Format) -> Result<Vec<u8>, Error> {
+        let mut buf = CssBuf::new(format);
+        for i in &self.imports {
+            i.write(&mut buf)?;
+        }
+        for i in &self.body {
+            i.write(&mut buf)?;
+        }
+        let buf = buf.take();
+        let compressed = format.is_compressed();
+        let mut result = if !buf.is_ascii() {
+            let mark = if compressed {
+                // U+FEFF is byte order mark, used to show encoding.
+                "\u{feff}"
+            } else {
+                "@charset \"UTF-8\";\n"
+            };
+            let mut result = Vec::with_capacity(mark.len() + buf.len());
+            result.extend_from_slice(mark.as_bytes());
+            result.extend(buf);
+            result
+        } else {
+            buf
+        };
+        while result.last() == Some(&b'\n') {
+            result.pop();
+        }
+        if compressed && result.last() == Some(&b';') {
+            result.pop();
+        }
+        if !result.is_empty() {
+            result.push(b'\n');
+        }
+        Ok(result)
+    }
+}
+
+impl CssDestination for CssData {
+    fn head(&mut self) -> &mut CssData {
+        self
+    }
+
+    fn start_rule(&mut self, selectors: Selectors) -> Result<RuleDest> {
+        Ok(RuleDest::new(self, selectors))
+    }
+    fn start_atrule(&mut self, name: String, args: Value) -> AtRuleDest {
+        AtRuleDest::new(self, name, args)
+    }
+    fn start_nsrule(&mut self, _name: String) -> Result<NsRuleDest> {
+        Err(Invalid::GlobalNsProperty)
+    }
+
+    fn push_import(&mut self, import: Import) {
+        self.add_import(import);
+    }
+
+    fn push_comment(&mut self, c: Comment) {
+        self.body.push(c.into())
+    }
+
+    fn push_item(&mut self, item: Item) -> Result<()> {
+        if let Item::Import(import) = item {
+            self.push_import(import);
+        } else {
+            self.body.push(item);
+        }
+        Ok(())
+    }
+
+    fn push_property(&mut self, _name: String, _value: Value) -> Result<()> {
+        Err(Invalid::DeclarationOutsideRule)
+    }
+
+    fn push_custom_property(
+        &mut self,
+        _: String,
+        _: CssString,
+    ) -> Result<()> {
+        Err(Invalid::GlobalCustomProperty)
+    }
+
+    fn separate(&mut self) {
+        self.body.push(Item::Separator);
+    }
+}

--- a/src/output/cssdest.rs
+++ b/src/output/cssdest.rs
@@ -1,0 +1,273 @@
+use super::CssData;
+use crate::css::{
+    AtRule, AtRuleBodyItem, Comment, CssString, Import, Item, Property, Rule,
+    Selectors, Value,
+};
+use crate::Invalid;
+
+type Result<T = ()> = std::result::Result<T, Invalid>;
+
+pub trait CssDestination {
+    fn head(&mut self) -> &mut CssData;
+
+    fn start_rule(&mut self, selectors: Selectors) -> Result<RuleDest>;
+    fn start_atrule(&mut self, name: String, args: Value) -> AtRuleDest;
+    fn start_nsrule(&mut self, name: String) -> Result<NsRuleDest>;
+
+    fn push_import(&mut self, import: Import);
+    fn push_comment(&mut self, c: Comment);
+    fn push_item(&mut self, item: Item) -> Result;
+    fn push_property(&mut self, name: String, value: Value) -> Result;
+    fn push_custom_property(
+        &mut self,
+        name: String,
+        value: CssString,
+    ) -> Result;
+
+    /// Nop in default implementation, adds a spacer in CssHead.
+    fn separate(&mut self) {}
+}
+
+pub struct RuleDest<'a> {
+    parent: &'a mut dyn CssDestination,
+    rule: Rule,
+    trail: Vec<Item>,
+}
+
+impl<'a> RuleDest<'a> {
+    pub fn new(
+        parent: &'a mut dyn CssDestination,
+        selectors: Selectors,
+    ) -> Self {
+        RuleDest {
+            parent,
+            rule: Rule::new(selectors),
+            trail: Default::default(),
+        }
+    }
+}
+impl<'a> Drop for RuleDest<'a> {
+    fn drop(&mut self) {
+        fn end(dest: &mut RuleDest) -> Result<()> {
+            dest.parent.push_item(dest.rule.clone().into())?;
+            let mut t = Vec::new();
+            std::mem::swap(&mut dest.trail, &mut t);
+            for item in t {
+                dest.parent.push_item(item)?;
+            }
+            dest.parent.separate();
+            Ok(())
+        }
+        if let Err(err) = end(self) {
+            eprintln!("Error in ending RuleDest: {}", err);
+        }
+    }
+}
+
+impl<'a> CssDestination for RuleDest<'a> {
+    fn head(&mut self) -> &mut CssData {
+        self.parent.head()
+    }
+    fn start_rule(&mut self, selectors: Selectors) -> Result<RuleDest> {
+        Ok(RuleDest::new(self, selectors))
+    }
+    fn start_atrule(&mut self, name: String, args: Value) -> AtRuleDest {
+        let selectors = self.rule.selectors.clone();
+        AtRuleDest {
+            parent: self,
+            name: name.into(),
+            args,
+            rule: Some(Rule::new(selectors)),
+            body: Vec::new(),
+        }
+    }
+    fn start_nsrule(&mut self, name: String) -> Result<NsRuleDest> {
+        Ok(NsRuleDest { parent: self, name })
+    }
+
+    fn push_import(&mut self, import: Import) {
+        self.rule.push(import.into());
+    }
+
+    fn push_comment(&mut self, c: Comment) {
+        self.rule.push(c.into())
+    }
+
+    fn push_item(&mut self, item: Item) -> Result {
+        match item {
+            Item::AtRule(r) => match r.try_into() {
+                Ok(item) => self.rule.push(item),
+                Err(r) => self.trail.push(r.into()),
+            },
+            item => self.trail.push(item),
+        }
+        Ok(())
+    }
+
+    fn push_property(&mut self, name: String, value: Value) -> Result {
+        self.rule.push(Property::new(name, value).into());
+        Ok(())
+    }
+
+    fn push_custom_property(
+        &mut self,
+        name: String,
+        value: CssString,
+    ) -> Result {
+        self.rule
+            .push(crate::css::BodyItem::CustomProperty(name, value));
+        Ok(())
+    }
+}
+
+pub struct NsRuleDest<'a> {
+    parent: &'a mut dyn CssDestination,
+    name: String,
+}
+
+impl<'a> CssDestination for NsRuleDest<'a> {
+    fn head(&mut self) -> &mut CssData {
+        self.parent.head()
+    }
+    fn start_rule(&mut self, _selectors: Selectors) -> Result<RuleDest> {
+        Err(Invalid::InNsRule)
+    }
+    fn start_atrule(&mut self, name: String, args: Value) -> AtRuleDest {
+        AtRuleDest {
+            parent: self,
+            name,
+            args,
+            rule: None,
+            body: Vec::new(),
+        }
+    }
+    fn start_nsrule(&mut self, name: String) -> Result<NsRuleDest> {
+        Ok(NsRuleDest { parent: self, name })
+    }
+
+    fn push_import(&mut self, import: Import) {
+        self.parent.push_import(import)
+    }
+    fn push_comment(&mut self, c: Comment) {
+        self.parent.push_comment(c)
+    }
+    fn push_item(&mut self, _item: Item) -> Result {
+        Err(Invalid::InNsRule)
+    }
+    fn push_property(&mut self, name: String, value: Value) -> Result {
+        self.parent
+            .push_property(format!("{}-{}", self.name, name), value)
+    }
+    fn push_custom_property(&mut self, _: String, _: CssString) -> Result {
+        Err(Invalid::InNsRule)
+    }
+}
+
+pub struct AtRuleDest<'a> {
+    parent: &'a mut dyn CssDestination,
+    name: String,
+    args: Value,
+    rule: Option<Rule>,
+    body: Vec<AtRuleBodyItem>,
+}
+impl<'a> AtRuleDest<'a> {
+    pub fn new(
+        parent: &'a mut dyn CssDestination,
+        name: String,
+        args: Value,
+    ) -> Self {
+        AtRuleDest {
+            parent,
+            name,
+            args,
+            rule: None,
+            body: Vec::new(),
+        }
+    }
+}
+
+impl<'a> Drop for AtRuleDest<'a> {
+    fn drop(&mut self) {
+        let mut body = Vec::new();
+        std::mem::swap(&mut self.body, &mut body);
+        let mut name = String::new();
+        std::mem::swap(&mut self.name, &mut name);
+        let mut args = Value::Null;
+        std::mem::swap(&mut self.args, &mut args);
+        if let Some(rule) = &self.rule {
+            body.insert(0, rule.clone().into());
+        }
+        let result = AtRule::new(name, args, Some(body));
+        if let Err(err) = self.parent.push_item(result.into()) {
+            eprintln!("Error ending AtRuleDest: {}", err);
+        }
+        self.parent.separate();
+    }
+}
+impl<'a> CssDestination for AtRuleDest<'a> {
+    fn head(&mut self) -> &mut CssData {
+        self.parent.head()
+    }
+    fn start_rule(&mut self, selectors: Selectors) -> Result<RuleDest> {
+        Ok(RuleDest::new(self, selectors))
+    }
+    fn start_atrule(&mut self, name: String, args: Value) -> AtRuleDest {
+        let rule = self.rule.as_ref().map(|r| Rule::new(r.selectors.clone()));
+        AtRuleDest {
+            parent: self,
+            name: name.into(),
+            args,
+            rule,
+            body: Vec::new(),
+        }
+    }
+    fn start_nsrule(&mut self, name: String) -> Result<NsRuleDest> {
+        Ok(NsRuleDest { parent: self, name })
+    }
+
+    fn push_import(&mut self, import: Import) {
+        self.body.push(import.into());
+    }
+
+    fn push_comment(&mut self, c: Comment) {
+        if let Some(rule) = &mut self.rule {
+            rule.push(c.into());
+        } else {
+            self.body.push(c.into());
+        }
+    }
+
+    fn push_item(&mut self, item: Item) -> Result {
+        self.body.push(match item {
+            Item::Comment(c) => c.into(),
+            Item::Import(i) => i.into(),
+            Item::Rule(r) => r.into(),
+            Item::AtRule(r) => r.into(),
+            Item::Separator => return Ok(()), // Not pushed?
+        });
+        Ok(())
+    }
+
+    fn push_property(&mut self, name: String, value: Value) -> Result {
+        let prop = Property::new(name, value);
+        if let Some(rule) = &mut self.rule {
+            rule.push(prop.into());
+        } else {
+            self.body.push(prop.into());
+        }
+        Ok(())
+    }
+
+    fn push_custom_property(
+        &mut self,
+        name: String,
+        value: CssString,
+    ) -> Result {
+        if let Some(rule) = &mut self.rule {
+            rule.push(crate::css::BodyItem::CustomProperty(name, value));
+            Ok(())
+        } else {
+            Err(Invalid::GlobalCustomProperty)
+        }
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,7 @@
 //! Types describing how to format output.
 mod cssbuf;
+mod cssdata;
+mod cssdest;
 mod format;
 mod style;
 mod transform;
@@ -7,5 +9,6 @@ mod transform;
 pub use format::{Format, Formatted};
 pub use style::Style;
 
-pub(crate) use cssbuf::{CssBuf, CssHead};
+pub(crate) use cssbuf::CssBuf;
+pub(crate) use cssdata::CssData;
 pub(crate) use transform::handle_parsed;

--- a/src/parser/css/mod.rs
+++ b/src/parser/css/mod.rs
@@ -49,25 +49,31 @@ fn top_level_item(input: Span) -> PResult<Item> {
                 let (input, body) = preceded(
                     opt_spacelike,
                     alt((
-                        delimited(
-                            terminated(tag("{"), opt_spacelike),
-                            many0(terminated(
-                                alt((
-                                    into(comment),
-                                    into(preceded(tag("@import"), import2)),
-                                    into(rule::rule),
-                                    into(rule::property),
+                        map(
+                            delimited(
+                                terminated(tag("{"), opt_spacelike),
+                                many0(terminated(
+                                    alt((
+                                        into(comment),
+                                        into(preceded(
+                                            tag("@import"),
+                                            import2,
+                                        )),
+                                        into(rule::rule),
+                                        into(rule::property),
+                                    )),
+                                    opt_spacelike,
                                 )),
-                                opt_spacelike,
-                            )),
-                            tag("}"),
+                                tag("}"),
+                            ),
+                            Some,
                         ),
-                        map(tag(";"), |_| Vec::new()),
+                        map(tag(";"), |_| None),
                     )),
                 )(input)?;
                 Ok((
                     input,
-                    AtRule::new(name, args.trim().to_string(), body).into(),
+                    AtRule::new(name, args.trim().into(), body).into(),
                 ))
             }
         }

--- a/src/variablescope.rs
+++ b/src/variablescope.rs
@@ -116,20 +116,22 @@ impl ScopeRef {
                     }
                     None
                 }
+                Item::Debug(ref value) => {
+                    eprintln!(
+                        "DEBUG: {}",
+                        value.evaluate(self.clone())?.introspect()
+                    );
+                    None
+                }
                 Item::Warn(ref value) => {
                     eprintln!(
                         "WARNING: {}",
-                        value
-                            .evaluate(self.clone())?
-                            .format(self.get_format())
+                        value.evaluate(self.clone())?.introspect()
                     );
                     None
                 }
                 Item::Error(ref value, ref pos) => {
-                    let msg = value
-                        .evaluate(self)?
-                        .format(Format::introspect())
-                        .to_string();
+                    let msg = value.evaluate(self)?.introspect().to_string();
                     return Err(Invalid::AtError(msg).at(pos.clone()));
                 }
                 Item::None => None,

--- a/tests/basic_manual.rs
+++ b/tests/basic_manual.rs
@@ -89,7 +89,7 @@ fn t14_imports() {
          foo goo {\n  blee: blee;\n  hello: world;\n}\n\
          foo goo hoo {\n  mux: scooba-dee-doo;\n  \
          flux: gooboo boo;\n}\n\
-         foo goo hoo d {\n  inside: d now;\n}\n\
+         foo goo hoo d {\n  inside: d now;\n}\n\n\
          foo blux {\n  hey: another thing;\n  \
          ho: will this work;\n}\n"
     )

--- a/tests/spec/directives/import/nested.rs
+++ b/tests/spec/directives/import/nested.rs
@@ -23,7 +23,6 @@ mod at_rule {
     }
 
     #[test]
-    #[ignore] // wrong result
     fn childless() {
         let runner = runner().with_cwd("childless");
         assert_eq!(

--- a/tests/spec/libsass/mixins_and_media_queries.rs
+++ b/tests/spec/libsass/mixins_and_media_queries.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@media screen and (orientation:landscape) {\


### PR DESCRIPTION
Instead of just writing output to a file (or buffer), build the complete result css as a data tree.  This is a requirement for implementing `@extend`, and it cleans up some of the ouptput/transform code.  Also some actual improvement in at-rule / rule interaction.