### PR TITLE
Extend is not yet supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to
 
 * `@media` rules are now handled specifically as `@media` rules,
   rather than as unknown `@`-rules (PR #172).
+* `@extend` is now explicitly unsupported (gives an error message,
+  rather than behaving as an unknown `@` rule) (PR #173).
 * Changed output format of non-finite numbers to match sass spec.
   They are now wrapped in `calc`, like `calc(infinite)` or
   `calc(NaN * 1deg)`.

--- a/rsass/src/output/transform.rs
+++ b/rsass/src/output/transform.rs
@@ -348,6 +348,9 @@ fn handle_item(
             let msg = value.evaluate(scope)?.introspect();
             return Err(Invalid::AtError(msg).at(pos.clone()));
         }
+        Item::Extend(_selectors) => {
+            return Err(Error::error("@extend is not supported yet"));
+        }
 
         Item::Rule(ref selectors, ref body) => {
             check_body(body, BodyContext::Rule)?;

--- a/rsass/src/parser/mod.rs
+++ b/rsass/src/parser/mod.rs
@@ -211,18 +211,26 @@ fn at_rule2(input0: Span) -> PResult<Item> {
             let pos = input0.up_to(&end).to_owned().opt_back("@");
             Ok((rest, Item::Error(v, pos)))
         }
+        "extend" => map(
+            delimited(
+                opt_spacelike,
+                selectors,
+                preceded(opt_spacelike, tag(";")),
+            ),
+            Item::Extend,
+        )(input),
         "for" => for_loop2(input),
         "forward" => forward2(input0),
         "function" => function_declaration2(input),
         "if" => if_statement2(input),
         "import" => import2(input),
         "include" => mixin_call2(input),
+        "media" => media::rule(input0),
         "mixin" => mixin_declaration2(input),
         "return" => return_stmt2(input0, input),
         "use" => use2(input0),
         "warn" => map(expression_argument, Item::Warn)(input),
         "while" => while_loop2(input),
-        "media" => media::rule(input0),
         _ => {
             let pos = input0.up_to(&input).to_owned().opt_back("@");
             let (input, args) = opt(unknown_rule_args)(input)?;

--- a/rsass/src/sass/item.rs
+++ b/rsass/src/sass/item.rs
@@ -88,6 +88,9 @@ pub enum Item {
         SourcePos,
     ),
 
+    /// Extend rule (not really supported yet).
+    Extend(Selectors),
+
     /// A sass rule; selectors followed by a block of items.
     Rule(Selectors, Vec<Item>),
     /// A sass namespace rule; a name followed by a block of properties.

--- a/rsass/tests/spec/core_functions/meta/load_css/error/from_other.rs
+++ b/rsass/tests/spec/core_functions/meta/load_css/error/from_other.rs
@@ -10,7 +10,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn extend() {
     let runner = runner().with_cwd("extend");
     assert_eq!(

--- a/rsass/tests/spec/core_functions/meta/load_css/extend.rs
+++ b/rsass/tests/spec/core_functions/meta/load_css/extend.rs
@@ -30,7 +30,7 @@ mod in_input {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn after() {
         let runner = runner().with_cwd("after");
         assert_eq!(
@@ -43,7 +43,7 @@ mod in_input {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn before() {
         let runner = runner().with_cwd("before");
         assert_eq!(
@@ -63,7 +63,7 @@ mod in_other {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn after() {
         let runner = runner().with_cwd("after");
         assert_eq!(
@@ -76,7 +76,7 @@ mod in_other {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn before() {
         let runner = runner().with_cwd("before");
         assert_eq!(
@@ -90,7 +90,7 @@ mod in_other {
     }
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn shared_cssless_midstream() {
     let runner = runner().with_cwd("shared_cssless_midstream");
     assert_eq!(

--- a/rsass/tests/spec/core_functions/meta/load_css/twice.rs
+++ b/rsass/tests/spec/core_functions/meta/load_css/twice.rs
@@ -25,7 +25,7 @@ mod load_css {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn different_extend() {
         let runner = runner().with_cwd("different_extend");
         assert_eq!(
@@ -86,7 +86,7 @@ mod test_use {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn different_extend() {
         let runner = runner().with_cwd("different_extend");
         assert_eq!(

--- a/rsass/tests/spec/css/plain/extend.rs
+++ b/rsass/tests/spec/css/plain/extend.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@import \"plain\";\n\

--- a/rsass/tests/spec/css/selector/slotted.rs
+++ b/rsass/tests/spec/css/selector/slotted.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("::slotted(.a) {x: y}\n\

--- a/rsass/tests/spec/directives/forward/error/extend.rs
+++ b/rsass/tests/spec/directives/forward/error/extend.rs
@@ -9,7 +9,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/directives/forward/extend.rs
+++ b/rsass/tests/spec/directives/forward/extend.rs
@@ -27,7 +27,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn forward_into_import() {
     let runner = runner().with_cwd("forward_into_import");
     assert_eq!(
@@ -39,7 +39,7 @@ fn forward_into_import() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn forward_into_use() {
     let runner = runner().with_cwd("forward_into_use");
     assert_eq!(
@@ -51,7 +51,7 @@ fn forward_into_use() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn upstream() {
     let runner = runner().with_cwd("upstream");
     assert_eq!(

--- a/rsass/tests/spec/directives/test_use/error/extend.rs
+++ b/rsass/tests/spec/directives/test_use/error/extend.rs
@@ -24,7 +24,7 @@ mod optional_and_mandatory {
     }
 
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn different_files() {
         let runner = runner().with_cwd("different_files");
         assert_eq!(
@@ -42,7 +42,7 @@ mod optional_and_mandatory {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn same_file() {
         let runner = runner().with_cwd("same_file");
         assert_eq!(
@@ -70,7 +70,7 @@ mod scope {
     }
 
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn diamond() {
         let runner = runner().with_cwd("diamond");
         assert_eq!(
@@ -91,7 +91,7 @@ mod scope {
     );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn downstream() {
         let runner = runner().with_cwd("downstream");
         assert_eq!(
@@ -109,7 +109,7 @@ mod scope {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn private() {
         let runner = runner().with_cwd("private");
         assert_eq!(
@@ -127,7 +127,7 @@ mod scope {
         );
     }
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn sibling() {
         let runner = runner().with_cwd("sibling");
         assert_eq!(

--- a/rsass/tests/spec/directives/test_use/extend/diamond.rs
+++ b/rsass/tests/spec/directives/test_use/extend/diamond.rs
@@ -20,7 +20,7 @@ mod dependency {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn with_midstream_extend() {
         let runner = runner().with_cwd("with_midstream_extend");
         assert_eq!(
@@ -39,7 +39,7 @@ mod dependency {
     }
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn merge() {
     let runner = runner().with_cwd("merge");
     assert_eq!(

--- a/rsass/tests/spec/directives/test_use/extend/extended.rs
+++ b/rsass/tests/spec/directives/test_use/extend/extended.rs
@@ -16,7 +16,7 @@ mod extended {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn from_other_file() {
         let runner = runner().with_cwd("from_other_file");
         assert_eq!(
@@ -28,7 +28,7 @@ mod extended {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn from_same_file() {
         let runner = runner().with_cwd("from_same_file");
         assert_eq!(

--- a/rsass/tests/spec/directives/test_use/extend/midstream_extend_within_pseudoselector.rs
+++ b/rsass/tests/spec/directives/test_use/extend/midstream_extend_within_pseudoselector.rs
@@ -19,7 +19,7 @@ mod three_files {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn is() {
         let runner = runner().with_cwd("is");
         assert_eq!(
@@ -37,7 +37,7 @@ mod three_files {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn matches() {
         let runner = runner().with_cwd("matches");
         assert_eq!(
@@ -62,7 +62,7 @@ mod two_files {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn is() {
         let runner = runner().with_cwd("is");
         assert_eq!(
@@ -81,7 +81,7 @@ mod two_files {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn matches() {
         let runner = runner().with_cwd("matches");
         assert_eq!(

--- a/rsass/tests/spec/directives/test_use/extend/optional_and_mandatory.rs
+++ b/rsass/tests/spec/directives/test_use/extend/optional_and_mandatory.rs
@@ -38,7 +38,7 @@ mod different_files {
     }
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn mandatory_first() {
         let runner = runner().with_cwd("mandatory_first");
         assert_eq!(
@@ -50,7 +50,7 @@ mod different_files {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn optional_first() {
         let runner = runner().with_cwd("optional_first");
         assert_eq!(
@@ -63,7 +63,7 @@ mod different_files {
     }
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn same_file() {
     let runner = runner().with_cwd("same_file");
     assert_eq!(

--- a/rsass/tests/spec/directives/test_use/extend/scope.rs
+++ b/rsass/tests/spec/directives/test_use/extend/scope.rs
@@ -35,7 +35,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn diamond() {
     let runner = runner().with_cwd("diamond");
     assert_eq!(
@@ -52,7 +52,7 @@ fn diamond() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn downstream() {
     let runner = runner().with_cwd("downstream");
     assert_eq!(
@@ -79,7 +79,7 @@ fn isolated_through_import() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn private() {
     let runner = runner().with_cwd("private");
     assert_eq!(
@@ -91,7 +91,7 @@ fn private() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn sibling() {
     let runner = runner().with_cwd("sibling");
     assert_eq!(
@@ -106,7 +106,7 @@ fn sibling() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn use_and_import_into_diamond_extend() {
     let runner = runner().with_cwd("use_and_import_into_diamond_extend");
     assert_eq!(
@@ -125,7 +125,7 @@ fn use_and_import_into_diamond_extend() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn use_into_use_and_import_into_import() {
     let runner = runner().with_cwd("use_into_use_and_import_into_import");
     assert_eq!(
@@ -140,7 +140,7 @@ fn use_into_use_and_import_into_import() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn use_into_use_and_import_into_use() {
     let runner = runner().with_cwd("use_into_use_and_import_into_use");
     assert_eq!(
@@ -155,7 +155,7 @@ fn use_into_use_and_import_into_use() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn use_into_use_and_use_into_import() {
     let runner = runner().with_cwd("use_into_use_and_use_into_import");
     assert_eq!(
@@ -170,7 +170,7 @@ fn use_into_use_and_use_into_import() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn use_into_use_and_use_into_import_into_use() {
     let runner =
         runner().with_cwd("use_into_use_and_use_into_import_into_use");

--- a/rsass/tests/spec/directives/test_use/extend/upstream.rs
+++ b/rsass/tests/spec/directives/test_use/extend/upstream.rs
@@ -15,7 +15,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn double() {
     let runner = runner().with_cwd("double");
     assert_eq!(
@@ -28,7 +28,7 @@ fn double() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn far() {
     let runner = runner().with_cwd("far");
     assert_eq!(
@@ -40,7 +40,7 @@ fn far() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn near() {
     let runner = runner().with_cwd("near");
     assert_eq!(
@@ -52,7 +52,7 @@ fn near() {
     );
 }
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn placeholder() {
     let runner = runner().with_cwd("placeholder");
     assert_eq!(

--- a/rsass/tests/spec/libsass/at_root/extend.rs
+++ b/rsass/tests/spec/libsass/at_root/extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/inh.rs
+++ b/rsass/tests/spec/libsass/inh.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("foo.a {\

--- a/rsass/tests/spec/libsass/placeholder_mediaquery.rs
+++ b/rsass/tests/spec/libsass/placeholder_mediaquery.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {\

--- a/rsass/tests/spec/libsass/placeholder_nested.rs
+++ b/rsass/tests/spec/libsass/placeholder_nested.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1063.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1063.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1091.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1091.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1210/extend.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1210/extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1248.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1248.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b .c {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1297.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1297.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".test .testa {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_137.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_137.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1482.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1482.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".mango {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1527/extend.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1527/extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1574.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1574.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1654/basic.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1654/basic.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1654/bem.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1654/bem.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo,\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1670.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1670.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1673.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1673.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1729.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1729.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1797.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1797.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%not {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1915.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1915.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@mixin wrapper() {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1916.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1916.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1923.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1923.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1927.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1927.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media screen {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1960.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1960.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("foo:not(.missing) {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1971.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1971.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo1 {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1993.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1993.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".test {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1994.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1994.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%hoverbrighter {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2000.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2000.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".m__exhibit-header--medium {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2007.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2007.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@mixin foo() {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2009.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2009.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@mixin breakpoint() {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2017.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2017.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("foo {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2031/extended_not.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2031/extended_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_2034.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2034.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(":not(.thing) {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2053.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2053.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo[disabled] {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2054.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2054.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(":not(.thing) {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2055.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2055.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_2057.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2057.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(":not(.thing) {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2139.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2139.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2150.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2150.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media (min-width: 100px) {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2200.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2200.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".media-object-section:last-child:not(:nth-child(2)) {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2246.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2246.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@mixin foo($option: \'foo\') {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2289.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2289.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo:baz:baz {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2291.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2291.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_2341.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2341.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@function aFunction() {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2347.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2347.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%baz2 {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2366/global.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2366/global.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".item {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2366/has.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2366/has.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".item {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2399.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2399.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".thing {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2468.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2468.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%matches {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2681.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2681.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%button-styles {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_279.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_279.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".theme {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2884.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2884.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_2959.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2959.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%color {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2994.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2994.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_439.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_439.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@mixin odd( $selector, $n) {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_592.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_592.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a::-webkit-scrollbar {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_615.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_615.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("$foo: \"bar\";\

--- a/rsass/tests/spec/libsass_closed_issues/issue_659/test_static.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_659/test_static.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("\

--- a/rsass/tests/spec/libsass_closed_issues/issue_673.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_673.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_712.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_712.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_823.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_823.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%test {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_871.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_871.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/libsass_closed_issues/issue_943.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_943.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%dog {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_950.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_950.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".selector1{ foo: bar; }\

--- a/rsass/tests/spec/libsass_todo_issues/issue_2051.rs
+++ b/rsass/tests/spec/libsass_todo_issues/issue_2051.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/non_conformant/errors/extend/placeholder/missing.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/placeholder/missing.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/non_conformant/errors/extend/placeholder/optional.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/placeholder/optional.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz {\r\

--- a/rsass/tests/spec/non_conformant/errors/extend/placeholder/simple.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/placeholder/simple.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {color: blue}\r\

--- a/rsass/tests/spec/non_conformant/errors/extend/selector/missing.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/selector/missing.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/non_conformant/errors/extend/selector/optional.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/selector/optional.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz {\r\

--- a/rsass/tests/spec/non_conformant/errors/extend/selector/simple.rs
+++ b/rsass/tests/spec/non_conformant/errors/extend/selector/simple.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {color: blue}\r\

--- a/rsass/tests/spec/non_conformant/extend_tests/compound_unification_in_not.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/compound_unification_in_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/escaped_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/escaped_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/extend_extender.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/extend_extender.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/extend_loop.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/extend_loop.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/extend_result_of_extend.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/extend_result_of_extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/extend_self.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/extend_self.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("// This shouldn\'t change the selector.\

--- a/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/after.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/after.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a:after {x: y}\

--- a/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/before.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/before.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a:before {x: y}\

--- a/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/first_letter.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/first_letter.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a:first-letter {x: y}\

--- a/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/first_line.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/fake_pseudo_element_order/first_line.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a:first-line {x: y}\

--- a/rsass/tests/spec/non_conformant/extend_tests/issue_146.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/issue_146.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%btn-style-default {\

--- a/rsass/tests/spec/non_conformant/extend_tests/nested_compound_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/nested_compound_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/not_into_not_not.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/not_into_not_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("// Regression test for dart-sass#191.\

--- a/rsass/tests/spec/non_conformant/extend_tests/selector_list.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/selector_list.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t001_test_basic.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t001_test_basic.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t002_test_basic.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t002_test_basic.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".bar {@extend .foo}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t003_test_basic.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t003_test_basic.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t004_test_basic.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t004_test_basic.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t005_test_multiple_targets.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t005_test_multiple_targets.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t006_test_multiple_extendees.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t006_test_multiple_extendees.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t007_test_multiple_extends_with_single_extender_and_single_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t007_test_multiple_extends_with_single_extender_and_single_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t008_test_multiple_extends_with_single_extender_and_single_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t008_test_multiple_extends_with_single_extender_and_single_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t009_test_multiple_extends_with_multiple_extenders_and_single_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t009_test_multiple_extends_with_multiple_extenders_and_single_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t010_test_multiple_extends_with_multiple_extenders_and_single_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t010_test_multiple_extends_with_multiple_extenders_and_single_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t011_test_chained_extends.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t011_test_chained_extends.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t014_test_nested_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t014_test_nested_target.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t015_test_target_with_child.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t015_test_target_with_child.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t016_test_class_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t016_test_class_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t017_test_class_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t017_test_class_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t018_test_id_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t018_test_id_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t019_test_id_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t019_test_id_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo#baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t020_test_universal_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t020_test_universal_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t021_test_universal_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t021_test_universal_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t022_test_universal_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t022_test_universal_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t023_test_universal_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t023_test_universal_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t024_test_universal_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t024_test_universal_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t025_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t025_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t026_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t026_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t027_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t027_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t028_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t028_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t029_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t029_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t030_test_universal_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t030_test_universal_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t031_test_universal_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t031_test_universal_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t032_test_universal_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t032_test_universal_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t033_test_universal_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t033_test_universal_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t034_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t034_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t035_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t035_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t036_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t036_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t037_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t037_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t038_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t038_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t039_test_universal_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t039_test_universal_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t040_test_universal_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t040_test_universal_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t041_test_universal_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t041_test_universal_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t042_test_universal_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t042_test_universal_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t043_test_element_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t043_test_element_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t044_test_element_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t044_test_element_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t045_test_element_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t045_test_element_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t046_test_element_unification_with_simple_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t046_test_element_unification_with_simple_target.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t047_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t047_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t048_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t048_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t049_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t049_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t050_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t050_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t051_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t051_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t052_test_element_unification_with_namespaceless_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t052_test_element_unification_with_namespaceless_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t053_test_element_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t053_test_element_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t054_test_element_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t054_test_element_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t055_test_element_unification_with_namespaced_universal_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t055_test_element_unification_with_namespaced_universal_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t056_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t056_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t057_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t057_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t058_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t058_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t059_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t059_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t060_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t060_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t061_test_element_unification_with_namespaceless_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t061_test_element_unification_with_namespaceless_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t062_test_element_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t062_test_element_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t063_test_element_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t063_test_element_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t064_test_element_unification_with_namespaced_element_target.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t064_test_element_unification_with_namespaced_element_target.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t065_test_attribute_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t065_test_attribute_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a [foo=bar].baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t066_test_attribute_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t066_test_attribute_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a [foo=bar].baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t067_test_attribute_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t067_test_attribute_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a [foo=bar].baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t068_test_attribute_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t068_test_attribute_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a [foo=bar].baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t069_test_attribute_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t069_test_attribute_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a %-a [foo=bar].bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t070_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t070_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t071_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t071_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t072_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t072_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ::foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t073_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t073_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ::foo(2n+1).baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t074_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t074_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t075_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t075_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .baz:foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t076_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t076_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a .baz:after {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t077_test_pseudo_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t077_test_pseudo_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :foo.baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t078_test_pseudoelement_remains_at_end_of_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t078_test_pseudoelement_remains_at_end_of_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo::bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t079_test_pseudoelement_remains_at_end_of_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t079_test_pseudoelement_remains_at_end_of_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.foo::bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t080_test_pseudoclass_remains_at_end_of_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t080_test_pseudoclass_remains_at_end_of_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo:bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t081_test_pseudoclass_remains_at_end_of_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t081_test_pseudoclass_remains_at_end_of_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.foo:bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t082_test_not_remains_at_end_of_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t082_test_not_remains_at_end_of_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo:not(.bar) {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t083_test_pseudoelement_goes_lefter_than_pseudoclass.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t083_test_pseudoelement_goes_lefter_than_pseudoclass.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo::bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t084_test_pseudoelement_goes_lefter_than_pseudoclass.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t084_test_pseudoelement_goes_lefter_than_pseudoclass.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo:bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t085_test_pseudoelement_goes_lefter_than_not.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t085_test_pseudoelement_goes_lefter_than_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo::bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t086_1_test_pseudoelement_goes_lefter_than_not.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t086_1_test_pseudoelement_goes_lefter_than_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t086_test_pseudoelement_goes_lefter_than_not.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t086_test_pseudoelement_goes_lefter_than_not.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo:not(.bang) {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t087_test_negation_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t087_test_negation_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :not(.foo).baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t088_test_negation_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t088_test_negation_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :not(.foo).baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t089_test_negation_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t089_test_negation_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a :not([a=b]).baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t090_test_comma_extendee.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t090_test_comma_extendee.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t091_test_redundant_selector_elimination.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t091_test_redundant_selector_elimination.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t094_test_long_extendee_runs_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t094_test_long_extendee_runs_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/non_conformant/extend_tests/t095_test_long_extender.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t095_test_long_extender.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t096_test_long_extender_runs_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t096_test_long_extender_runs_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("ns|*.foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t097_test_nested_extender.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t097_test_nested_extender.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t098_test_nested_extender_runs_unification.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t098_test_nested_extender_runs_unification.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t099_test_nested_extender_alternates_parents.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t099_test_nested_extender_alternates_parents.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t100_test_nested_extender_unifies_identical_parents.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t100_test_nested_extender_unifies_identical_parents.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz .bip .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t101_test_nested_extender_unifies_common_substring.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t101_test_nested_extender_unifies_common_substring.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t102_test_nested_extender_unifies_common_subseq.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t102_test_nested_extender_unifies_common_subseq.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t103_test_nested_extender_chooses_first_subseq.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t103_test_nested_extender_chooses_first_subseq.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a .b .c .d .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t104_test_nested_extender_counts_extended_subselectors/t104_test_nested_extender_counts_extended_subselectors.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t104_test_nested_extender_counts_extended_subselectors/t104_test_nested_extender_counts_extended_subselectors.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a .bip.bop .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t105_test_nested_extender_counts_extended_superselectors.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t105_test_nested_extender_counts_extended_superselectors.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a .bip .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t106_test_nested_extender_with_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t106_test_nested_extender_with_child_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t107_test_nested_extender_finds_common_selectors_around_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t107_test_nested_extender_finds_common_selectors_around_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a > b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t108_test_nested_extender_finds_common_selectors_around_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t108_test_nested_extender_finds_common_selectors_around_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a > b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t109_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t109_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a + b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t110_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t110_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a + b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t111_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t111_test_nested_extender_finds_common_selectors_around_adjacent_sibling.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a + b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t112_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t112_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a ~ b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t113_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t113_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a ~ b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t114_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t114_test_nested_extender_finds_common_selectors_around_sibling_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a ~ b c .c1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t118_test_nested_extender_with_early_child_selectors_doesnt_subseq_them.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t118_test_nested_extender_with_early_child_selectors_doesnt_subseq_them.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t119_test_nested_extender_with_early_child_selectors_doesnt_subseq_them.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t119_test_nested_extender_with_early_child_selectors_doesnt_subseq_them.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t120_test_nested_extender_with_child_selector_unifies.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t120_test_nested_extender_with_child_selector_unifies.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t121_test_nested_extender_with_child_selector_unifies.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t121_test_nested_extender_with_child_selector_unifies.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz > {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t122_test_nested_extender_with_child_selector_unifies.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t122_test_nested_extender_with_child_selector_unifies.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t123_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t123_test_nested_extender_with_early_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t124_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t124_test_nested_extender_with_early_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t125_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t125_test_nested_extender_with_early_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo > .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t126_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t126_test_nested_extender_with_early_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo + .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t127_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t127_test_nested_extender_with_early_child_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo > .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t128_test_nested_extender_with_sibling_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t128_test_nested_extender_with_sibling_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t129_test_nested_extender_with_hacky_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t129_test_nested_extender_with_hacky_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t130_test_nested_extender_with_hacky_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t130_test_nested_extender_with_hacky_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".baz .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t131_test_nested_extender_merges_with_same_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t131_test_nested_extender_merges_with_same_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t132_test_nested_extender_with_child_selector_merges_with_same_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t132_test_nested_extender_with_child_selector_merges_with_same_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo > .bar .baz {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t133_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t133_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t134_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t134_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t135_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t135_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t136_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t136_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ > + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t137_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t137_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t138_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t138_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t139_test_combinator_unification_for_hacky_combinators.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t139_test_combinator_unification_for_hacky_combinators.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ > + .b > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t140_test_combinator_unification_double_tilde.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t140_test_combinator_unification_double_tilde.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t141_test_combinator_unification_double_tilde.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t141_test_combinator_unification_double_tilde.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t142_test_combinator_unification_double_tilde.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t142_test_combinator_unification_double_tilde.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t143_test_combinator_unification_double_tilde.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t143_test_combinator_unification_double_tilde.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t144_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t144_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t145_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t145_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t146_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t146_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t147_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t147_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t148_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t148_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t149_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t149_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t150_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t150_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t151_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t151_test_combinator_unification_tilde_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t152_test_combinator_unification_angle_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t152_test_combinator_unification_angle_sibling.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t153_test_combinator_unification_angle_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t153_test_combinator_unification_angle_sibling.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t154_test_combinator_unification_angle_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t154_test_combinator_unification_angle_sibling.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t155_test_combinator_unification_angle_sibling.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t155_test_combinator_unification_angle_sibling.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t156_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t156_test_combinator_unification_double_angle.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t157_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t157_test_combinator_unification_double_angle.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t158_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t158_test_combinator_unification_double_angle.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t159_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t159_test_combinator_unification_double_angle.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t160_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t160_test_combinator_unification_double_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t161_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t161_test_combinator_unification_double_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t162_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t162_test_combinator_unification_double_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t163_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t163_test_combinator_unification_double_plus.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t164_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t164_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t165_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t165_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t166_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t166_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t167_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t167_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t168_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t168_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t169_test_combinator_unification_angle_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t169_test_combinator_unification_angle_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t170_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t170_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t171_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t171_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t172_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t172_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t173_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t173_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a.b x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t174_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t174_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t175_test_combinator_unification_plus_space.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t175_test_combinator_unification_plus_space.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t176_test_combinator_unification_nested.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t176_test_combinator_unification_nested.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > .b + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t177_test_combinator_unification_nested.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t177_test_combinator_unification_nested.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a > .b + x {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t178_test_combinator_unification_with_newlines.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t178_test_combinator_unification_with_newlines.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a >\

--- a/rsass/tests/spec/non_conformant/extend_tests/t179_test_extend_self_loop.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t179_test_extend_self_loop.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b; @extend .foo}\n"),

--- a/rsass/tests/spec/non_conformant/extend_tests/t180_test_basic_extend_loop.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t180_test_basic_extend_loop.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b; @extend .bar}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t181_test_three_level_extend_loop.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t181_test_three_level_extend_loop.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {a: b; @extend .bar}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t182_test_nested_extend_loop.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t182_test_nested_extend_loop.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".bar {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t183_test_multiple_extender_merges_with_superset_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t183_test_multiple_extender_merges_with_superset_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {@extend .bar; @extend .baz}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t187_test_basic_placeholder_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t187_test_basic_placeholder_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t188_test_unused_placeholder_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t188_test_unused_placeholder_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {color: blue}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t189_test_placeholder_descendant_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t189_test_placeholder_descendant_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("#context %foo a {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t190_test_semi_placeholder_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t190_test_semi_placeholder_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("#context %foo, .bar .baz {color: blue}\n\

--- a/rsass/tests/spec/non_conformant/extend_tests/t191_test_placeholder_selector_with_multiple_extenders.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t191_test_placeholder_selector_with_multiple_extenders.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {color: blue}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t192_test_placeholder_interpolation.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t192_test_placeholder_interpolation.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("$foo: foo;\n\

--- a/rsass/tests/spec/non_conformant/extend_tests/t194_test_extend_within_media.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t194_test_extend_within_media.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media screen {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t195_test_extend_within_unknown_directive.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t195_test_extend_within_unknown_directive.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@flooblehoof {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t196_test_extend_within_nested_directives.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t196_test_extend_within_nested_directives.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media screen {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t197_test_extend_within_disparate_media.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t197_test_extend_within_disparate_media.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media screen {.foo {a: b}}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t198_test_extend_within_disparate_unknown_directive.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t198_test_extend_within_disparate_unknown_directive.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@flooblehoof {.foo {a: b}}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t199_test_extend_within_disparate_nested_directives.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t199_test_extend_within_disparate_nested_directives.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media screen {@flooblehoof {.foo {a: b}}}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t206_test_extend_succeeds_when_one_extension_fails_but_others_dont.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t206_test_extend_succeeds_when_one_extension_fails_but_others_dont.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t207_test_optional_extend_succeeds_when_extendee_doesnt_exist.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t207_test_optional_extend_succeeds_when_extendee_doesnt_exist.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(runner().ok(".foo {@extend .bar !optional}\n"), "");
 }

--- a/rsass/tests/spec/non_conformant/extend_tests/t208_test_optional_extend_succeeds_when_extension_fails.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t208_test_optional_extend_succeeds_when_extension_fails.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t209_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t209_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t210_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t210_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x#bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t211_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t211_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x#bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t212_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t212_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x#bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t213_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t213_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x#bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t214_test_pseudo_element_superselector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t214_test_pseudo_element_superselector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x#bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t215_test_multiple_source_redundancy_elimination.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t215_test_multiple_source_redundancy_elimination.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%default-color {color: red}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t216_test_nested_sibling_extend.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t216_test_nested_sibling_extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {@extend .bar}\n\

--- a/rsass/tests/spec/non_conformant/extend_tests/t217_test_parent_and_sibling_extend.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t217_test_parent_and_sibling_extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t218_test_nested_extend_specificity.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t218_test_nested_extend_specificity.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo {a: b}\n\

--- a/rsass/tests/spec/non_conformant/extend_tests/t219_test_nested_double_extend_optimization.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t219_test_nested_double_extend_optimization.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%foo %bar {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t220_test_extend_in_double_nested_media_query.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t220_test_extend_in_double_nested_media_query.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("@media all {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t221_test_partially_failed_extend.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t221_test_partially_failed_extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("test { @extend .rc; }\

--- a/rsass/tests/spec/non_conformant/extend_tests/t222_test_newline_near_combinator.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t222_test_newline_near_combinator.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".a +\

--- a/rsass/tests/spec/non_conformant/extend_tests/t223_test_duplicated_selector_with_newlines.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t223_test_duplicated_selector_with_newlines.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".example-1-1,\

--- a/rsass/tests/spec/non_conformant/extend_tests/t224_test_nested_selector_with_child_selector_hack_extendee.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t224_test_nested_selector_with_child_selector_hack_extendee.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("> .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t225_test_nested_selector_with_child_selector_hack_extender.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t225_test_nested_selector_with_child_selector_hack_extender.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo .bar {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t226_test_nested_selector_with_child_selector_hack_extender_and_extendee.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t226_test_nested_selector_with_child_selector_hack_extender_and_extendee.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("> .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t227_test_nested_with_child_hack_extender_and_sibling_extendee.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t227_test_nested_with_child_hack_extender_and_sibling_extendee.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("~ .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t228_test_nested_with_child_selector_hack_extender_extendee_newline.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t228_test_nested_with_child_selector_hack_extender_extendee_newline.rs
@@ -8,7 +8,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("> .foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t229_test_extended_parent_and_child_redundancy_elimination.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t229_test_extended_parent_and_child_redundancy_elimination.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a {\

--- a/rsass/tests/spec/non_conformant/extend_tests/t230_test_extend_redundancy_elimination_when_it_would_reduce_specificity.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t230_test_extend_redundancy_elimination_when_it_would_reduce_specificity.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t231_test_extend_redundancy_elimination_when_it_would_preserve_specificity.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t231_test_extend_redundancy_elimination_when_it_would_preserve_specificity.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".bar a {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t232_test_extend_redundancy_elimination_never_eliminates_base_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t232_test_extend_redundancy_elimination_never_eliminates_base_selector.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("a.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t233_test_extend_cross_branch_redundancy_elimination.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t233_test_extend_cross_branch_redundancy_elimination.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x .c %y {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t234_test_extend_cross_branch_redundancy_elimination.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t234_test_extend_cross_branch_redundancy_elimination.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/extend_tests/t235_extend_with_universal_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t235_extend_with_universal_selector.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a *.foo1 {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t236_extend_with_universal_selector_empty_namespace.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t236_extend_with_universal_selector_empty_namespace.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a |*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t237_extend_with_universal_selector_different_namespace.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t237_extend_with_universal_selector_different_namespace.rs
@@ -7,7 +7,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%-a ns|*.foo {a: b}\

--- a/rsass/tests/spec/non_conformant/extend_tests/t238_unify_root_pseudoelement.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t238_unify_root_pseudoelement.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/misc/jma_pseudo_test.rs
+++ b/rsass/tests/spec/non_conformant/misc/jma_pseudo_test.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\

--- a/rsass/tests/spec/non_conformant/scss/nested_extend.rs
+++ b/rsass/tests/spec/non_conformant/scss/nested_extend.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".sprites-nav {\

--- a/rsass/tests/spec/non_conformant/scss/placeholder.rs
+++ b/rsass/tests/spec/non_conformant/scss/placeholder.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%x {\

--- a/rsass/tests/spec/non_conformant/scss/placeholder_with_media.rs
+++ b/rsass/tests/spec/non_conformant/scss/placeholder_with_media.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok("%a {\

--- a/rsass/tests/spec/non_conformant/scss_tests/t191_test_extend_in_media_in_rule.rs
+++ b/rsass/tests/spec/non_conformant/scss_tests/t191_test_extend_in_media_in_rule.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
+#[ignore] // unexepected error
 fn test() {
     assert_eq!(
         runner().ok(".foo {\


### PR DESCRIPTION
The `@extend` syntax wasn't supported before and isn't supported now, but now it signals an error instead of behaving like an unknown `@` rule.