### PR TITLE
Filter out placeholder selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to
 
 ## Unreleased
 
+* Filter out placeholder selectors when writing the resulting css
+  (they are still parsed of the internal data representation, so they
+  can be used when implementing `@extend`) (PR #180).
 * Handle trailing comma in function arguments in plain css correctly.
 * Refactored function name/plain string handling in scss values to not parse
   the same unquoted string twice.

--- a/rsass/src/css/rule.rs
+++ b/rsass/src/css/rule.rs
@@ -28,17 +28,19 @@ impl Rule {
     /// Write this rule to a css output buffer.
     pub(crate) fn write(&self, buf: &mut CssBuf) -> io::Result<()> {
         if !self.body.is_empty() {
-            buf.do_indent_no_nl();
-            if buf.format().is_compressed() {
-                write!(buf, "{:#}", self.selectors)?;
-            } else {
-                write!(buf, "{}", self.selectors)?;
+            if let Some(selectors) = self.selectors.no_placeholder() {
+                buf.do_indent_no_nl();
+                if buf.format().is_compressed() {
+                    write!(buf, "{selectors:#}")?;
+                } else {
+                    write!(buf, "{selectors}")?;
+                }
+                buf.start_block();
+                for item in &self.body {
+                    item.write(buf)?;
+                }
+                buf.end_block();
             }
-            buf.start_block();
-            for item in &self.body {
-                item.write(buf)?;
-            }
-            buf.end_block();
         }
         Ok(())
     }

--- a/rsass/src/parser/selectors.rs
+++ b/rsass/src/parser/selectors.rs
@@ -27,7 +27,18 @@ pub fn selector(input: Span) -> PResult<Selector> {
 
 pub(crate) fn selector_part(input: Span) -> PResult<SelectorPart> {
     alt((
-        map(sass_string, SelectorPart::Simple),
+        map(
+            tuple((opt(tag("%")), sass_string, opt(tag("%")))),
+            |(pre, mut s, post)| {
+                if pre.is_some() {
+                    s.prepend("%");
+                }
+                if post.is_some() {
+                    s.append_str("%");
+                }
+                SelectorPart::Simple(s)
+            },
+        ),
         value(SelectorPart::Simple("*".into()), tag("*")),
         map(
             preceded(

--- a/rsass/src/parser/strings.rs
+++ b/rsass/src/parser/strings.rs
@@ -381,10 +381,8 @@ fn selector_string(input: Span) -> PResult<String> {
 }
 
 fn selector_plain_part(input: Span) -> PResult<&str> {
-    // TODO: This should include "%", but then it needs to be handled
-    // specially for keyframes percentages and placeholder selectors.
-    // Also TODO: This should probably be based on unicode alphanumeric.
-    map_res(is_not("\r\n\t <>$\"'\\#+*/()[]{}:;,=!&@"), input_to_str)(input)
+    // TODO: This should probably be based on unicode alphanumeric.
+    map_res(is_not("\r\n\t %<>$\"'\\#+*/()[]{}:;,=!&@"), input_to_str)(input)
 }
 
 fn hash_no_interpolation(input: Span) -> PResult<&str> {

--- a/rsass/tests/basic_manual.rs
+++ b/rsass/tests/basic_manual.rs
@@ -571,6 +571,20 @@ fn open_by_path_and_import() {
     );
 }
 
+#[test]
+fn skip_placeholders() {
+    assert_eq!(
+        rsass(
+            b"%p { color: pink; }\
+              \n%p, p { margin: 0 auto 1em 0; }\n"
+        )
+        .unwrap(),
+        "p {\
+         \n  margin: 0 auto 1em 0;\
+         \n}\n",
+    );
+}
+
 fn check_value(input: &str, expected: &str) {
     assert_eq!(
         String::from_utf8(

--- a/rsass/tests/spec/css/selector/placeholder.rs
+++ b/rsass/tests/spec/css/selector/placeholder.rs
@@ -14,7 +14,6 @@ mod pseudoselectors {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn solo() {
             assert_eq!(
         runner().ok(
@@ -26,7 +25,6 @@ mod pseudoselectors {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn with_real() {
             assert_eq!(
         runner().ok(
@@ -44,7 +42,6 @@ mod pseudoselectors {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn solo() {
             assert_eq!(
         runner().ok(
@@ -56,7 +53,6 @@ mod pseudoselectors {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn with_real() {
             assert_eq!(
         runner().ok(
@@ -74,7 +70,6 @@ mod pseudoselectors {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn solo() {
             assert_eq!(
         runner().ok(
@@ -87,7 +82,6 @@ mod pseudoselectors {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn universal() {
             assert_eq!(
         runner().ok(
@@ -100,7 +94,6 @@ mod pseudoselectors {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn with_real() {
             assert_eq!(
         runner().ok(
@@ -131,7 +124,6 @@ mod pseudoselectors {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn solo() {
             assert_eq!(
         runner().ok(
@@ -143,7 +135,6 @@ mod pseudoselectors {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn with_real() {
             assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_167.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_167.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("%l-cell, .l-cell {\r\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1996.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1996.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("$foo: \"bar\";\n\

--- a/rsass/tests/spec/libsass_closed_issues/issue_239.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_239.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/parser/selector.rs
+++ b/rsass/tests/spec/parser/selector.rs
@@ -10,7 +10,7 @@ mod error {
     use super::runner;
 
     #[test]
-    #[ignore] // missing error
+    #[ignore] // wrong error
     fn empty_placeholder() {
         assert_eq!(
             runner().err(


### PR DESCRIPTION
They are still parsed of the internal data representation, so they can be used when implementing `@extend`.

This is a part of the larger work to support `@extend`, #65.