### PR TITLE
Improve `calc(...)` support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to
   could be _either_ a quoted string or something else).  Thanks @kartikynwa
   for reporting (issue #175, PR #176).
 * Improved handling of `calc(...)` expressions in plain css.
+* Improved handling of non-interpolated `calc(...)` expressions in scss,
+  they are now properly evaluated (PR #177).
 * Some more (minor, mostly clippy-pedantic-suggested) internal cleanup.
 * Updated sass-spec test suite to 2023-07-21.
 

--- a/rsass/src/css/binop.rs
+++ b/rsass/src/css/binop.rs
@@ -123,7 +123,7 @@ impl Display for Formatted<'_, BinOp> {
             self.value.a.format(self.format).fmt(out)?;
             self.value.b.format(self.format).fmt(out)
         } else {
-            use Operator::{Minus, Plus};
+            use Operator::{Div, Minus, Plus};
             fn is_op(v: &Value) -> Option<Operator> {
                 match v {
                     Value::BinOp(op) => Some(op.op),
@@ -137,6 +137,14 @@ impl Display for Formatted<'_, BinOp> {
                 }
                 (Minus, Value::Numeric(v, _)) if v.value.is_negative() => {
                     (Plus, Value::from(-v))
+                }
+                (Div, Value::Numeric(v, c))
+                    if !v.value.is_finite() && !v.is_no_unit() =>
+                {
+                    (
+                        Div,
+                        Value::Paren(Box::new(Value::Numeric(v.clone(), *c))),
+                    )
                 }
                 (op, Value::Paren(p)) => {
                     if let Some(op2) = is_op(p.as_ref()) {

--- a/rsass/src/sass/string.rs
+++ b/rsass/src/sass/string.rs
@@ -111,6 +111,13 @@ impl SassString {
     pub fn is_unquoted(&self) -> bool {
         self.quotes == Quotes::None
     }
+    /// Return true if self contains any string interpolation(s).
+    pub fn is_interpolated(&self) -> bool {
+        self.parts
+            .iter()
+            .any(|p| matches!(p, StringPart::Interpolation(_)))
+    }
+
     /// Check if this `SassString` is a single raw value.
     ///
     /// If so, return a reference to it.

--- a/rsass/src/value/operator.rs
+++ b/rsass/src/value/operator.rs
@@ -205,7 +205,7 @@ fn valid_operand(v: &Value) -> bool {
         Value::Numeric(..) => true,
         Value::Call(..) => true,
         Value::BinOp(_) => true,
-        Value::Literal(s) => s.is_css_fn(),
+        Value::Literal(_) => true,
         Value::Paren(v) => valid_operand(v),
         _ => false,
     }

--- a/rsass/tests/spec/values/calculation/calc/constant.rs
+++ b/rsass/tests/spec/values/calculation/calc/constant.rs
@@ -10,7 +10,6 @@ mod e {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn alone() {
         assert_eq!(
             runner().ok("a {b: calc(e)}\n"),
@@ -20,7 +19,6 @@ mod e {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn case_insensitive() {
         assert_eq!(
             runner().ok("a {b: calc(E)}\n"),
@@ -30,7 +28,6 @@ mod e {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn equals_max_precision() {
         assert_eq!(
         runner().ok(
@@ -47,7 +44,6 @@ mod e {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn simplified() {
             assert_eq!(
                 runner().ok("a {b: calc(e * 2)}\n"),
@@ -57,7 +53,6 @@ mod e {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn unsimplified() {
             assert_eq!(
                 runner().ok("a {b: calc(e * (1% + 1px))}\n"),
@@ -82,7 +77,6 @@ mod infinity {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn case_insensitive() {
         assert_eq!(
             runner().ok("a {b: calc(InFiNiTy)}\n"),
@@ -96,7 +90,6 @@ mod infinity {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn simplified() {
             assert_eq!(
                 runner().ok("a {b: calc(infinity * 2)}\n"),
@@ -110,7 +103,6 @@ mod infinity {
             use super::runner;
 
             #[test]
-            #[ignore] // wrong result
             fn computed() {
                 assert_eq!(
                     runner().ok("a {b: calc((1/0) * (1% + 1px))}\n"),
@@ -142,7 +134,6 @@ mod infinity {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn test_type() {
         assert_eq!(
             runner().ok("@use \'sass:meta\';\
@@ -167,7 +158,6 @@ mod minus_infinity {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn case_insensitive() {
         assert_eq!(
             runner().ok("a {b: calc(-iNfInItY)}\n"),
@@ -181,7 +171,6 @@ mod minus_infinity {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn simplified() {
             assert_eq!(
                 runner().ok("a {b: calc(-infinity * 2)}\n"),
@@ -195,7 +184,6 @@ mod minus_infinity {
             use super::runner;
 
             #[test]
-            #[ignore] // wrong result
             fn computed() {
                 assert_eq!(
                     runner().ok("a {b: calc((-1/0) * (1% + 1px))}\n"),
@@ -227,7 +215,6 @@ mod minus_infinity {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn test_type() {
         assert_eq!(
             runner().ok("@use \'sass:meta\';\
@@ -252,7 +239,6 @@ mod nan {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn case_insensitive() {
         assert_eq!(
             runner().ok("a {b: calc(nan)}\n"),
@@ -266,7 +252,6 @@ mod nan {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn simplified() {
             assert_eq!(
                 runner().ok("a {b: calc(NaN * 2)}\n"),
@@ -280,7 +265,6 @@ mod nan {
             use super::runner;
 
             #[test]
-            #[ignore] // wrong result
             fn computed() {
                 assert_eq!(
                     runner().ok("a {b: calc((0/0) * (1% + 1px))}\n"),
@@ -312,7 +296,6 @@ mod nan {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn test_type() {
         assert_eq!(
             runner().ok("@use \'sass:meta\';\
@@ -328,7 +311,6 @@ mod pi {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn alone() {
         assert_eq!(
             runner().ok("a {b: calc(pi)}\n"),
@@ -338,7 +320,6 @@ mod pi {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn case_insensitive() {
         assert_eq!(
             runner().ok("a {b: calc(pI)}\n"),
@@ -348,7 +329,6 @@ mod pi {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn equals_max_precision() {
         assert_eq!(
         runner().ok(
@@ -365,7 +345,6 @@ mod pi {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn simplified() {
             assert_eq!(
                 runner().ok("a {b: calc(pi * 2)}\n"),
@@ -375,7 +354,6 @@ mod pi {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn unsimplified() {
             assert_eq!(
                 runner().ok("a {b: calc(pi * (1% + 1px))}\n"),
@@ -414,7 +392,6 @@ mod precedence {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn after_minus() {
         assert_eq!(
             runner().ok("a {b: calc(1% - (infinity * 1px))}\n"),
@@ -424,7 +401,6 @@ mod precedence {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn after_plus() {
         assert_eq!(
             runner().ok("a {b: calc(1% + (infinity * 1px))}\n"),
@@ -434,7 +410,6 @@ mod precedence {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn after_times() {
         assert_eq!(
             runner().ok("a {b: calc(var(--c) * (infinity * 1px))}\n"),

--- a/rsass/tests/spec/values/calculation/calc/error/syntax.rs
+++ b/rsass/tests/spec/values/calculation/calc/error/syntax.rs
@@ -6,7 +6,7 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn dollar() {
     assert_eq!(
         runner().err("a {b: calc($)}\n"),
@@ -19,7 +19,7 @@ fn dollar() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn double_operator() {
     assert_eq!(
         runner().err("a {b: calc(1px ** 2px)}\n"),
@@ -32,7 +32,7 @@ fn double_operator() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn empty() {
     assert_eq!(
         runner().err("a {b: calc()}\n"),
@@ -115,7 +115,7 @@ fn leading_operator() {
     );
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn multiple_args() {
     assert_eq!(
         runner().err("a {b: calc(1px, 2px)}\n"),
@@ -136,7 +136,7 @@ mod no_whitespace {
         use super::runner;
 
         #[test]
-        #[ignore] // missing error
+        #[ignore] // wrong error
         fn after() {
             assert_eq!(
         runner().err(
@@ -233,7 +233,7 @@ mod no_whitespace {
     }
 }
 #[test]
-#[ignore] // missing error
+#[ignore] // wrong error
 fn trailing_operator() {
     assert_eq!(
         runner().err("a {b: calc(1px *)}\n"),


### PR DESCRIPTION
The `calc(...)` function can be parsed as a special string if, but only if, it contains a string interpolation.  In other cases, it is now parsed as a proper function call.  This change improves how it is evaluated.