### PR TITLE
Improve colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ project adheres to
 
 ### Other changes:
 
+* Lots of color handling.
+  - Spec changes for traditional css colors (PR #198).
 * Updated sass-spec test suite to 2024-09-13.
 
 

--- a/rsass/src/css/valueformat.rs
+++ b/rsass/src/css/valueformat.rs
@@ -19,11 +19,11 @@ impl<'a> Display for Formatted<'a, Value> {
                 write!(out, "get-function(\"{name}\")")
             }
             Value::Numeric(ref num, _) => num.format(self.format).fmt(out),
-            Value::Color(ref rgba, ref name) => {
+            Value::Color(ref col, ref name) => {
                 if let Some(ref name) = *name {
                     name.fmt(out)
                 } else {
-                    rgba.format(self.format).fmt(out)
+                    col.format(self.format).fmt(out)
                 }
             }
             Value::List(ref v, sep, brackets) => {

--- a/rsass/src/sass/functions/color/channels.rs
+++ b/rsass/src/sass/functions/color/channels.rs
@@ -17,60 +17,54 @@ impl TryFrom<Value> for Channels {
         if is_special(&channels) {
             Ok(Self::Special(channels))
         } else if let Value::List(vec, sep, bracketed) = channels.clone() {
-            use crate::value::Operator::Div;
-            use Value::{BinOp, Numeric};
             if bracketed {
-                return Err(ChaError::Bracketed);
-            }
-            if sep == Some(ListSeparator::Comma) {
-                return Err(ChaError::BadSep);
-            }
-            if sep == Some(ListSeparator::Slash) {
-                match vec.as_slice() {
-                    [Value::List(inner, i_s, i_b), a] => {
-                        if *i_b {
-                            return Err(ChaError::Bracketed);
-                        }
-                        if i_s.unwrap_or_default() != ListSeparator::Space {
-                            return Err(ChaError::BadSep);
-                        }
-                        Ok(inner_channels(inner)?.map_or_else(
-                            || Self::Special(channels),
-                            |[c1, c2, c3]| {
-                                Self::Data([c1, c2, c3, a.clone()])
-                            },
-                        ))
-                    }
-                    [h, _a] => {
-                        if is_special(h) {
-                            Ok(Self::Special(channels))
-                        } else {
-                            Err(ChaError::Missing1)
-                        }
-                    }
-                    list => Err(ChaError::SlashBadNum(list.len())),
-                }
+                Err(ChaError::Bracketed)
             } else {
-                match vec.as_slice() {
-                    [r, g, BinOp(op)] if op.op() == Div => Ok(
-                        if let (b @ Numeric(..), a @ Numeric(..)) =
-                            (op.a(), op.b())
-                        {
-                            Self::Data([
+                use crate::value::Operator::Div;
+                match sep {
+                    Some(ListSeparator::Comma) => {
+                        return Err(ChaError::BadSep);
+                    }
+                    Some(ListSeparator::Slash) => match vec.as_slice() {
+                        [Value::List(inner, i_s, i_b), a] => {
+                            if *i_b {
+                                return Err(ChaError::Bracketed);
+                            }
+                            if i_s.unwrap_or_default() != ListSeparator::Space
+                            {
+                                return Err(ChaError::BadSep);
+                            }
+                            Ok(inner_channels(inner)?.map_or_else(
+                                || Self::Special(channels),
+                                |[c1, c2, c3]| {
+                                    Self::Data([c1, c2, c3, a.clone()])
+                                },
+                            ))
+                        }
+                        [h, _a] => {
+                            if is_special(h) {
+                                Ok(Self::Special(channels))
+                            } else {
+                                Err(ChaError::Missing1)
+                            }
+                        }
+                        list => Err(ChaError::SlashBadNum(list.len())),
+                    },
+                    _ => match vec.as_slice() {
+                        [r, g, Value::BinOp(op)] if op.op() == Div => {
+                            Ok(Self::Data([
                                 r.clone(),
                                 g.clone(),
-                                b.clone(),
-                                a.clone(),
-                            ])
-                        } else {
-                            Self::Special(channels)
-                        },
-                    ),
-                    other => Ok(inner_channels(other)?
-                        .map(|[c1, c2, c3]| {
-                            Self::Data([c1, c2, c3, Value::Null])
-                        })
-                        .unwrap_or_else(|| Self::Special(channels))),
+                                op.a().clone(),
+                                op.b().clone(),
+                            ]))
+                        }
+                        other => Ok(inner_channels(other)?
+                            .map(|[c1, c2, c3]| {
+                                Self::Data([c1, c2, c3, Value::Null])
+                            })
+                            .unwrap_or_else(|| Self::Special(channels))),
+                    },
                 }
             }
         } else {

--- a/rsass/src/sass/functions/color/channels.rs
+++ b/rsass/src/sass/functions/color/channels.rs
@@ -14,61 +14,41 @@ pub enum Channels {
 impl TryFrom<Value> for Channels {
     type Error = ChaError;
     fn try_from(channels: Value) -> Result<Self, ChaError> {
-        if is_special(&channels) {
-            Ok(Self::Special(channels))
-        } else if let Value::List(vec, sep, bracketed) = channels.clone() {
-            if bracketed {
-                Err(ChaError::Bracketed)
-            } else {
-                use crate::value::Operator::Div;
-                match sep {
-                    Some(ListSeparator::Comma) => {
-                        return Err(ChaError::BadSep);
-                    }
-                    Some(ListSeparator::Slash) => match vec.as_slice() {
-                        [Value::List(inner, i_s, i_b), a] => {
-                            if *i_b {
-                                return Err(ChaError::Bracketed);
-                            }
-                            if i_s.unwrap_or_default() != ListSeparator::Space
-                            {
-                                return Err(ChaError::BadSep);
-                            }
-                            Ok(inner_channels(inner)?.map_or_else(
-                                || Self::Special(channels),
-                                |[c1, c2, c3]| {
-                                    Self::Data([c1, c2, c3, a.clone()])
-                                },
-                            ))
-                        }
-                        [h, _a] => {
-                            if is_special(h) {
-                                Ok(Self::Special(channels))
-                            } else {
-                                Err(ChaError::Missing1)
-                            }
-                        }
-                        list => Err(ChaError::SlashBadNum(list.len())),
-                    },
-                    _ => match vec.as_slice() {
-                        [r, g, Value::BinOp(op)] if op.op() == Div => {
-                            Ok(Self::Data([
-                                r.clone(),
-                                g.clone(),
-                                op.a().clone(),
-                                op.b().clone(),
-                            ]))
-                        }
-                        other => Ok(inner_channels(other)?
-                            .map(|[c1, c2, c3]| {
-                                Self::Data([c1, c2, c3, Value::Null])
-                            })
-                            .unwrap_or_else(|| Self::Special(channels))),
-                    },
-                }
+        use crate::value::Operator::Div;
+        match &channels {
+            c if is_special(c) => Ok(Self::Special(channels)),
+            Value::List(_, _, true) => Err(ChaError::Bracketed),
+            Value::List(_, Some(ListSeparator::Comma), _) => {
+                Err(ChaError::BadSep)
             }
-        } else {
-            Err(ChaError::Missing1)
+            Value::List(v, Some(ListSeparator::Slash), _) => match &v[..] {
+                [Value::List(_, _, true), _] => Err(ChaError::Bracketed),
+                [Value::List(_, Some(i_s), _), _]
+                    if *i_s != ListSeparator::Space =>
+                {
+                    Err(ChaError::BadSep)
+                }
+                [Value::List(inner, _, _), a] => Ok(inner_channels(inner)?
+                    .map(|[c1, c2, c3]| Self::Data([c1, c2, c3, a.clone()]))
+                    .unwrap_or_else(|| Self::Special(channels))),
+                [h, _a] if is_special(h) => Ok(Self::Special(channels)),
+                [_, _] => Err(ChaError::Missing1),
+                list => Err(ChaError::SlashBadNum(list.len())),
+            },
+            Value::List(vec, _, false) => match &vec[..] {
+                [r, g, Value::BinOp(op)] if op.op() == Div => {
+                    Ok(Self::Data([
+                        r.clone(),
+                        g.clone(),
+                        op.a().clone(),
+                        op.b().clone(),
+                    ]))
+                }
+                other => Ok(inner_channels(other)?
+                    .map(|[c1, c2, c3]| Self::Data([c1, c2, c3, Value::Null]))
+                    .unwrap_or_else(|| Self::Special(channels))),
+            },
+            _ => Err(ChaError::Missing1),
         }
     }
 }

--- a/rsass/src/sass/functions/color/hsl.rs
+++ b/rsass/src/sass/functions/color/hsl.rs
@@ -9,7 +9,7 @@ use crate::output::Format;
 use crate::sass::{ArgsError, FormalArgs, Name};
 use crate::value::{Color, Hsla, Numeric, Rational, Unit};
 use crate::Scope;
-use num_traits::zero;
+use num_traits::{one, zero};
 
 pub fn register(f: &mut Scope) {
     def_va!(f, _hsl(kwargs), |s| do_hsla(&name!(hsl), s));
@@ -91,7 +91,7 @@ pub fn expose(m: &Scope, global: &mut FunctionMap) {
                 let col = s.get::<Color>(name!(color))?;
                 let sat = s.get_map(name!(amount), check_amount)?;
                 let col = col.to_hsla();
-                let sat = col.sat() + sat;
+                let sat = (col.sat() + sat).clamp(zero(), one());
                 Ok(Hsla::new(col.hue(), sat, col.lum(), col.alpha(), false)
                     .into())
             }

--- a/rsass/src/sass/functions/color/hsl.rs
+++ b/rsass/src/sass/functions/color/hsl.rs
@@ -30,9 +30,12 @@ pub fn register(f: &mut Scope) {
     });
     def!(f, grayscale(color), |args| match args.get(name!(color))? {
         Value::Color(col, _) => {
+            let is_rgb = col.is_rgb();
             let col = col.to_hsla();
-            Ok(Hsla::new(col.hue(), zero(), col.lum(), col.alpha(), false)
-                .into())
+            Ok(
+                Hsla::new(col.hue(), zero(), col.lum(), col.alpha(), !is_rgb)
+                    .into(),
+            )
         }
         v @ Value::Numeric(..) => Ok(Value::call("grayscale", [v])),
         v => Err(is_not(&v, "a color")).named(name!(color)),

--- a/rsass/src/sass/functions/color/mod.rs
+++ b/rsass/src/sass/functions/color/mod.rs
@@ -55,6 +55,7 @@ pub fn create_module() -> Scope {
 pub fn expose(m: &Scope, global: &mut FunctionMap) {
     rgb::expose(m, global);
     hsl::expose(m, global);
+    hwb::expose(m, global);
     other::expose(m, global);
 }
 

--- a/rsass/src/sass/functions/color/rgb.rs
+++ b/rsass/src/sass/functions/color/rgb.rs
@@ -243,11 +243,4 @@ mod test {
     fn test_low() {
         assert_eq!(do_evaluate(&[], b"rgb(-3, -2%, 0);"), "rgb(0, 0, 0)");
     }
-    #[test]
-    fn test_mid() {
-        assert_eq!(
-            do_evaluate(&[], b"rgb(50%, 255/2, 25% + 25);"),
-            "rgb(128, 128, 128)"
-        );
-    }
 }

--- a/rsass/src/sass/functions/color/rgb.rs
+++ b/rsass/src/sass/functions/color/rgb.rs
@@ -59,7 +59,7 @@ pub fn register(f: &mut Scope) {
         match s.get(name!(color))? {
             Value::Color(col, _) => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
-                Ok(do_invert(col, w))
+                Ok(col.invert(w).into())
             }
             col => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
@@ -94,7 +94,7 @@ pub fn expose(m: &Scope, global: &mut FunctionMap) {
         match s.get(name!(color))? {
             Value::Color(col, _) => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
-                Ok(do_invert(col, w))
+                Ok(col.invert(w).into())
             }
             col => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
@@ -114,19 +114,6 @@ pub fn expose(m: &Scope, global: &mut FunctionMap) {
         let f = f.get_lfunction(&name);
         global.insert(name, f);
     }
-}
-
-fn do_invert(col: Color, w: Rational) -> Value {
-    let rgba = col.to_rgba();
-    let inv = |v: Rational| -(v - 255) * w + v * -(w - 1);
-    Rgba::new(
-        inv(rgba.red()),
-        inv(rgba.green()),
-        inv(rgba.blue()),
-        rgba.alpha(),
-        rgba.source(),
-    )
-    .into()
 }
 
 fn do_rgba(fn_name: &Name, s: &ResolvedArgs) -> Result<Value, CallError> {

--- a/rsass/src/value/colors/hsla.rs
+++ b/rsass/src/value/colors/hsla.rs
@@ -1,6 +1,6 @@
 use crate::output::{Format, Formatted};
 use crate::value::{Number, Rational};
-use num_traits::{one, zero, Signed};
+use num_traits::{one, zero, One as _, Signed};
 use std::fmt::{self, Display};
 
 /// A color defined by hue, saturation, luminance, and alpha.
@@ -55,6 +55,18 @@ impl Hsla {
     pub fn set_alpha(&mut self, alpha: Rational) {
         self.alpha = alpha.clamp(zero(), one());
     }
+
+    pub(crate) fn invert(&self, weight: Rational) -> Self {
+        let one = Rational::one();
+        Self {
+            hue: deg_mod(self.hue + 180),
+            sat: self.sat,
+            lum: (one - self.lum) * weight + self.lum * (one - weight),
+            alpha: self.alpha,
+            hsla_format: self.hsla_format,
+        }
+    }
+
     pub(crate) fn reset_source(&mut self) {
         self.hsla_format = false;
     }

--- a/rsass/src/value/colors/hsla.rs
+++ b/rsass/src/value/colors/hsla.rs
@@ -24,8 +24,8 @@ impl Hsla {
     ) -> Self {
         Self {
             hue: deg_mod(hue),
-            sat: sat.clamp(zero(), one()),
-            lum: lum.clamp(zero(), one()),
+            sat: sat.max(zero()),
+            lum,
             alpha: alpha.clamp(zero(), one()),
             hsla_format,
         }
@@ -83,14 +83,16 @@ impl<'a> Display for Formatted<'a, Hsla> {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         let hsla = self.value;
         let hue = Number::from(hsla.hue);
+        let sat = Number::from(hsla.sat * 100);
+        let lum = Number::from(hsla.lum * 100);
         let a = hsla.alpha;
         if a >= one() {
             write!(
                 out,
                 "hsl({}, {}%, {}%)",
                 hue.format(self.format),
-                hsla.sat * 100,
-                hsla.lum * 100
+                sat.format(self.format),
+                lum.format(self.format),
             )
         } else {
             let a = Number::from(a);
@@ -98,8 +100,8 @@ impl<'a> Display for Formatted<'a, Hsla> {
                 out,
                 "hsla({}, {}%, {}%, {})",
                 hue.format(self.format),
-                hsla.sat * 100,
-                hsla.lum * 100,
+                sat.format(self.format),
+                lum.format(self.format),
                 a.format(self.format)
             )
         }

--- a/rsass/src/value/colors/mod.rs
+++ b/rsass/src/value/colors/mod.rs
@@ -25,6 +25,10 @@ pub enum Color {
 }
 
 impl Color {
+    pub(crate) fn is_rgb(&self) -> bool {
+        matches!(self, Self::Rgba(_))
+    }
+
     /// Get this color as a rgba value.
     ///
     /// If this color is a rgba value, return a borrow of it.
@@ -111,6 +115,13 @@ impl Color {
             .into(),
         }
     }
+    pub(crate) fn invert(&self, weight: Rational) -> Self {
+        match self {
+            Color::Rgba(rgba) => rgba.invert(weight).into(),
+            Color::Hsla(hsla) => hsla.invert(weight).into(),
+            Color::Hwba(hwba) => Rgba::from(hwba).invert(weight).into(),
+        }
+    }
     pub(crate) fn reset_source(&mut self) {
         match self {
             Self::Rgba(rgba) => rgba.reset_source(),
@@ -149,6 +160,9 @@ impl<'a> Display for Formatted<'a, Color> {
             Color::Rgba(rgba) => rgba.format(self.format).fmt(out),
             Color::Hsla(hsla) if hsla.hsla_format => {
                 hsla.format(self.format).fmt(out)
+            }
+            Color::Hwba(hwba) => {
+                Hsla::from(hwba).format(self.format).fmt(out)
             }
             any => any.to_rgba().format(self.format).fmt(out),
         }

--- a/rsass/src/variablescope.rs
+++ b/rsass/src/variablescope.rs
@@ -786,22 +786,6 @@ pub mod test {
     }
 
     #[test]
-    fn color_mixed_with_alpha_1() {
-        assert_expr!(
-            b"mix(rgba(255, 0, 0, 0.5), #00f);",
-            "rgba(64, 0, 191, 0.75)"
-        )
-    }
-
-    #[test]
-    fn color_mixed_with_alpha_2() {
-        assert_expr!(
-            b"mix(#00f, rgba(255, 0, 0, 0.5));",
-            "rgba(64, 0, 191, 0.75)"
-        )
-    }
-
-    #[test]
     fn value_multiple_dashes() {
         assert_expr!(b"foo-bar-baz 17%;", "foo-bar-baz 17%")
     }

--- a/rsass/tests/misc/basic.rs
+++ b/rsass/tests/misc/basic.rs
@@ -156,24 +156,6 @@ fn ti574_map_trailing_comma() {
     );
 }
 
-/// From `spec/core_functions/invert/weight-parameter`
-#[test]
-fn weight_parameter() {
-    init_logger();
-    assert_eq!(
-        rsass(
-            b".invert-with-weight {\n  zero-percent: invert(#edc, 0%);\n  \
-              ten-percent: invert(#edc, 10%);\n  \
-              keyword: invert(#edc, $weight: 10%);\n  \
-              one-hundred-percent: invert(#edc, 100%);\n}\n"
-        )
-        .unwrap(),
-        ".invert-with-weight {\n  zero-percent: #eeddcc;\n  \
-         ten-percent: #d8cabd;\n  keyword: #d8cabd;\n  \
-         one-hundred-percent: #112233;\n}\n"
-    );
-}
-
 /// From `spec/libsass-closed-issues/issue_1133/normal`
 #[test]
 fn each_binds_multiple() {

--- a/rsass/tests/spec/core_functions/color/adjust/error/args.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/error/args.rs
@@ -40,7 +40,6 @@ fn too_many() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn unknown() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/adjust/error/incompatible_channel.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/error/incompatible_channel.rs
@@ -22,7 +22,6 @@ fn legacy_channel() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn legacy_space() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/adjust/error/mixed_formats.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/error/mixed_formats.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong error
 fn blue_and_lightness() {
     assert_eq!(
         runner().err(
@@ -22,7 +21,6 @@ fn blue_and_lightness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_saturation() {
     assert_eq!(
         runner().err(
@@ -38,7 +36,6 @@ fn green_and_saturation() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -54,7 +51,6 @@ fn green_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn lightness_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -70,7 +66,6 @@ fn lightness_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_blackness() {
     assert_eq!(
         runner().err(
@@ -86,7 +81,6 @@ fn red_and_blackness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_hue() {
     assert_eq!(
         runner().err(
@@ -102,7 +96,6 @@ fn red_and_hue() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn saturation_and_blackness() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/adjust/hsl.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/hsl.rs
@@ -141,7 +141,6 @@ mod lightness {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -152,7 +151,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn arg_above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -163,7 +161,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn arg_below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -174,7 +171,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -225,7 +221,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -273,7 +268,6 @@ mod saturation {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -284,7 +278,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn arg_above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -295,7 +288,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn arg_below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -336,7 +328,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max_remaining() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/adjust/hsl.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/hsl.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn all() {
     assert_eq!(
         runner().ok(
@@ -19,7 +18,6 @@ fn all() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -38,7 +36,6 @@ fn alpha_arg() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg_above_max() {
     assert_eq!(
         runner().ok("// Regression test for sass/dart-sass#708.\
@@ -58,7 +55,6 @@ fn alpha_arg_above_max() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_input() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -90,7 +86,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn fraction() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -101,7 +96,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -112,7 +106,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn middle() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -192,7 +185,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn fraction() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -203,7 +195,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -214,7 +205,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -267,7 +257,6 @@ mod lightness {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(
@@ -317,7 +306,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -328,7 +316,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -339,7 +326,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -361,7 +347,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -372,7 +357,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn min_remaining() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/adjust/hwb.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/hwb.rs
@@ -101,7 +101,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max_remaining() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -191,7 +190,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max_remaining() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/adjust/units.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/units.rs
@@ -45,7 +45,6 @@ mod hue {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn angle() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -126,7 +125,6 @@ mod saturation {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn percent() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -137,7 +135,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn unitless() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -148,7 +145,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn unknown() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/adjust_hue.rs
+++ b/rsass/tests/spec/core_functions/color/adjust_hue.rs
@@ -15,7 +15,6 @@ fn above_max() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha() {
     assert_eq!(
         runner().ok("a {b: adjust-hue(rgba(red, 0.1), 359)}\n"),
@@ -106,7 +105,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn fraction() {
     assert_eq!(
         runner().ok("a {b: adjust-hue(red, 0.5)}\n"),
@@ -116,7 +114,6 @@ fn fraction() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn max() {
     assert_eq!(
         runner().ok("a {b: adjust-hue(red, 359)}\n"),
@@ -126,7 +123,6 @@ fn max() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn middle() {
     assert_eq!(
         runner().ok("a {b: adjust-hue(red, 123)}\n"),
@@ -145,7 +141,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("a {b: adjust-hue($color: red, $degrees: 123)}\n"),
@@ -168,7 +163,6 @@ mod units {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn angle() {
         assert_eq!(
             runner().ok("a {b: adjust-hue(red, 60rad)}\n"),

--- a/rsass/tests/spec/core_functions/color/blackness.rs
+++ b/rsass/tests/spec/core_functions/color/blackness.rs
@@ -80,7 +80,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // unexepected error
 fn fraction() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -105,7 +104,6 @@ mod middle {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn half_whiteness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -116,7 +114,6 @@ mod middle {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn high_whiteness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -127,7 +124,6 @@ mod middle {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn zero_whiteness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -149,7 +145,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // unexepected error
 fn named() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/change/error/args.rs
+++ b/rsass/tests/spec/core_functions/color/change/error/args.rs
@@ -40,7 +40,6 @@ fn too_many() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn unknown() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/change/error/incompatible_channel.rs
+++ b/rsass/tests/spec/core_functions/color/change/error/incompatible_channel.rs
@@ -22,7 +22,6 @@ fn legacy_channel() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn legacy_space() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/change/error/mixed_formats.rs
+++ b/rsass/tests/spec/core_functions/color/change/error/mixed_formats.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong error
 fn blue_and_lightness() {
     assert_eq!(
         runner().err(
@@ -22,7 +21,6 @@ fn blue_and_lightness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_saturation() {
     assert_eq!(
         runner().err(
@@ -38,7 +36,6 @@ fn green_and_saturation() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -54,7 +51,6 @@ fn green_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn lightness_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -70,7 +66,6 @@ fn lightness_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_blackness() {
     assert_eq!(
         runner().err(
@@ -86,7 +81,6 @@ fn red_and_blackness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_hue() {
     assert_eq!(
         runner().err(
@@ -102,7 +96,6 @@ fn red_and_hue() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn saturation_and_blackness() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/change/hsl.rs
+++ b/rsass/tests/spec/core_functions/color/change/hsl.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn all() {
     assert_eq!(
         runner().ok(
@@ -19,7 +18,6 @@ fn all() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg() {
     assert_eq!(
         runner().ok(
@@ -32,7 +30,6 @@ fn alpha_arg() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_input() {
     assert_eq!(
         runner().ok(
@@ -59,7 +56,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn fraction() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -70,7 +66,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -81,7 +76,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn middle() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -150,7 +144,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn fraction() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -161,7 +154,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -172,7 +164,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -215,7 +206,6 @@ mod lightness {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(
@@ -254,7 +244,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -265,7 +254,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -286,7 +274,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -317,7 +304,6 @@ mod units {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn angle() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -398,7 +384,6 @@ mod units {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn percent() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -409,7 +394,6 @@ mod units {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn unitless() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -420,7 +404,6 @@ mod units {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn unknown() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/change/hwb.rs
+++ b/rsass/tests/spec/core_functions/color/change/hwb.rs
@@ -66,7 +66,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -148,7 +147,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/darken.rs
+++ b/rsass/tests/spec/core_functions/color/darken.rs
@@ -125,7 +125,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn fraction() {
     assert_eq!(
         runner().ok("a {b: darken(red, 0.5%)}\n"),
@@ -153,7 +152,6 @@ fn max_remaining() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn middle() {
     assert_eq!(
         runner().ok("a {b: darken(red, 14%)}\n"),
@@ -172,7 +170,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("a {b: darken($color: red, $amount: 14%)}\n"),

--- a/rsass/tests/spec/core_functions/color/desaturate.rs
+++ b/rsass/tests/spec/core_functions/color/desaturate.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn alpha() {
     assert_eq!(
         runner().ok("a {b: desaturate(rgba(plum, 0.3), 100%)}\n"),
@@ -147,7 +146,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn max() {
     assert_eq!(
         runner().ok("a {b: desaturate(plum, 100%)}\n"),
@@ -157,7 +155,6 @@ fn max() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn max_remaining() {
     assert_eq!(
         runner().ok("a {b: desaturate(plum, 48%)}\n"),
@@ -167,7 +164,6 @@ fn max_remaining() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn middle() {
     assert_eq!(
         runner().ok("a {b: desaturate(plum, 14%)}\n"),
@@ -186,7 +182,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("a {b: desaturate($color: plum, $amount: 14%)}\n"),

--- a/rsass/tests/spec/core_functions/color/grayscale.rs
+++ b/rsass/tests/spec/core_functions/color/grayscale.rs
@@ -212,7 +212,7 @@ mod legacy {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
+        #[ignore] // wrong result
         fn different() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -223,7 +223,6 @@ mod legacy {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn same() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/grayscale.rs
+++ b/rsass/tests/spec/core_functions/color/grayscale.rs
@@ -132,7 +132,6 @@ mod legacy {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn alpha() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -143,7 +142,6 @@ mod legacy {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max_saturation() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -154,7 +152,6 @@ mod legacy {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn mid_saturation() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/hsl/four_args/out_of_gamut.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/four_args/out_of_gamut.rs
@@ -148,7 +148,6 @@ mod lightness {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn finite() {
         assert_eq!(
             runner().ok("a {b: hsl(0, 100%, 9999%, 0.5)}\n"),

--- a/rsass/tests/spec/core_functions/color/hsl/one_arg/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/one_arg/alpha.rs
@@ -33,7 +33,6 @@ mod clamped {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn lightness() {
         assert_eq!(
             runner().ok("a {b: hsl(0 100% 9999% / 0.5)}\n"),

--- a/rsass/tests/spec/core_functions/color/hsl/one_arg/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/one_arg/alpha.rs
@@ -110,7 +110,7 @@ mod missing {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn slash() {
         assert_eq!(
             runner().ok("a {b: hsl(180 60% 50% / none)}\n"),

--- a/rsass/tests/spec/core_functions/color/hsl/one_arg/no_alpha.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/one_arg/no_alpha.rs
@@ -14,7 +14,6 @@ mod clamped {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn above() {
             assert_eq!(
                 runner().ok("a {b: hsl(0 100% 500%)}\n"),
@@ -24,7 +23,6 @@ mod clamped {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn below() {
             assert_eq!(
                 runner().ok("a {b: hsl(0 100% -100%)}\n"),
@@ -139,7 +137,6 @@ mod out_of_gamut {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn above() {
             assert_eq!(
                 runner().ok("a {b: hsl(0 500% 50%)}\n"),

--- a/rsass/tests/spec/core_functions/color/hsl/one_arg/special_functions/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/one_arg/special_functions/alpha.rs
@@ -32,7 +32,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("a {b: hsl(1 2% calc(1px + 1%) / 0.4)}\n"),
@@ -42,7 +41,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("a {b: hsl(1 2% 3% / calc(1px + 1%))}\n"),
@@ -77,7 +75,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -88,7 +85,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -131,7 +127,6 @@ mod clamp {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
         runner().ok(
@@ -144,7 +139,6 @@ mod clamp {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
         runner().ok(
@@ -181,7 +175,6 @@ mod env {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_3() {
         assert_eq!(
             runner().ok("a {b: hsl(1 2% env(--foo) / 0.4)}\n"),
@@ -191,7 +184,6 @@ mod env {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_4() {
         assert_eq!(
             runner().ok("a {b: hsl(1 2% 3% / env(--foo))}\n"),
@@ -230,7 +222,6 @@ mod max {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -241,7 +232,6 @@ mod max {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -282,7 +272,6 @@ mod min {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -293,7 +282,6 @@ mod min {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -363,7 +351,6 @@ mod var {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_3() {
         assert_eq!(
             runner().ok("a {b: hsl(1 2% var(--foo) / 0.4)}\n"),
@@ -373,7 +360,6 @@ mod var {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_4() {
         assert_eq!(
             runner().ok("a {b: hsl(1 2% 3% / var(--foo))}\n"),

--- a/rsass/tests/spec/core_functions/color/hsl/three_args/out_of_gamut.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/three_args/out_of_gamut.rs
@@ -10,7 +10,6 @@ mod saturation {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn above() {
         assert_eq!(
             runner().ok("a {b: hsl(0, 500%, 50%)}\n"),

--- a/rsass/tests/spec/core_functions/color/hwb/four_args.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/four_args.rs
@@ -72,7 +72,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn min() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -83,7 +82,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn negative() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -94,7 +92,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn positive() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -130,7 +127,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn min() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -141,7 +137,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn negative() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -152,7 +147,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn positive() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -306,7 +300,6 @@ mod hue {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/core_functions/color/hwb/global.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/global.rs
@@ -14,7 +14,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn above() {
             assert_eq!(
                 runner().ok("a {b: hwb(0 30% 40% / 1.1)}\n"),
@@ -24,7 +23,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn below() {
             assert_eq!(
                 runner().ok("a {b: hwb(0 30% 40% / -0.1)}\n"),
@@ -39,7 +37,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 runner().ok("a {b: hwb($channels: 180 30% 40% / 0.4)}\n"),
@@ -49,7 +46,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 runner().ok("a {b: hwb(180 30% 40% / 1)}\n"),
@@ -59,7 +55,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         runner().ok(
@@ -72,7 +67,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 runner().ok("a {b: hwb(180 30% 40% / 0.5)}\n"),
@@ -82,7 +76,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 runner().ok("a {b: hwb(180 30% 40% / 0)}\n"),
@@ -97,7 +90,7 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn slash() {
             assert_eq!(
                 runner().ok("a {b: hwb(0 30% 40% / none)}\n"),
@@ -107,7 +100,7 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
+        #[ignore] // unexepected error
         fn slash_list() {
             assert_eq!(
                 runner().ok("@use \'sass:list\';\
@@ -124,7 +117,7 @@ mod missing {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn blackness() {
         assert_eq!(
             runner().ok("a {b: hwb(0 30% none)}\n"),
@@ -134,6 +127,7 @@ mod missing {
         );
     }
     #[test]
+    #[ignore] // unexepected error
     fn hue() {
         assert_eq!(
             runner().ok("a {b: hwb(none 30% 40%)}\n"),
@@ -143,7 +137,7 @@ mod missing {
         );
     }
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn whiteness() {
         assert_eq!(
             runner().ok("a {b: hwb(0 none 40%)}\n"),
@@ -154,7 +148,6 @@ mod missing {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("a {b: hwb($channels: 180 30% 40% / 0.4)}\n"),
@@ -164,7 +157,6 @@ fn named() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn no_alpha() {
     assert_eq!(
         runner().ok("a {b: hwb(180 30% 40%)}\n"),
@@ -233,7 +225,7 @@ mod relative_color {
             use super::runner;
 
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn alpha() {
                 assert_eq!(
         runner().err(
@@ -248,7 +240,7 @@ mod relative_color {
     );
             }
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn no_alpha() {
                 assert_eq!(
         runner().err(
@@ -268,7 +260,7 @@ mod relative_color {
             use super::runner;
 
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn alpha() {
                 assert_eq!(
         runner().err(
@@ -283,7 +275,7 @@ mod relative_color {
     );
             }
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn no_alpha() {
                 assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/hwb/one_arg.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/one_arg.rs
@@ -14,7 +14,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn above() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -25,7 +24,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn below() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -41,7 +39,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn named() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -52,7 +49,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn opaque() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -63,7 +59,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn parenthesized() {
             assert_eq!(
         runner().ok(
@@ -77,7 +72,6 @@ mod alpha {
     );
         }
         #[test]
-        #[ignore] // wrong result
         fn partial() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -88,7 +82,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn transparent() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -182,7 +175,6 @@ mod hue {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -193,7 +185,6 @@ fn named() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn no_alpha() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -263,7 +254,7 @@ mod relative_color {
             use super::runner;
 
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn alpha() {
                 assert_eq!(
         runner().err(
@@ -278,7 +269,7 @@ mod relative_color {
     );
             }
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn no_alpha() {
                 assert_eq!(
         runner().err(
@@ -298,7 +289,7 @@ mod relative_color {
             use super::runner;
 
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn alpha() {
                 assert_eq!(
         runner().err(
@@ -313,7 +304,7 @@ mod relative_color {
     );
             }
             #[test]
-            #[ignore] // missing error
+            #[ignore] // wrong error
             fn no_alpha() {
                 assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/named.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/named.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/units.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/units.rs
@@ -10,7 +10,6 @@ mod hue {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn deg() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -32,7 +31,6 @@ mod hue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn rad() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/blue_magentas.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/blue_magentas.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/blues.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/blues.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/cyan_blues.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/cyan_blues.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/cyans.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/cyans.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/green_cyans.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/green_cyans.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/greens.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/greens.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/magenta_reds.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/magenta_reds.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/magentas.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/magentas.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/oranges.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/oranges.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/reds.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/reds.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/yellow_greens.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/yellow_greens.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/yellows.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/three_args/w3c/yellows.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \'../test-hue\' as *;\

--- a/rsass/tests/spec/core_functions/color/invert/legacy.rs
+++ b/rsass/tests/spec/core_functions/color/invert/legacy.rs
@@ -84,7 +84,6 @@ mod no_space {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn high() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -95,7 +94,6 @@ mod no_space {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn low() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -116,7 +114,6 @@ mod no_space {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn middle() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -275,7 +272,6 @@ mod units {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn unitless() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -286,7 +282,6 @@ mod units {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn unknown() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/invert/legacy.rs
+++ b/rsass/tests/spec/core_functions/color/invert/legacy.rs
@@ -30,7 +30,6 @@ mod no_space {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn hsl() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -41,7 +40,6 @@ mod no_space {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn hwb() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/lighten.rs
+++ b/rsass/tests/spec/core_functions/color/lighten.rs
@@ -125,7 +125,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn fraction() {
     assert_eq!(
         runner().ok("a {b: lighten(red, 0.5%)}\n"),
@@ -153,7 +152,6 @@ fn max_remaining() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn middle() {
     assert_eq!(
         runner().ok("a {b: lighten(red, 14%)}\n"),
@@ -172,7 +170,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("a {b: lighten($color: red, $amount: 14%)}\n"),

--- a/rsass/tests/spec/core_functions/color/mix/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/mix/alpha.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn even() {
     assert_eq!(
         runner().ok("a {b: mix(rgba(#91e16f, 0.3), rgba(#0144bf, 0.3))}\n"),
@@ -25,7 +24,6 @@ fn first() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn firstwards() {
     assert_eq!(
         runner().ok("a {b: mix(rgba(#91e16f, 0.8), rgba(#0144bf, 0.3))}\n"),
@@ -44,7 +42,6 @@ fn last() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn lastwards() {
     assert_eq!(
         runner().ok("a {b: mix(rgba(#91e16f, 0.4), rgba(#0144bf, 0.9))}\n"),

--- a/rsass/tests/spec/core_functions/color/mix/both_weights.rs
+++ b/rsass/tests/spec/core_functions/color/mix/both_weights.rs
@@ -24,7 +24,6 @@ mod mixed {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn firstwards() {
         assert_eq!(
             runner().ok(
@@ -36,7 +35,6 @@ mod mixed {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn lastwards() {
         assert_eq!(
             runner().ok(

--- a/rsass/tests/spec/core_functions/color/mix/explicit_weight.rs
+++ b/rsass/tests/spec/core_functions/color/mix/explicit_weight.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn even() {
     assert_eq!(
         runner().ok("a {b: mix(#91e16f, #0144bf, 50%)}\n"),
@@ -25,7 +24,6 @@ fn first() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn firstwards() {
     assert_eq!(
         runner().ok("a {b: mix(#91e16f, #0144bf, 92%)}\n"),
@@ -44,7 +42,6 @@ fn last() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn lastwards() {
     assert_eq!(
         runner().ok("a {b: mix(#91e16f, #0144bf, 43%)}\n"),

--- a/rsass/tests/spec/core_functions/color/mix/units.rs
+++ b/rsass/tests/spec/core_functions/color/mix/units.rs
@@ -10,7 +10,6 @@ mod weight {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn unitless() {
         assert_eq!(
             runner().ok("a {b: mix(#91e16f, #0144bf, 50)}\n"),
@@ -20,7 +19,6 @@ mod weight {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn unknown() {
         assert_eq!(
             runner().ok("a {b: mix(#91e16f, #0144bf, 50px)}\n"),

--- a/rsass/tests/spec/core_functions/color/mix/unweighted.rs
+++ b/rsass/tests/spec/core_functions/color/mix/unweighted.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn average() {
     assert_eq!(
         runner()
@@ -30,7 +29,6 @@ fn identical() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn min_and_max() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/core_functions/color/rgb/one_arg/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/rgb/one_arg/alpha.rs
@@ -237,7 +237,7 @@ mod missing {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
+    #[ignore] // unexepected error
     fn slash() {
         assert_eq!(
             runner().ok("a {b: rgb(0 255 127 / none)}\n"),

--- a/rsass/tests/spec/core_functions/color/rgb/one_arg/no_alpha.rs
+++ b/rsass/tests/spec/core_functions/color/rgb/one_arg/no_alpha.rs
@@ -49,7 +49,6 @@ mod percents {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn percent() {
             assert_eq!(
                 runner().ok("a {b: rgb(7.1% 20.4% 33.9%)}\n"),
@@ -60,7 +59,6 @@ mod percents {
         }
     }
     #[test]
-    #[ignore] // wrong result
     fn boundaries() {
         assert_eq!(
             runner().ok("a {b: rgb(0% 100% 50%)}\n"),
@@ -106,7 +104,6 @@ mod percents {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn green() {
             assert_eq!(
                 runner().ok("a {b: rgb(190 68% 237)}\n"),
@@ -121,7 +118,6 @@ mod percents {
         use super::runner;
 
         #[test]
-        #[ignore] // wrong result
         fn green() {
             assert_eq!(
                 runner().ok("a {b: rgb(74.7% 173 93%)}\n"),

--- a/rsass/tests/spec/core_functions/color/rgb/one_arg/special_functions/alpha.rs
+++ b/rsass/tests/spec/core_functions/color/rgb/one_arg/special_functions/alpha.rs
@@ -32,7 +32,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("a {b: rgb(1 2 calc(1px + 1%) / 0.4)}\n"),
@@ -42,7 +41,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("a {b: rgb(1 2 3 / calc(1px + 1%))}\n"),
@@ -77,7 +75,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -88,7 +85,6 @@ mod calc {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -129,7 +125,6 @@ mod clamp {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -140,7 +135,6 @@ mod clamp {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
         runner().ok(
@@ -177,7 +171,6 @@ mod env {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_3() {
         assert_eq!(
             runner().ok("a {b: rgb(1 2 env(--foo) / 0.4)}\n"),
@@ -187,7 +180,6 @@ mod env {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_4() {
         assert_eq!(
             runner().ok("a {b: rgb(1 2 3 / env(--foo))}\n"),
@@ -226,7 +218,6 @@ mod max {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -237,7 +228,6 @@ mod max {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -278,7 +268,6 @@ mod min {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_3() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -289,7 +278,6 @@ mod min {
             );
         }
         #[test]
-        #[ignore] // wrong result
         fn arg_4() {
             assert_eq!(
                 runner().ok("@use \"sass:string\";\
@@ -359,7 +347,6 @@ mod var {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_3() {
         assert_eq!(
             runner().ok("a {b: rgb(1 2 var(--foo) / 0.4)}\n"),
@@ -369,7 +356,6 @@ mod var {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn arg_4() {
         assert_eq!(
             runner().ok("a {b: rgb(1 2 3 / var(--foo))}\n"),

--- a/rsass/tests/spec/core_functions/color/rgb/three_args/percents.rs
+++ b/rsass/tests/spec/core_functions/color/rgb/three_args/percents.rs
@@ -10,7 +10,6 @@ mod all {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn percent() {
         assert_eq!(
             runner().ok("a {b: rgb(7.1%, 20.4%, 33.9%)}\n"),
@@ -21,7 +20,6 @@ mod all {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn boundaries() {
     assert_eq!(
         runner().ok("a {b: rgb(0%, 100%, 50%)}\n"),
@@ -67,7 +65,6 @@ mod percent {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn green() {
         assert_eq!(
             runner().ok("a {b: rgb(190, 68%, 237)}\n"),
@@ -82,7 +79,6 @@ mod unitless {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn green() {
         assert_eq!(
             runner().ok("a {b: rgb(74.7%, 173, 93%)}\n"),

--- a/rsass/tests/spec/core_functions/color/saturate.rs
+++ b/rsass/tests/spec/core_functions/color/saturate.rs
@@ -270,7 +270,6 @@ mod two_args {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn middle() {
         assert_eq!(
             runner().ok("a {b: saturate(plum, 14%)}\n"),
@@ -289,7 +288,6 @@ mod two_args {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn named() {
         assert_eq!(
             runner().ok("a {b: saturate($color: plum, $amount: 14%)}\n"),

--- a/rsass/tests/spec/core_functions/color/scale/error/args.rs
+++ b/rsass/tests/spec/core_functions/color/scale/error/args.rs
@@ -40,7 +40,6 @@ fn too_many() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn unknown() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/scale/error/incompatible_channel.rs
+++ b/rsass/tests/spec/core_functions/color/scale/error/incompatible_channel.rs
@@ -22,7 +22,6 @@ fn legacy_channel() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn legacy_space() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/scale/error/mixed_formats.rs
+++ b/rsass/tests/spec/core_functions/color/scale/error/mixed_formats.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong error
 fn blue_and_lightness() {
     assert_eq!(
         runner().err(
@@ -22,7 +21,6 @@ fn blue_and_lightness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_saturation() {
     assert_eq!(
         runner().err(
@@ -38,7 +36,6 @@ fn green_and_saturation() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn green_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -54,7 +51,6 @@ fn green_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn lightness_and_whiteness() {
     assert_eq!(
         runner().err(
@@ -70,7 +66,6 @@ fn lightness_and_whiteness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_blackness() {
     assert_eq!(
         runner().err(
@@ -86,7 +81,6 @@ fn red_and_blackness() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn red_and_saturation() {
     assert_eq!(
         runner().err(
@@ -102,7 +96,6 @@ fn red_and_saturation() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn saturation_and_blackness() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/scale/error/polar.rs
+++ b/rsass/tests/spec/core_functions/color/scale/error/polar.rs
@@ -22,7 +22,6 @@ fn lch() {
     );
 }
 #[test]
-#[ignore] // wrong error
 fn legacy() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/core_functions/color/scale/global.rs
+++ b/rsass/tests/spec/core_functions/color/scale/global.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn legacy() {
     assert_eq!(
         runner().ok("a {b: scale-color(pink, $blue: 20%)}\n"),

--- a/rsass/tests/spec/core_functions/color/scale/hsl.rs
+++ b/rsass/tests/spec/core_functions/color/scale/hsl.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn all() {
     assert_eq!(
         runner().ok(
@@ -19,7 +18,6 @@ fn all() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg() {
     assert_eq!(
         runner().ok(
@@ -32,7 +30,6 @@ fn alpha_arg() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_input() {
     assert_eq!(
         runner().ok(
@@ -49,7 +46,6 @@ mod lightness {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -60,7 +56,6 @@ mod lightness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -102,7 +97,6 @@ mod lightness {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(
@@ -119,7 +113,6 @@ mod saturation {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -130,7 +123,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -151,7 +143,6 @@ mod saturation {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/scale/hwb.rs
+++ b/rsass/tests/spec/core_functions/color/scale/hwb.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn all() {
     assert_eq!(
         runner().ok(
@@ -19,7 +18,6 @@ fn all() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg() {
     assert_eq!(
         runner().ok(
@@ -32,7 +30,6 @@ fn alpha_arg() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_input() {
     assert_eq!(
         runner().ok(
@@ -49,7 +46,6 @@ mod blackness {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -60,7 +56,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -71,7 +66,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -103,7 +97,6 @@ mod blackness {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(
@@ -120,7 +113,6 @@ mod whiteness {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -131,7 +123,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -142,7 +133,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/scale/rgb.rs
+++ b/rsass/tests/spec/core_functions/color/scale/rgb.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn all() {
     assert_eq!(
         runner().ok(
@@ -19,7 +18,6 @@ fn all() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_arg() {
     assert_eq!(
         runner().ok(
@@ -32,7 +30,6 @@ fn alpha_arg() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn alpha_input() {
     assert_eq!(
         runner().ok(
@@ -49,7 +46,6 @@ mod blue {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -60,7 +56,6 @@ mod blue {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -106,7 +101,6 @@ mod green {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -117,7 +111,6 @@ mod green {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -159,7 +152,6 @@ mod green {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok(
@@ -176,7 +168,6 @@ mod red {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn high() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -187,7 +178,6 @@ mod red {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn low() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/whiteness.rs
+++ b/rsass/tests/spec/core_functions/color/whiteness.rs
@@ -80,7 +80,6 @@ mod error {
     }
 }
 #[test]
-#[ignore] // wrong result
 fn fraction() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\
@@ -105,7 +104,6 @@ mod middle {
     use super::runner;
 
     #[test]
-    #[ignore] // wrong result
     fn half_blackness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -116,7 +114,6 @@ mod middle {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn high_blackness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -127,7 +124,6 @@ mod middle {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn zero_blackness() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -149,7 +145,6 @@ fn min() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn named() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/global/color/darken.rs
+++ b/rsass/tests/spec/core_functions/global/color/darken.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("a {b: darken(#abcdef, 10%)}\n"),

--- a/rsass/tests/spec/core_functions/global/color/grayscale.rs
+++ b/rsass/tests/spec/core_functions/global/color/grayscale.rs
@@ -15,7 +15,6 @@ fn with_calc() {
     );
 }
 #[test]
-#[ignore] // wrong result
 fn with_color() {
     assert_eq!(
         runner().ok("a {b: grayscale(red)}\n"),

--- a/rsass/tests/spec/core_functions/global/color/lighten.rs
+++ b/rsass/tests/spec/core_functions/global/color/lighten.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("a {b: lighten(#abcdef, 10%)}\n"),

--- a/rsass/tests/spec/core_functions/global/color/mix.rs
+++ b/rsass/tests/spec/core_functions/global/color/mix.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("a {b: mix(#abcdef, #daddee)}\n"),

--- a/rsass/tests/spec/core_functions/global/color/scale.rs
+++ b/rsass/tests/spec/core_functions/global/color/scale.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("a {b: scale-color(#abcdef, $red: 10%)}\n"),

--- a/rsass/tests/spec/core_functions/modules/color/mix.rs
+++ b/rsass/tests/spec/core_functions/modules/color/mix.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/modules/color/scale.rs
+++ b/rsass/tests/spec/core_functions/modules/color/scale.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass/bourbon.rs
+++ b/rsass/tests/spec/libsass/bourbon.rs
@@ -58,7 +58,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass/color_functions/other/change_color/h.rs
+++ b/rsass/tests/spec/libsass/color_functions/other/change_color/h.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass/color_functions/other/change_color/l.rs
+++ b/rsass/tests/spec/libsass/color_functions/other/change_color/l.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass/color_functions/other/change_color/s.rs
+++ b/rsass/tests/spec/libsass/color_functions/other/change_color/s.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgb/b.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgb/b.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgb/g.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgb/g.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgb/r.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgb/r.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgba/b.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgba/b.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgba/g.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgba/g.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass/color_functions/rgb/rgba/r.rs
+++ b/rsass/tests/spec/libsass/color_functions/rgb/rgba/r.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("foo {\

--- a/rsass/tests/spec/libsass_closed_issues/issue_1101.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1101.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/libsass_closed_issues/issue_1285.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_1285.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2462.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2462.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/libsass_closed_issues/issue_2472.rs
+++ b/rsass/tests/spec/libsass_closed_issues/issue_2472.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@function dark(\r\

--- a/rsass/tests/spec/libsass_todo_issues/issue_2818.rs
+++ b/rsass/tests/spec/libsass_todo_issues/issue_2818.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok(

--- a/rsass/tests/spec/non_conformant/basic/t22_colors_with_alpha.rs
+++ b/rsass/tests/spec/non_conformant/basic/t22_colors_with_alpha.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/non_conformant/errors/fn_change_color_1.rs
+++ b/rsass/tests/spec/non_conformant/errors/fn_change_color_1.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong error
 fn test() {
     assert_eq!(
         runner().err(

--- a/rsass/tests/spec/non_conformant/scss_tests/t190_test_options_passed_to_script.rs
+++ b/rsass/tests/spec/non_conformant/scss_tests/t190_test_options_passed_to_script.rs
@@ -6,7 +6,6 @@ fn runner() -> crate::TestRunner {
 }
 
 #[test]
-#[ignore] // wrong result
 fn test() {
     assert_eq!(
         runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/values/colors/equality.rs
+++ b/rsass/tests/spec/values/colors/equality.rs
@@ -88,6 +88,7 @@ mod test_false {
     );
                 }
                 #[test]
+                #[ignore] // unexepected error
                 fn one_none() {
                     assert_eq!(
                         runner()
@@ -258,7 +259,6 @@ mod test_true {
                 use super::runner;
 
                 #[test]
-                #[ignore] // wrong result
                 fn no_none() {
                     assert_eq!(
         runner().ok(
@@ -270,6 +270,7 @@ mod test_true {
     );
                 }
                 #[test]
+                #[ignore] // unexepected error
                 fn none() {
                     assert_eq!(
                         runner().ok(


### PR DESCRIPTION
The spec test suite has updated with a lot of changes in how colors should behave.

These changes fixes most changed requirements of traditional colors, while ignoring partial colors and everything regarding explicit color spaces.