### PR TITLE
Clap now requires rust 1.64.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.60.0
+          - 1.64.0
           - beta
           - nightly
     steps:
@@ -45,7 +45,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: echo "::add-matcher::.github/workflows/rust-problem-matcher.json"
-      - run: cargo test
+      - run: cargo test -q
 
   test-windows:
     name: Test on Windows
@@ -55,14 +55,14 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.60.0
+          - 1.64.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
       - run: echo "::add-matcher::.github/workflows/rust-problem-matcher.json"
-      - run: cargo test
+      - run: cargo test -q
 
   test-macos:
     name: Test on MacOS
@@ -72,14 +72,14 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.60.0
+          - 1.64.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
       - run: echo "::add-matcher::.github/workflows/rust-problem-matcher.json"
-      - run: cargo test
+      - run: cargo test -q
 
   test-lib:
     name: Lib Tests
@@ -88,15 +88,17 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.62.1
+          - 1.60.0
           - 1.58.1
-          - 1.56.1
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
       - run: echo "::add-matcher::.github/workflows/rust-problem-matcher.json"
-      - run: cargo test --package rsass
+      - run: sed -i 's/"rsass-cli",/# \0/' Cargo.toml
+      - run: cargo test --package rsass -q
 
   commandline:
     name: Build cli

--- a/rsass-cli/Cargo.toml
+++ b/rsass-cli/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["command-line-utilities", "web-programming"]
 keywords = ["scss", "sass", "css", "web"]
 repository = "https://github.com/kaj/rsass"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [[bin]]
 name = "rsass"
@@ -18,6 +18,4 @@ unimplemented_args = []
 
 [dependencies]
 rsass = { path = "../rsass" }
-# Note: The 3 will fail, it's just an ugly hack to be able to compile
-# the library with rust versions not supported by clap 4.
-clap = { version = "<5.0.0", features = ["derive", "wrap_help"] }
+clap = { version = "4.1.1", features = ["derive", "wrap_help"] }

--- a/rsass/Cargo.toml
+++ b/rsass/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/kaj/rsass"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.58.1"
 
 [dependencies]
 arc-swap = "1.5.0"


### PR DESCRIPTION
So require rust 1.64 for rsass-cli, while trying to keep compat back to 1.58.1 for rsass the library crate.

This raises MSRV for the library itself from 1.56.1 to 1.58.1, allowing direct variable capture in format strings and some other rust features.

Also, less verbose build logs.