### PR TITLE
Make all color channels f64.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ project adheres to
 
 * Lots of color handling.
   - Spec changes for traditional css colors (PR #198).
+  - Made all color channels f64 instead of Rational (PR #199).
 * Updated sass-spec test suite to 2024-09-13.
 
 

--- a/rsass/src/sass/functions/color/rgb.rs
+++ b/rsass/src/sass/functions/color/rgb.rs
@@ -6,9 +6,8 @@ use super::{
 };
 use crate::css::{CallArgs, Value};
 use crate::sass::{ArgsError, FormalArgs, Name};
-use crate::value::{Color, Rational, RgbFormat, Rgba};
+use crate::value::{Color, RgbFormat, Rgba};
 use crate::Scope;
-use num_traits::{one, Zero};
 
 pub fn register(f: &mut Scope) {
     def_va!(f, _rgb(kwargs), |s| do_rgba(&name!(rgb), s));
@@ -31,26 +30,25 @@ pub fn register(f: &mut Scope) {
         let b: Color = s.get(name!(color2))?;
         let b = b.to_rgba();
         let w = s.get_map(name!(weight), check_pct_range)?;
-        let one: Rational = one();
 
         let w_a = {
             let wa = a.alpha() - b.alpha();
-            let w2 = w * 2 - 1;
-            let divis = w2 * wa + 1;
-            if divis.is_zero() {
+            let w2 = w * 2. - 1.;
+            let divis = w2 * wa + 1.;
+            if divis == 0. {
                 w
             } else {
-                (((w2 + wa) / divis) + 1) / 2
+                (((w2 + wa) / divis) + 1.) / 2.
             }
         };
-        let w_b = one - w_a;
+        let w_b = 1. - w_a;
 
         let m_c = |c_a, c_b| w_a * c_a + w_b * c_b;
         Ok(Rgba::new(
             m_c(a.red(), b.red()),
             m_c(a.green(), b.green()),
             m_c(a.blue(), b.blue()),
-            a.alpha() * w + b.alpha() * (one - w),
+            a.alpha() * w + b.alpha() * (1. - w),
             RgbFormat::Name,
         )
         .into())
@@ -63,7 +61,7 @@ pub fn register(f: &mut Scope) {
             }
             col => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
-                if w == one() {
+                if w == 1. {
                     match col {
                         v @ Value::Numeric(..) => {
                             Ok(Value::call("invert", [v]))
@@ -98,7 +96,7 @@ pub fn expose(m: &Scope, global: &mut FunctionMap) {
             }
             col => {
                 let w = s.get_map(name!(weight), check_pct_range)?;
-                if w == one() {
+                if w == 1. {
                     NumOrSpecial::try_from(col)
                         .map_err(|e| is_not(e.value(), "a color"))
                         .named(name!(color))

--- a/rsass/src/value/colors/convert.rs
+++ b/rsass/src/value/colors/convert.rs
@@ -1,34 +1,34 @@
-use super::*;
+use super::{Hsla, Hwba, RgbFormat, Rgba};
 
 impl From<&Hsla> for Rgba {
     fn from(hsla: &Hsla) -> Self {
-        let hue = hsla.hue() / 360;
+        let hue = hsla.hue() / 360.;
         let sat = hsla.sat();
         let lum = hsla.lum();
-        if sat.is_zero() {
-            let gray = lum * 255;
+        if sat == 0. {
+            let gray = lum * 255.;
             Self::new(gray, gray, gray, hsla.alpha(), RgbFormat::Name)
         } else {
-            fn hue2rgb(p: Rational, q: Rational, t: Rational) -> Rational {
-                let t = (t - t.floor()) * 6;
-                match t.to_integer() {
+            fn hue2rgb(p: f64, q: f64, t: f64) -> f64 {
+                let t = (t - t.floor()) * 6.;
+                match t as u8 {
                     0 => p + (q - p) * t,
                     1 | 2 => q,
-                    3 => p + (p - q) * (t - 4),
+                    3 => p + (p - q) * (t - 4.),
                     _ => p,
                 }
             }
-            let q = if lum < Rational::new(1, 2) {
-                lum * (sat + 1)
+            let q = if lum < 0.5 {
+                lum * (sat + 1.)
             } else {
                 lum + sat - lum * sat
             };
-            let p = lum * 2 - q;
-
+            let p = lum * 2. - q;
+            const THIRD: f64 = 1. / 3.;
             Self::new(
-                hue2rgb(p, q, hue + Rational::new(1, 3)) * 255,
-                hue2rgb(p, q, hue) * 255,
-                hue2rgb(p, q, hue - Rational::new(1, 3)) * 255,
+                hue2rgb(p, q, hue + THIRD) * 255.,
+                hue2rgb(p, q, hue) * 255.,
+                hue2rgb(p, q, hue - THIRD) * 255.,
                 hsla.alpha(),
                 RgbFormat::Name,
             )
@@ -46,34 +46,39 @@ impl From<&Hwba> for Hsla {
     fn from(hwba: &Hwba) -> Self {
         let w = hwba.whiteness();
         let b = hwba.blackness();
-        let l = (Rational::one() - b + w) / 2;
-        let s = if l.is_zero() || l.is_one() {
-            zero()
+        let l = (1. - b + w) / 2.;
+        let s = if l == 0. || l == 1. {
+            0.
         } else {
-            (Rational::one() - b - l) / std::cmp::min(l, Rational::one() - l)
+            (1. - b - l) / f64::min(l, 1. - l)
         };
-        Self::new(hwba.hue(), s, l, hwba.alpha(), false)
+        let (hue, lum) = if w.is_finite() && b.is_finite() {
+            (hwba.hue(), l)
+        } else {
+            (f64::NAN, f64::NAN)
+        };
+        Self::new(hue, s, lum, hwba.alpha(), false)
     }
 }
 
 impl From<&Rgba> for Hsla {
     fn from(rgba: &Rgba) -> Self {
         let (red, green, blue) =
-            (rgba.red() / 255, rgba.green() / 255, rgba.blue() / 255);
+            (rgba.red() / 255., rgba.green() / 255., rgba.blue() / 255.);
         let (max, min, largest) = max_min_largest(red, green, blue);
 
         if max == min {
-            Self::new(zero(), zero(), max, rgba.alpha(), false)
+            Self::new(0., 0., max, rgba.alpha(), false)
         } else {
             let d = max - min;
             let hue = match largest {
-                0 => (green - blue) / d + if green < blue { 6 } else { 0 },
-                1 => (blue - red) / d + 2,
-                _ => (red - green) / d + 4,
-            } * (360 / 6);
+                0 => (green - blue) / d + if green < blue { 6. } else { 0. },
+                1 => (blue - red) / d + 2.,
+                _ => (red - green) / d + 4.,
+            } * (360. / 6.);
             let mm = max + min;
-            let sat = d / if mm > one() { -mm + 2 } else { mm };
-            Self::new(hue, sat, mm / 2, rgba.alpha(), false)
+            let sat = d / if mm > 1. { -mm + 2. } else { mm };
+            Self::new(hue, sat, mm / 2., rgba.alpha(), false)
         }
     }
 }
@@ -81,11 +86,10 @@ impl From<&Rgba> for Hsla {
 impl From<&Rgba> for Hwba {
     fn from(rgba: &Rgba) -> Self {
         let hsla = Hsla::from(rgba);
-        let arr = [rgba.red(), rgba.blue(), rgba.green()];
         Self::new(
             hsla.hue(),
-            *arr.iter().min().unwrap() / 255,
-            Rational::one() - *arr.iter().max().unwrap() / 255,
+            rgba.red().min(rgba.blue()).min(rgba.green()) / 255.,
+            1. - rgba.red().max(rgba.blue()).max(rgba.green()) / 255.,
             hsla.alpha(),
         )
     }
@@ -93,24 +97,24 @@ impl From<&Rgba> for Hwba {
 impl From<&Hsla> for Hwba {
     fn from(hsla: &Hsla) -> Self {
         let rgba = Rgba::from(hsla);
-        let arr = [rgba.red(), rgba.blue(), rgba.green()];
         Self::new(
             hsla.hue(),
-            Rational::one() - *arr.iter().max().unwrap() / 255,
-            *arr.iter().min().unwrap() / 255,
+            rgba.red().min(rgba.blue()).min(rgba.green()) / 255.,
+            1. - rgba.red().max(rgba.blue()).max(rgba.green()) / 255.,
             hsla.alpha(),
         )
     }
 }
 
 // Find which of three numbers are largest and smallest
-fn max_min_largest(
-    a: Rational,
-    b: Rational,
-    c: Rational,
-) -> (Rational, Rational, u32) {
-    let v = [(a, 0), (b, 1), (c, 2)];
-    let max = v.iter().max().unwrap();
-    let min = v.iter().min().unwrap();
-    (max.0, min.0, max.1)
+fn max_min_largest(a: f64, b: f64, c: f64) -> (f64, f64, u32) {
+    let (max, largest) = if a > b && a > c {
+        (a, 0)
+    } else if b > a && b > c {
+        (b, 1)
+    } else {
+        (c, 2)
+    };
+    let min = a.min(b).min(c);
+    (max, min, largest)
 }

--- a/rsass/src/value/colors/hwba.rs
+++ b/rsass/src/value/colors/hwba.rs
@@ -1,6 +1,3 @@
-use super::Rational;
-use num_traits::{one, zero};
-
 /// A color defined by hue, whiteness, blackness, and alpha.
 ///
 /// All components are rational numbers.
@@ -8,12 +5,12 @@ use num_traits::{one, zero};
 /// The whiteness, blackness, and alpha are all in the zero to one
 /// range (inclusive), whith the additional invariant that whiteness +
 /// blackness will never be more than one.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Hwba {
-    hue: Rational,
-    w: Rational,
-    b: Rational,
-    alpha: Rational,
+    hue: f64,
+    w: f64,
+    b: f64,
+    alpha: f64,
 }
 
 impl Hwba {
@@ -21,16 +18,11 @@ impl Hwba {
     ///
     /// Hue is modulo 360 degrees.  Other inputs will be clamped to
     /// their ranges.
-    pub fn new(
-        hue: Rational,
-        w: Rational,
-        b: Rational,
-        alpha: Rational,
-    ) -> Self {
-        let mut w = w.clamp(zero(), one());
-        let mut b = b.clamp(zero(), one());
+    pub fn new(hue: f64, w: f64, b: f64, alpha: f64) -> Self {
+        let mut w = w;
+        let mut b = b;
         let wbsum = w + b;
-        if w + b > one() {
+        if !(wbsum < 1.) {
             w /= wbsum;
             b /= wbsum;
         }
@@ -38,36 +30,36 @@ impl Hwba {
             hue,
             w,
             b,
-            alpha: alpha.clamp(zero(), one()),
+            alpha: alpha.clamp(0., 1.),
         }
     }
 
     /// Get the hue of this color.
-    pub fn hue(&self) -> Rational {
+    pub fn hue(&self) -> f64 {
         self.hue
     }
     /// Get the whiteness of this color.
     ///
     /// Zero is no whiteness, one means this color is white.
-    pub fn whiteness(&self) -> Rational {
+    pub fn whiteness(&self) -> f64 {
         self.w
     }
     /// Get the black of this color.
     ///
     /// Zero is no blackness, one means this color is black.
-    pub fn blackness(&self) -> Rational {
+    pub fn blackness(&self) -> f64 {
         self.b
     }
     /// Get the alpha value of this color.
     ///
     /// Zero is fully transparent, one is fully opaque.
-    pub fn alpha(&self) -> Rational {
+    pub fn alpha(&self) -> f64 {
         self.alpha
     }
     /// Set the alpha value of this color.
     ///
     /// Zero is fully transparent, one is fully opaque.
-    pub fn set_alpha(&mut self, alpha: Rational) {
-        self.alpha = alpha.clamp(zero(), one());
+    pub fn set_alpha(&mut self, alpha: f64) {
+        self.alpha = alpha.clamp(0., 1.);
     }
 }

--- a/rsass/tests/spec/core_functions/color/adjust/hwb.rs
+++ b/rsass/tests/spec/core_functions/color/adjust/hwb.rs
@@ -90,7 +90,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -179,7 +178,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // wrong result
     fn max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/hsl/four_args/out_of_gamut.rs
+++ b/rsass/tests/spec/core_functions/color/hsl/four_args/out_of_gamut.rs
@@ -14,7 +14,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, 50%, calc(NaN))}\n"),
@@ -24,7 +23,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, 50%, calc(-infinity))}\n"),
@@ -34,7 +32,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, 50%, calc(infinity))}\n"),
@@ -77,7 +74,6 @@ mod hue {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: hsl(calc(NaN), 100%, 50%)}\n"),
@@ -87,7 +83,6 @@ mod hue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(calc(-infinity), 100%, 50%)}\n"),
@@ -97,7 +92,6 @@ mod hue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(calc(infinity), 100%, 50%)}\n"),
@@ -117,7 +111,6 @@ mod lightness {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, calc(NaN))}\n"),
@@ -127,7 +120,6 @@ mod lightness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, calc(-infinity))}\n"),
@@ -137,7 +129,6 @@ mod lightness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, 100%, calc(infinity))}\n"),
@@ -166,7 +157,6 @@ mod saturation {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, calc(NaN), 50%)}\n"),
@@ -176,7 +166,6 @@ mod saturation {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, calc(-infinity), 50%)}\n"),
@@ -186,7 +175,6 @@ mod saturation {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: hsl(0, calc(infinity), 50%)}\n"),

--- a/rsass/tests/spec/core_functions/color/hwb/four_args.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/four_args.rs
@@ -14,7 +14,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -25,7 +24,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -36,7 +34,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -174,7 +171,6 @@ mod blackness {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -185,7 +181,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -200,7 +195,6 @@ mod blackness {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -211,7 +205,6 @@ mod blackness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -222,7 +215,6 @@ mod blackness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -254,7 +246,7 @@ mod hue {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
+        #[ignore] // wrong result
         fn nan() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -265,7 +257,7 @@ mod hue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
+        #[ignore] // wrong result
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -276,7 +268,7 @@ mod hue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
+        #[ignore] // wrong result
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -316,7 +308,6 @@ mod whiteness {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -327,7 +318,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -342,7 +332,6 @@ mod whiteness {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -353,7 +342,6 @@ mod whiteness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\
@@ -364,7 +352,6 @@ mod whiteness {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/hwb/one_arg.rs
+++ b/rsass/tests/spec/core_functions/color/hwb/one_arg.rs
@@ -109,7 +109,6 @@ mod blackness {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -120,7 +119,6 @@ mod blackness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -382,7 +380,6 @@ mod whiteness {
     use super::runner;
 
     #[test]
-    #[ignore] // unexepected error
     fn above_max() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\
@@ -393,7 +390,6 @@ mod whiteness {
         );
     }
     #[test]
-    #[ignore] // unexepected error
     fn below_min() {
         assert_eq!(
             runner().ok("@use \"sass:color\";\

--- a/rsass/tests/spec/core_functions/color/rgb/four_args/clamped.rs
+++ b/rsass/tests/spec/core_functions/color/rgb/four_args/clamped.rs
@@ -32,7 +32,6 @@ mod alpha {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, 0, calc(NaN))}\n"),
@@ -42,7 +41,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, 0, calc(-infinity))}\n"),
@@ -52,7 +50,6 @@ mod alpha {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, 0, calc(infinity))}\n"),
@@ -72,7 +69,6 @@ mod blue {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, calc(NaN), 0.5)}\n"),
@@ -82,7 +78,6 @@ mod blue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, calc(-infinity), 0.5)}\n"),
@@ -92,7 +87,6 @@ mod blue {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, 0, calc(infinity), 0.5)}\n"),
@@ -121,7 +115,6 @@ mod green {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, calc(NaN), 0, 0.5)}\n"),
@@ -131,7 +124,6 @@ mod green {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, calc(-infinity), 0, 0.5)}\n"),
@@ -141,7 +133,6 @@ mod green {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(0, calc(infinity), 0, 0.5)}\n"),
@@ -170,7 +161,6 @@ mod red {
         use super::runner;
 
         #[test]
-        #[ignore] // unexepected error
         fn nan() {
             assert_eq!(
                 runner().ok("a {b: rgb(calc(NaN), 0, 0, 0.5)}\n"),
@@ -180,7 +170,6 @@ mod red {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn negative_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(calc(-infinity), 0, 0, 0.5)}\n"),
@@ -190,7 +179,6 @@ mod red {
             );
         }
         #[test]
-        #[ignore] // unexepected error
         fn positive_infinity() {
             assert_eq!(
                 runner().ok("a {b: rgb(calc(infinity), 0, 0, 0.5)}\n"),


### PR DESCRIPTION
A color channel can now be NaN or infinite, so represent them as f64 rather than as rationals.  This also makes the color structs smaller, as the rational numbers were 16 bytes each while a f64 is 8.