### PR TITLE
Use logical selectors in nest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ project adheres to
 
 ## Unreleased
 
-* (Oops: Removed a missing dbg call.)
+* Improve support for the `selector.nest` function (PR #189).
+* Some internal cleanup and improvements in the next-generation css
+  selector implementation (which is currently internal and used only
+  for selector functions, but should replace the old css selector
+  implementation in release 0.29).
 
 
 ## Release 0.28.8

--- a/rsass/src/css/mod.rs
+++ b/rsass/src/css/mod.rs
@@ -23,5 +23,5 @@ pub use self::selectors::{BadSelector, Selector, SelectorPart, Selectors};
 pub use self::string::CssString;
 pub use self::value::{InvalidCss, Value, ValueMap, ValueToMapError};
 
-pub(crate) use self::selectors::{LogicalSelectorSet, SelectorCtx};
+pub(crate) use self::selectors::{CssSelectorSet, SelectorCtx};
 pub(crate) use self::util::{is_calc_name, is_function_name, is_not};

--- a/rsass/src/css/selectors.rs
+++ b/rsass/src/css/selectors.rs
@@ -14,8 +14,10 @@ use crate::value::ListSeparator;
 use std::fmt;
 use std::io::Write;
 
+mod cssselectorset;
 mod logical;
-pub(crate) use logical::SelectorSet as LogicalSelectorSet;
+pub(crate) use cssselectorset::CssSelectorSet;
+mod pseudo;
 
 /// A full set of selectors.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]

--- a/rsass/src/css/selectors/cssselectorset.rs
+++ b/rsass/src/css/selectors/cssselectorset.rs
@@ -1,0 +1,106 @@
+use crate::{css::Value, parser::input_span, Invalid};
+
+use super::{logical::SelectorSet, BadSelector};
+
+/// A CssSelectorset is like a [Selectorset] but valid in css.
+///
+/// The practical difference is that a CssSelectorset is guaranteed
+/// not to contain backrefs (`&`), which may be present in a
+/// Selectorset.
+pub struct CssSelectorSet {
+    pub(super) s: SelectorSet,
+}
+
+impl CssSelectorSet {
+    pub fn is_superselector(&self, sub: &CssSelectorSet) -> bool {
+        self.s.is_superselector(&sub.s)
+    }
+
+    pub(crate) fn nest(&self, other: SelectorSet) -> Self {
+        let mut parts = other
+            .s
+            .into_iter()
+            .map(|o| {
+                if o.has_backref() {
+                    o.resolve_ref(self)
+                } else {
+                    self.s.s.iter().map(|s| s.nest(&o)).collect()
+                }
+            })
+            .map(Vec::into_iter)
+            .collect::<Vec<_>>();
+
+        let mut result = Vec::new();
+        let mut empty = false;
+        while !empty {
+            empty = true;
+            for i in &mut parts {
+                if let Some(next) = i.next() {
+                    result.push(next);
+                    empty = false;
+                }
+            }
+        }
+
+        CssSelectorSet {
+            s: SelectorSet { s: result },
+        }
+    }
+
+    pub(crate) fn replace(
+        self,
+        original: &Self,
+        replacement: &Self,
+    ) -> Result<Self, Invalid> {
+        self.s
+            .replace(&original.s, &replacement.s)
+            .map(|s| CssSelectorSet { s })
+    }
+
+    pub(crate) fn unify(self, other: Self) -> Self {
+        CssSelectorSet {
+            s: SelectorSet {
+                s: self
+                    .s
+                    .s
+                    .into_iter()
+                    .flat_map(|s| {
+                        other
+                            .s
+                            .s
+                            .iter()
+                            .flat_map(move |o| s.clone().unify(o.clone()))
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl TryFrom<SelectorSet> for CssSelectorSet {
+    type Error = BadSelector;
+
+    fn try_from(value: SelectorSet) -> Result<Self, Self::Error> {
+        for s in &value.s {
+            if s.has_backref() {
+                let sel = s.clone().into_string_vec().join(" ");
+                return Err(BadSelector::Backref(input_span(sel)));
+            }
+        }
+        Ok(CssSelectorSet { s: value })
+    }
+}
+
+impl TryFrom<Value> for CssSelectorSet {
+    type Error = BadSelector;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        SelectorSet::try_from(value)?.try_into()
+    }
+}
+
+impl From<CssSelectorSet> for Value {
+    fn from(value: CssSelectorSet) -> Self {
+        value.s.into()
+    }
+}

--- a/rsass/src/css/selectors/pseudo.rs
+++ b/rsass/src/css/selectors/pseudo.rs
@@ -1,0 +1,153 @@
+use super::{logical::SelectorSet, CssSelectorSet};
+use crate::css::{CssString, Selectors};
+
+/// A pseudo-class or a css2 pseudo-element (:foo)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Pseudo {
+    /// The name of the pseudo-class
+    name: String,
+    /// Arguments to the pseudo-class
+    arg: Option<SelectorSet>,
+    /// True if this is a `::psedu-element`, false for a `:pseudo-class`.
+    element: bool,
+}
+
+impl Pseudo {
+    /// Named constructor for pseudo classes.
+    pub(crate) fn class(name: &CssString, arg: &Option<Selectors>) -> Self {
+        Pseudo {
+            name: name.value().into(),
+            arg: arg.as_ref().and_then(|s| SelectorSet::try_from(s).ok()),
+            element: false,
+        }
+    }
+
+    /// Named constructor for psedo elements.
+    pub(crate) fn element(name: &CssString, arg: &Option<Selectors>) -> Self {
+        Pseudo {
+            name: name.value().into(),
+            arg: arg.as_ref().and_then(|s| SelectorSet::try_from(s).ok()),
+            element: true,
+        }
+    }
+
+    pub(crate) fn is_superselector(&self, b: &Self) -> bool {
+        if self.is_element() != b.is_element() || self.name != b.name {
+            return false;
+        }
+        // Note: A better implementetation of is/matches/any would be
+        // different from has, host, and host-context.
+        if name_in(
+            &self.name,
+            &[
+                "is",
+                "matches",
+                "any",
+                "where",
+                "has",
+                "host",
+                "host-context",
+            ],
+        ) {
+            if self.arg == b.arg {
+                true
+            } else if let (Some(a), Some(b)) = (&self.arg, &b.arg) {
+                a.is_superselector(b)
+            } else {
+                false
+            }
+        } else if name_in(&self.name, &["not"]) {
+            if let (Some(a), Some(b)) = (&self.arg, &b.arg) {
+                b.is_superselector(a) // NOTE: Reversed!
+            } else {
+                false
+            }
+        } else {
+            self.name == b.name && self.arg == b.arg
+        }
+    }
+
+    pub(super) fn is_element(&self) -> bool {
+        self.element || is_pseudo_element(&self.name)
+    }
+    pub(super) fn is_hover(&self) -> bool {
+        self.name == "hover"
+    }
+    pub(super) fn is_host(&self) -> bool {
+        name_in(&self.name, &["host", "host-context"])
+    }
+    pub(super) fn is_rootish(&self) -> bool {
+        name_in(&self.name, &["host", "host-context", "root", "scope"])
+    }
+
+    pub(super) fn has_backref(&self) -> bool {
+        self.arg.as_ref().map_or(false, SelectorSet::has_backref)
+    }
+    pub(super) fn resolve_ref(mut self, ctx: &CssSelectorSet) -> Self {
+        self.arg = self.arg.map(|arg| arg.resolve_ref(ctx));
+        self
+    }
+    pub(super) fn replace(
+        mut self,
+        original: &SelectorSet,
+        replacement: &SelectorSet,
+    ) -> Self {
+        if name_in(
+            &self.name,
+            &[
+                "is",
+                "matches",
+                "not",
+                "any",
+                "where",
+                "has",
+                "host",
+                "host-context",
+            ],
+        ) {
+            self.arg =
+                self.arg.map(|s| s.replace(original, replacement).unwrap());
+        }
+        self
+    }
+
+    pub(super) fn write_to_buf(&self, buf: &mut String) {
+        buf.push(':');
+        if self.element {
+            buf.push(':');
+        }
+        buf.push_str(&self.name);
+        if let Some(arg) = &self.arg {
+            buf.push('(');
+            arg.write_to_buf(buf);
+            buf.push(')');
+        }
+    }
+}
+
+fn is_pseudo_element(n: &str) -> bool {
+    let pse = [
+        "after",
+        "before",
+        "file-selector-button",
+        "first-letter",
+        "first-line",
+        "grammar-error",
+        "marker",
+        "placeholder",
+        "selection",
+        "spelling-error",
+        "target-text",
+    ];
+    pse.binary_search(&n).is_ok()
+}
+
+fn name_in(name: &str, known: &[&str]) -> bool {
+    if name.starts_with('-') {
+        known.iter().any(|end| {
+            name.strip_suffix(end).map_or(false, |s| s.ends_with('-'))
+        })
+    } else {
+        known.iter().any(|known| name == *known)
+    }
+}

--- a/rsass/src/parser/error.rs
+++ b/rsass/src/parser/error.rs
@@ -31,7 +31,7 @@ impl ParseError {
         }
     }
 
-    fn new<Msg>(msg: Msg, pos: SourcePos) -> Self
+    pub(crate) fn new<Msg>(msg: Msg, pos: SourcePos) -> Self
     where
         Msg: Into<String>,
     {

--- a/rsass/src/sass/functions/mod.rs
+++ b/rsass/src/sass/functions/mod.rs
@@ -416,6 +416,18 @@ fn looks_like_call(s: &CssString) -> bool {
         && s.value().ends_with(')')
 }
 
+/// Convert an error for a specific argument to not mentioning the argument.
+///
+/// Ok results and other errors are returned unmodified.
+/// This is used in some cases to make errors from rsass the same as
+/// the expected errors for dart sass.
+fn unnamed<T>(result: Result<T, CallError>) -> Result<T, CallError> {
+    match result {
+        Err(CallError::BadArgument(_name, msg)) => Err(CallError::msg(msg)),
+        other => other,
+    }
+}
+
 mod check {
     use super::{expected_to, is_not};
     use crate::css::Value;

--- a/rsass/tests/spec/core_functions/selector/nest/error.rs
+++ b/rsass/tests/spec/core_functions/selector/nest/error.rs
@@ -66,7 +66,6 @@ mod parent {
         );
     }
     #[test]
-    #[ignore] // missing error
     fn non_initial() {
         assert_eq!(
         runner().err(
@@ -86,7 +85,6 @@ mod parent {
     );
     }
     #[test]
-    #[ignore] // missing error
     fn prefix() {
         assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/selector/nest/list.rs
+++ b/rsass/tests/spec/core_functions/selector/nest/list.rs
@@ -78,7 +78,6 @@ mod list {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn multiple() {
             assert_eq!(
                 runner().ok("a {b: selector-nest(\"c, d\", \"&.e &.f\")}\n"),
@@ -92,7 +91,6 @@ mod list {
             use super::runner;
 
             #[test]
-            #[ignore] // wrong result
             fn is() {
                 assert_eq!(
                     runner()
@@ -103,7 +101,6 @@ mod list {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn matches() {
                 assert_eq!(
                     runner().ok(
@@ -115,7 +112,6 @@ mod list {
                 );
             }
             #[test]
-            #[ignore] // wrong result
             fn test_where() {
                 assert_eq!(
                     runner().ok(


### PR DESCRIPTION
This adds supports for sass backref (`&`) is `LogicalSelectorSet` and introduces a new type, `CssSelectorSet`, which is guaranteed to not contain backrefs.

Functions that are intended to not accept backrefs are moved to `CssSelectorSet`.  The `nest` function is also created as a `CssSelectorSet` method, as the first argument may not contain backrefs.  The other argument is a `LogicalSelectorSet`, though.