### PR TITLE
Refactor selector handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ project adheres to
 * Handle trailing comma in function arguments in plain css correctly.
 * Refactored function name/plain string handling in scss values to not parse
   the same unquoted string twice.
+* Remove separate backref membere from `css::Selectors` for cleanup before
+  implementing more selector functions.  Instead, add it to an internal
+  struct `SelectorCtx` (PR #179).
 * Refactored some parsers for less backtracking, making it easier to point
   parse errors at the right place in the code and maybe making parsing
   slightly more efficient.

--- a/rsass/src/css/mod.rs
+++ b/rsass/src/css/mod.rs
@@ -23,4 +23,5 @@ pub use self::selectors::{BadSelector, Selector, SelectorPart, Selectors};
 pub use self::string::CssString;
 pub use self::value::{InvalidCss, Value, ValueMap, ValueToMapError};
 
+pub(crate) use self::selectors::SelectorCtx;
 pub(crate) use self::util::{is_calc_name, is_function_name, is_not};

--- a/rsass/src/output/transform.rs
+++ b/rsass/src/output/transform.rs
@@ -3,7 +3,7 @@
 
 use super::cssdest::CssDestination;
 use super::CssData;
-use crate::css::{self, AtRule, Import, Selectors};
+use crate::css::{self, AtRule, Import, SelectorCtx};
 use crate::error::ResultPos;
 use crate::input::{Context, Loader, Parsed, SourceKind};
 use crate::sass::{get_global_module, Expose, Item, UseAs};
@@ -152,7 +152,7 @@ fn handle_item(
                                 let selectors = scope.get_selectors();
                                 if !selectors.is_root() {
                                     let mut rule = thead
-                                        .start_rule(selectors.clone())
+                                        .start_rule(selectors.real())
                                         .at(pos)?;
                                     handle_body(
                                         &items,
@@ -207,7 +207,7 @@ fn handle_item(
                 .with_backref(scope.get_selectors().one());
             let subscope = ScopeRef::sub_selectors(scope, selectors.clone());
             if !selectors.is_root() {
-                let mut rule = dest.start_rule(selectors).no_pos()?;
+                let mut rule = dest.start_rule(selectors.real()).no_pos()?;
                 handle_body(body, &mut rule, subscope, file_context)?;
             } else {
                 handle_body(body, dest, subscope, file_context)?;
@@ -232,7 +232,7 @@ fn handle_item(
             if let Some(ref body) = *body {
                 let mut atrule = dest.start_atrule(name.clone(), args);
                 let local = if name == "keyframes" {
-                    ScopeRef::sub_selectors(scope, Selectors::root())
+                    ScopeRef::sub_selectors(scope, SelectorCtx::root())
                 } else {
                     ScopeRef::sub(scope)
                 };
@@ -358,9 +358,9 @@ fn handle_item(
 
         Item::Rule(ref selectors, ref body) => {
             check_body(body, BodyContext::Rule)?;
-            let selectors =
-                selectors.eval(scope.clone())?.inside(scope.get_selectors());
-            let mut dest = dest.start_rule(selectors.clone()).no_pos()?;
+            let selectors = SelectorCtx::from(selectors.eval(scope.clone())?)
+                .inside(scope.get_selectors());
+            let mut dest = dest.start_rule(selectors.real()).no_pos()?;
             let scope = ScopeRef::sub_selectors(scope, selectors);
             handle_body(body, &mut dest, scope, file_context)?;
         }

--- a/rsass/src/sass/functions/selector.rs
+++ b/rsass/src/sass/functions/selector.rs
@@ -22,7 +22,7 @@ pub fn create_module() -> Scope {
     def_va!(f, nest(selectors), |s| {
         let mut v = get_selectors(s, name!(selectors))?.into_iter();
         let first = v.next().unwrap().css_ok()?;
-        Ok(v.fold(first, |b, e| e.inside(&b)).into())
+        Ok(v.fold(first, |b, e| e.inside(&b.into())).into())
     });
     def!(f, parse(selector), |s| {
         Ok(s.get_map(name!(selector), parse_selectors_x)?.into())

--- a/rsass/src/sass/value.rs
+++ b/rsass/src/sass/value.rs
@@ -187,7 +187,7 @@ impl Value {
                     (op, v) => css::Value::UnaryOp(*op, Box::new(v)),
                 }
             }
-            Value::HereSelector => scope.get_selectors().clone().into(),
+            Value::HereSelector => scope.get_selectors().real().into(),
             Value::UnicodeRange(s) => css::Value::UnicodeRange(s.clone()),
         })
     }

--- a/rsass/src/variablescope.rs
+++ b/rsass/src/variablescope.rs
@@ -1,5 +1,5 @@
 //! A scope is something that contains variable values.
-use crate::css::{CssString, Selectors, Value};
+use crate::css::{CssString, SelectorCtx, Value};
 use crate::input::SourcePos;
 use crate::output::Format;
 use crate::sass::{Expose, Function, Item, MixinDecl, Name, UseAs};
@@ -35,7 +35,7 @@ impl ScopeRef {
         Self::dynamic(Scope::sub(parent))
     }
     /// Create a new subscope of a given parent with selectors.
-    pub fn sub_selectors(parent: ScopeRef, selectors: Selectors) -> Self {
+    pub fn sub_selectors(parent: ScopeRef, selectors: SelectorCtx) -> Self {
         Self::dynamic(Scope::sub_selectors(parent, selectors))
     }
     fn dynamic(scope: Scope) -> Self {
@@ -209,7 +209,7 @@ pub struct Scope {
     variables: Mutex<BTreeMap<Name, Value>>,
     mixins: Mutex<BTreeMap<Name, MixinDecl>>,
     functions: Mutex<BTreeMap<Name, Function>>,
-    selectors: Option<Selectors>,
+    selectors: Option<SelectorCtx>,
     forward: Mutex<Option<ScopeRef>>,
     format: Format,
     /// The thing to use for `@content` in a mixin.
@@ -264,7 +264,7 @@ impl Scope {
         }
     }
     /// Create a new subscope of a given parent with selectors.
-    pub fn sub_selectors(parent: ScopeRef, selectors: Selectors) -> Self {
+    pub fn sub_selectors(parent: ScopeRef, selectors: SelectorCtx) -> Self {
         let format = parent.get_format();
         Scope {
             parent: Some(parent),
@@ -506,9 +506,9 @@ impl Scope {
     }
 
     /// Get the selectors active for this scope.
-    pub fn get_selectors(&self) -> &Selectors {
+    pub fn get_selectors(&self) -> &SelectorCtx {
         lazy_static! {
-            static ref ROOT: Selectors = Selectors::root();
+            static ref ROOT: SelectorCtx = SelectorCtx::root();
         }
         self.selectors.as_ref().unwrap_or_else(|| {
             self.parent.as_ref().map_or(&ROOT, |p| p.get_selectors())


### PR DESCRIPTION
Move the separate backref selector from `Selector` to a new struct `SelectorCtx`, to have it only where needed.  This simplifies selector handling in rules and functions.