### PR TITLE
Be more flexible in custom values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to
 
 ## Unreleased
 
+* Quoted strings can now be part of part of custom values (earlier, a
+  custom value could be _either_ a quoted string or something else).
+  Thanks @kartikynwa for reporting (issue #175, PR #176).
 * Some more (minor, mostly clippy-pedantic-suggested) internal cleanup.
 * Updated sass-spec test suite to 2023-07-21.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ project adheres to
 
 ## Unreleased
 
-* Quoted strings can now be part of part of custom values (earlier, a
-  custom value could be _either_ a quoted string or something else).
-  Thanks @kartikynwa for reporting (issue #175, PR #176).
+* Quoted strings can now be part of custom values (earlier, a custom value
+  could be _either_ a quoted string or something else).  Thanks @kartikynwa
+  for reporting (issue #175, PR #176).
 * Some more (minor, mostly clippy-pedantic-suggested) internal cleanup.
 * Updated sass-spec test suite to 2023-07-21.
 

--- a/rsass/src/parser/mod.rs
+++ b/rsass/src/parser/mod.rs
@@ -465,6 +465,7 @@ fn content_stmt2(input: Span) -> PResult<Item> {
 fn custom_property(input: Span) -> PResult<Item> {
     let (rest, name) = terminated(opt(sass_string), tag(":"))(input)?;
     let mut name = name.unwrap_or_else(|| SassString::from(""));
+    // The dashes was parsed before calling this method.
     name.prepend("--");
     let (rest, value) =
         terminated(custom_value, alt((tag(";"), peek(tag("}")))))(rest)?;

--- a/rsass/src/sass/string.rs
+++ b/rsass/src/sass/string.rs
@@ -139,6 +139,9 @@ impl SassString {
     pub(crate) fn append(&mut self, other: &Self) {
         self.parts.extend_from_slice(&other.parts);
     }
+    pub(crate) fn parts(self) -> Vec<StringPart> {
+        self.parts
+    }
 }
 
 impl fmt::Display for SassString {

--- a/rsass/tests/basic_manual.rs
+++ b/rsass/tests/basic_manual.rs
@@ -345,6 +345,40 @@ fn issue_116() {
     );
 }
 
+mod issue_175 {
+    use super::{init_logger, rsass};
+    #[test]
+    fn single() {
+        init_logger();
+        assert_eq!(
+            rsass(
+                b":root {\
+                  \n    --main-font: 'Times New Roman', serif;\
+                  \n}\n",
+            )
+            .unwrap(),
+            ":root {\
+             \n  --main-font: 'Times New Roman', serif;\
+             \n}\n"
+        );
+    }
+    #[test]
+    fn double() {
+        init_logger();
+        assert_eq!(
+            rsass(
+                b":root {\
+                  \n    --main-font: \"Times New Roman\", serif;\
+                  \n}\n",
+            )
+            .unwrap(),
+            ":root {\
+             \n  --main-font: \"Times New Roman\", serif;\
+             \n}\n"
+        );
+    }
+}
+
 /// Test auto-converted from "sass-spec/spec/libsass/rel.hrx", except one failing unit calculation.
 #[test]
 fn rel() {


### PR DESCRIPTION
The values of custom properties (css variables) are not parsed as ordinary values, but as a kind of extended strings.  Up to now, it was either a quoted string or a unquoted specially extended string.  Now, it is instead the extended string directly, but the extended string can contain quoted strings.

Fixes #175.