### PR TITLE
Parse new selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ project adheres to
 * Improved support for the `selector.nest` function (PR #189).
 * Moved `selector.append` to new selector implementation (PR #190).
 * Implemented the `selector.simple-selectors` function (PR #191).
+* Parse next-generation css selectors directly (rather than parsing as
+  the old type and converting to the new).  Fixes the `selector.parse`
+  function and improves support for other selector functions (PR #192).
 * Some internal cleanup and improvements in the next-generation css
   selector implementation (which is currently internal and used only
   for selector functions, but should replace the old css selector

--- a/rsass/src/css/selectors/attribute.rs
+++ b/rsass/src/css/selectors/attribute.rs
@@ -14,19 +14,6 @@ pub(super) struct Attribute {
 }
 
 impl Attribute {
-    pub fn new(
-        name: &CssString,
-        op: &str,
-        val: &CssString,
-        modifier: Option<char>,
-    ) -> Self {
-        Attribute {
-            name: name.value().into(),
-            op: op.into(),
-            val: val.clone(),
-            modifier,
-        }
-    }
     pub(super) fn is_superselector(&self, b: &Self) -> bool {
         self.name == b.name
             && self.op == b.op
@@ -43,5 +30,67 @@ impl Attribute {
             buf.push(m);
         }
         buf.push(']');
+    }
+}
+
+pub(crate) mod parser {
+    use super::super::logical::parser::name_opt_ns;
+    use super::Attribute;
+    use crate::parser::css::css_string_any;
+    use crate::parser::{input_to_str, util::opt_spacelike, PResult, Span};
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    use nom::character::complete::one_of;
+    use nom::combinator::{map, map_res, opt};
+    use nom::sequence::{delimited, terminated, tuple};
+
+    pub fn attribute(input: Span) -> PResult<Attribute> {
+        delimited(
+            terminated(tag("["), opt_spacelike),
+            alt((
+                map(
+                    tuple((
+                        terminated(name_opt_ns, opt_spacelike),
+                        terminated(
+                            map_res(
+                                alt((
+                                    tag("*="),
+                                    tag("|="),
+                                    tag("="),
+                                    tag("$="),
+                                    tag("~="),
+                                    tag("^="),
+                                )),
+                                input_to_str,
+                            ),
+                            opt_spacelike,
+                        ),
+                        terminated(css_string_any, opt_spacelike),
+                        opt(terminated(
+                            one_of(
+                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                                 abcdefghijklmnopqrstuvwxyz",
+                            ),
+                            opt_spacelike,
+                        )),
+                    )),
+                    |(name, op, val, modifier)| Attribute {
+                        name,
+                        op: op.to_owned(),
+                        val,
+                        modifier,
+                    },
+                ),
+                map(terminated(name_opt_ns, opt_spacelike), |name| {
+                    Attribute {
+                        name,
+                        op: String::new(),
+                        val: "".into(),
+                        modifier: None,
+                    }
+                }),
+            )),
+            tag("]"),
+        )(input)
     }
 }

--- a/rsass/src/css/selectors/attribute.rs
+++ b/rsass/src/css/selectors/attribute.rs
@@ -2,7 +2,7 @@ use crate::css::CssString;
 
 /// A logical attribute selector.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct Attribute {
+pub(crate) struct Attribute {
     /// The attribute name
     name: String,
     /// An operator
@@ -44,7 +44,7 @@ pub(crate) mod parser {
     use nom::combinator::{map, map_res, opt};
     use nom::sequence::{delimited, terminated, tuple};
 
-    pub fn attribute(input: Span) -> PResult<Attribute> {
+    pub(crate) fn attribute(input: Span) -> PResult<Attribute> {
         delimited(
             terminated(tag("["), opt_spacelike),
             alt((

--- a/rsass/src/css/selectors/cssselectorset.rs
+++ b/rsass/src/css/selectors/cssselectorset.rs
@@ -44,7 +44,7 @@ impl CssSelectorSet {
         fn join3(value: &Value) -> Result<String, BadSelector0> {
             match value {
                 Value::Literal(s) => Ok(s.value().to_string()),
-                _ => return Err(BadSelector0::Value),
+                _ => Err(BadSelector0::Value),
             }
         }
         let selector = join(&value).map_err(|e| e.ctx(value))?;

--- a/rsass/src/css/selectors/cssselectorset.rs
+++ b/rsass/src/css/selectors/cssselectorset.rs
@@ -1,6 +1,11 @@
 use super::selectorset::SelectorSet;
-use super::BadSelector;
-use crate::{css::Value, parser::input_span, sass::CallError, Invalid};
+use super::{BadSelector, BadSelector0};
+use crate::css::Value;
+use crate::error::Invalid;
+use crate::parser::{input_span, ParseError};
+use crate::sass::CallError;
+use crate::value::ListSeparator;
+use nom::Finish;
 
 /// A `CssSelectorset` is like a [`Selectorset`] but valid in css.
 ///
@@ -12,6 +17,50 @@ pub struct CssSelectorSet {
 }
 
 impl CssSelectorSet {
+    pub fn parse_value(value: Value) -> Result<Self, BadSelector> {
+        fn join(value: &Value) -> Result<String, BadSelector0> {
+            if let Value::List(vs, Some(ListSeparator::Comma), false) = value
+            {
+                vs.iter()
+                    .map(join2)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|v| v.join(", "))
+            } else {
+                join2(value)
+            }
+        }
+        fn join2(value: &Value) -> Result<String, BadSelector0> {
+            if let Value::List(vs, Some(ListSeparator::Space) | None, false) =
+                value
+            {
+                vs.iter()
+                    .map(join3)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|v| v.join(" "))
+            } else {
+                join3(value)
+            }
+        }
+        fn join3(value: &Value) -> Result<String, BadSelector0> {
+            match value {
+                Value::Literal(s) => Ok(s.value().to_string()),
+                _ => return Err(BadSelector0::Value),
+            }
+        }
+        let selector = join(&value).map_err(|e| e.ctx(value))?;
+        let span = input_span(selector);
+
+        let (rest, value) =
+            super::selectorset::parser::selector_set(span.borrow())
+                .finish()
+                .map_err(ParseError::from)?;
+        if rest.fragment().is_empty() {
+            value.try_into()
+        } else {
+            Err(ParseError::new("expected selector.", rest.to_owned()).into())
+        }
+    }
+
     pub fn is_superselector(&self, sub: &CssSelectorSet) -> bool {
         self.s.is_superselector(&sub.s)
     }

--- a/rsass/src/css/selectors/logical.rs
+++ b/rsass/src/css/selectors/logical.rs
@@ -801,7 +801,7 @@ pub(crate) mod parser {
     use super::super::attribute::parser::attribute;
     use super::super::pseudo::parser::pseudo;
     use super::{ElemType, RelKind, Selector};
-    use crate::parser::css::css_string_nohash as css_string;
+    use crate::parser::css::strings::css_string_nohash as css_string;
     use crate::parser::util::{opt_spacelike, spacelike};
     use crate::parser::{PResult, Span};
     use nom::branch::alt;

--- a/rsass/src/css/selectors/logical.rs
+++ b/rsass/src/css/selectors/logical.rs
@@ -810,7 +810,7 @@ pub(crate) mod parser {
     use nom::multi::fold_many0;
     use nom::sequence::{delimited, pair, preceded};
 
-    pub fn selector(input: Span) -> PResult<Selector> {
+    pub(crate) fn selector(input: Span) -> PResult<Selector> {
         let (input, prerel) = opt(rel_kind)(input)?;
         let (input, first) = if let Some(prerel) = prerel {
             let (input, first) = opt(compound_selector)(input)?;
@@ -846,7 +846,7 @@ pub(crate) mod parser {
         ))(input)
     }
 
-    pub fn compound_selector(input: Span) -> PResult<Selector> {
+    pub(crate) fn compound_selector(input: Span) -> PResult<Selector> {
         let mut result = Selector::default();
         let (rest, backref) = opt(value((), tag("&")))(input)?;
         result.backref = backref;
@@ -887,7 +887,7 @@ pub(crate) mod parser {
         Ok((rest, result))
     }
 
-    pub fn name_opt_ns(input: Span) -> PResult<String> {
+    pub(crate) fn name_opt_ns(input: Span) -> PResult<String> {
         fn name_part(input: Span) -> PResult<String> {
             alt((value(String::from("*"), tag("*")), css_string))(input)
         }

--- a/rsass/src/css/selectors/pseudo.rs
+++ b/rsass/src/css/selectors/pseudo.rs
@@ -175,7 +175,7 @@ pub(crate) mod parser {
     use nom::combinator::{map, value};
     use nom::sequence::{delimited, tuple};
 
-    pub fn pseudo(input: Span) -> PResult<Pseudo> {
+    pub(crate) fn pseudo(input: Span) -> PResult<Pseudo> {
         map(
             tuple((
                 alt((value(true, tag("::")), value(false, tag(":")))),

--- a/rsass/src/css/selectors/pseudo.rs
+++ b/rsass/src/css/selectors/pseudo.rs
@@ -168,8 +168,10 @@ impl Arg {
 pub(crate) mod parser {
     use super::super::selectorset::parser::selector_set;
     use super::{Arg, Pseudo};
-    use crate::parser::css::strings::custom_value_inner;
-    use crate::parser::{css::css_string, PResult, Span};
+    use crate::parser::css::strings::{
+        css_string_nohash, custom_value_inner,
+    };
+    use crate::parser::{PResult, Span};
     use nom::branch::alt;
     use nom::bytes::complete::tag;
     use nom::combinator::{map, value};
@@ -179,7 +181,7 @@ pub(crate) mod parser {
         map(
             tuple((
                 alt((value(true, tag("::")), value(false, tag(":")))),
-                css_string,
+                css_string_nohash,
                 // Note: The accepted type of selector should probably
                 // depend on the name, so that known pseudo attributes
                 // requires the correct kind of arguments.

--- a/rsass/src/css/selectors/selectorset.rs
+++ b/rsass/src/css/selectors/selectorset.rs
@@ -20,7 +20,7 @@ impl SelectorSet {
             .all(|sub| self.s.iter().any(|sup| sup.is_superselector(sub)))
     }
 
-    pub fn replace(
+    pub(crate) fn replace(
         self,
         original: &SelectorSet,
         replacement: &SelectorSet,
@@ -117,7 +117,7 @@ pub(crate) mod parser {
     use nom::multi::separated_list1;
     use nom::sequence::delimited;
 
-    pub fn selector_set(input: Span) -> PResult<SelectorSet> {
+    pub(crate) fn selector_set(input: Span) -> PResult<SelectorSet> {
         map(
             separated_list1(
                 delimited(opt_spacelike, tag(","), opt_spacelike),

--- a/rsass/src/parser/css/mod.rs
+++ b/rsass/src/parser/css/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod media;
 mod rule;
 mod selectors;
-mod strings;
+pub(crate) mod strings;
 mod values;
 
 pub(crate) use self::selectors::{selector, selector_parts, selectors};

--- a/rsass/src/parser/css/mod.rs
+++ b/rsass/src/parser/css/mod.rs
@@ -5,9 +5,6 @@ pub(crate) mod strings;
 mod values;
 
 pub(crate) use self::selectors::{selector, selector_parts, selectors};
-pub(crate) use self::strings::{
-    css_string, css_string_any, css_string_nohash,
-};
 
 use super::util::{opt_spacelike, spacelike};
 use super::{PResult, Span};

--- a/rsass/src/parser/css/mod.rs
+++ b/rsass/src/parser/css/mod.rs
@@ -5,6 +5,9 @@ mod strings;
 mod values;
 
 pub(crate) use self::selectors::{selector, selector_parts, selectors};
+pub(crate) use self::strings::{
+    css_string, css_string_any, css_string_nohash,
+};
 
 use super::util::{opt_spacelike, spacelike};
 use super::{PResult, Span};

--- a/rsass/src/parser/css/strings.rs
+++ b/rsass/src/parser/css/strings.rs
@@ -38,6 +38,21 @@ pub fn css_string(input: Span) -> PResult<String> {
     )(input)
 }
 
+pub fn css_string_nohash(input: Span) -> PResult<String> {
+    let (input, first) =
+        alt((selector_plain_part, normalized_first_escaped_char))(input)?;
+    fold_many0(
+        // Note: This could probably be a whole lot more efficient,
+        // but try to get stuff correct before caring too much about that.
+        alt((selector_plain_part, normalized_escaped_char)),
+        move || first.clone(),
+        |mut acc: String, item: String| {
+            acc.push_str(&item);
+            acc
+        },
+    )(input)
+}
+
 pub fn css_string_dq(input: Span) -> PResult<CssString> {
     let (input, parts) = delimited(
         tag("\""),

--- a/rsass/src/parser/mod.rs
+++ b/rsass/src/parser/mod.rs
@@ -527,7 +527,7 @@ fn body_block2(input: Span) -> PResult<Vec<Item>> {
     Ok((input, v))
 }
 
-fn input_to_str(s: Span) -> Result<&str, Utf8Error> {
+pub(crate) fn input_to_str(s: Span) -> Result<&str, Utf8Error> {
     from_utf8(s.fragment())
 }
 

--- a/rsass/src/parser/util.rs
+++ b/rsass/src/parser/util.rs
@@ -8,6 +8,15 @@ use nom::multi::{fold_many0, fold_many1, many0};
 use nom::sequence::{preceded, terminated};
 use std::str::from_utf8;
 
+pub(crate) fn term_opt_space<'a, F, T>(
+    f: F,
+) -> impl FnMut(Span<'a>) -> PResult<'a, T>
+where
+    F: FnMut(Span<'a>) -> PResult<'a, T>,
+{
+    terminated(f, opt_spacelike)
+}
+
 pub fn semi_or_end(input: Span) -> PResult<()> {
     terminated(
         opt_spacelike,

--- a/rsass/src/sass/functions/selector.rs
+++ b/rsass/src/sass/functions/selector.rs
@@ -31,7 +31,9 @@ pub fn create_module() -> Scope {
         Ok(v.fold(first, |b, e| b.nest(e)).into())
     });
     def!(f, parse(selector), |s| {
-        Ok(s.get::<CssSelectorSet>(name!(selector))?.into())
+        CssSelectorSet::parse_value(s.get(name!(selector))?)
+            .named(name!(selector))
+            .map(Into::into)
     });
     def!(f, replace(selector, original, replacement), |s| {
         let selector: CssSelectorSet = s.get(name!(selector))?;

--- a/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/arg.rs
+++ b/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/arg.rs
@@ -10,7 +10,6 @@ mod class {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn equal() {
         assert_eq!(
             runner()
@@ -25,7 +24,6 @@ mod class {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn argument() {
             assert_eq!(
                 runner().ok(
@@ -37,7 +35,6 @@ mod class {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn has_argument() {
             assert_eq!(
                 runner().ok("a {b: is-superselector(\":c(@#$)\", \":c\")}\n"),
@@ -47,7 +44,6 @@ mod class {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn name() {
             assert_eq!(
                 runner().ok(
@@ -65,7 +61,6 @@ mod element {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn equal() {
         assert_eq!(
             runner()
@@ -80,7 +75,6 @@ mod element {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn argument() {
             assert_eq!(
                 runner().ok(
@@ -92,7 +86,6 @@ mod element {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn has_argument() {
             assert_eq!(
                 runner()
@@ -103,7 +96,6 @@ mod element {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn name() {
             assert_eq!(
                 runner().ok(

--- a/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/nth_child.rs
+++ b/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/nth_child.rs
@@ -56,7 +56,6 @@ mod prefix {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn superset() {
         assert_eq!(
             runner().ok("a {\
@@ -84,7 +83,6 @@ fn subset() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn superset() {
     assert_eq!(
         runner().ok("a {\

--- a/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/nth_last_child.rs
+++ b/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/nth_last_child.rs
@@ -59,7 +59,6 @@ mod prefix {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn superset() {
         assert_eq!(
             runner().ok("a {\
@@ -87,7 +86,6 @@ fn subset() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn superset() {
     assert_eq!(
         runner().ok("a {\

--- a/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/slotted.rs
+++ b/rsass/tests/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/slotted.rs
@@ -32,7 +32,6 @@ mod prefix {
     );
     }
     #[test]
-    #[ignore] // wrong result
     fn superset() {
         assert_eq!(
         runner().ok(
@@ -56,7 +55,6 @@ fn subset() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn superset() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/core_functions/selector/nest/error.rs
+++ b/rsass/tests/spec/core_functions/selector/nest/error.rs
@@ -66,6 +66,7 @@ mod parent {
         );
     }
     #[test]
+    #[ignore] // wrong error
     fn non_initial() {
         assert_eq!(
         runner().err(
@@ -85,6 +86,7 @@ mod parent {
     );
     }
     #[test]
+    #[ignore] // wrong error
     fn prefix() {
         assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/selector/parse/error.rs
+++ b/rsass/tests/spec/core_functions/selector/parse/error.rs
@@ -55,7 +55,6 @@ mod parse {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong error
     fn extra() {
         assert_eq!(
             runner().err("a {b: selector-parse(\"c {\")}\n"),

--- a/rsass/tests/spec/core_functions/selector/parse/selector.rs
+++ b/rsass/tests/spec/core_functions/selector/parse/selector.rs
@@ -223,7 +223,6 @@ mod simple {
             use super::runner;
 
             #[test]
-            #[ignore] // unexepected error
             fn arg() {
                 assert_eq!(
                     runner().ok("a {b: selector-parse(\":c(@#$)\")}\n"),
@@ -316,7 +315,6 @@ mod simple {
             use super::runner;
 
             #[test]
-            #[ignore] // unexepected error
             fn arg() {
                 assert_eq!(
                     runner().ok("a {b: selector-parse(\"::c(@#$)\")}\n"),

--- a/rsass/tests/spec/core_functions/selector/unify/simple/pseudo.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/simple/pseudo.rs
@@ -14,7 +14,6 @@ mod arg {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn different() {
             assert_eq!(
                 runner()
@@ -25,7 +24,6 @@ mod arg {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn same() {
             assert_eq!(
                 runner()
@@ -41,7 +39,6 @@ mod arg {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn different() {
             assert_eq!(
         runner().ok(
@@ -53,7 +50,6 @@ mod arg {
     );
         }
         #[test]
-        #[ignore] // unexepected error
         fn same() {
             assert_eq!(
                 runner().ok(


### PR DESCRIPTION
Parse next-generation css selectors directly (rather than parsing as the old type and converting to the new).  Fixes the `selector.parse` function and improves support for other selector functions.