### PR TITLE
Update tests to 2024-09-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ project adheres to
 * Improved parse error handling (PR #201, Issue #141).
   Many parse errors now match the dart sass error message.
   Also allow "loud" comments in more places.
-* Updated sass-spec test suite to 2024-09-20.
+* Updated sass-spec test suite to 2024-09-30.
 
 
 ## Release 0.28.10

--- a/rsass/src/css/selectors/selector.rs
+++ b/rsass/src/css/selectors/selector.rs
@@ -525,12 +525,12 @@ fn unify_relbox(a: RelBox, b: RelBox) -> Option<Vec<RelBox>> {
         s.into_iter().map(|s| Box::new((kind, s))).collect()
     }
     if a.0 == b.0 && a.1.compound.is_rootish() && b.1.compound.is_rootish() {
-        return Some(as_rel_vec(a.0, b.1.unify(a.1)));
+        return Some(as_rel_vec(a.0, a.1.unify(b.1)));
     }
 
     Some(match (*a, *b) {
         ((k @ AdjacentSibling, a), (AdjacentSibling, b))
-        | ((k @ Parent, a), (Parent, b)) => as_rel_vec(k, b._unify(a)?),
+        | ((k @ Parent, a), (Parent, b)) => as_rel_vec(k, a._unify(b)?),
         ((Ancestor, a), (Ancestor, b)) => {
             if b.is_local_superselector(&a) {
                 as_rel_vec(Ancestor, a._unify(b)?)
@@ -560,10 +560,10 @@ fn unify_relbox(a: RelBox, b: RelBox) -> Option<Vec<RelBox>> {
                         .with_rel_of(k, a.clone())
                         .into_iter()
                         .chain(a.clone().with_rel_of(k, b.clone()))
-                        .chain(b.unify(a)),
+                        .chain(a.unify(b)),
                 )
             } else {
-                as_rel_vec(Sibling, b.unify(a))
+                as_rel_vec(Sibling, a.unify(b))
             }
         }
         ((a_k @ AdjacentSibling, a_s), (Sibling, b_s))
@@ -578,7 +578,7 @@ fn unify_relbox(a: RelBox, b: RelBox) -> Option<Vec<RelBox>> {
                     a_s.clone()
                         .with_rel_of(Sibling, b_s.clone())
                         .into_iter()
-                        .chain(a_s.unify(b_s)),
+                        .chain(b_s.unify(a_s)),
                 )
             }
         }

--- a/rsass/tests/spec/core_functions/selector/unify/complex/combinators/child.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/complex/combinators/child.rs
@@ -28,7 +28,7 @@ mod and_child {
             runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c > .d\", \".e > .f\")}\n"),
             "a {\
-         \n  b: .e.c > .d.f;\
+         \n  b: .c.e > .d.f;\
          \n}\n"
         );
     }
@@ -40,7 +40,7 @@ mod and_child {
              \na {b: selector.unify(\".c.s1-1 > .s1-2\", \".c.s2-1 > .s2-2\")}\n"
         ),
         "a {\
-         \n  b: .c.s2-1.s1-1 > .s1-2.s2-2;\
+         \n  b: .c.s1-1.s2-1 > .s1-2.s2-2;\
          \n}\n"
     );
     }

--- a/rsass/tests/spec/core_functions/selector/unify/complex/combinators/multiple.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/complex/combinators/multiple.rs
@@ -62,7 +62,7 @@ fn isolated() {
         runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c > .d + .e\", \".f .g ~ .h\")}\n"),
         "a {\
-         \n  b: .f .c > .g ~ .d + .e.h, .f .c > .d.g + .e.h;\
+         \n  b: .f .c > .g ~ .d + .e.h, .f .c > .g.d + .e.h;\
          \n}\n"
     );
 }

--- a/rsass/tests/spec/core_functions/selector/unify/complex/combinators/next_sibling.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/complex/combinators/next_sibling.rs
@@ -48,7 +48,7 @@ mod and_next_sibling {
             runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c + .d\", \".e + .f\")}\n"),
             "a {\
-         \n  b: .e.c + .d.f;\
+         \n  b: .c.e + .d.f;\
          \n}\n"
         );
     }
@@ -60,7 +60,7 @@ mod and_next_sibling {
              \na {b: selector.unify(\".c.s1-1 + .s1-2\", \".c.s2-1 + .s2-2\")}\n"
         ),
         "a {\
-         \n  b: .c.s2-1.s1-1 + .s1-2.s2-2;\
+         \n  b: .c.s1-1.s2-1 + .s1-2.s2-2;\
          \n}\n"
     );
     }
@@ -97,7 +97,7 @@ mod and_sibling {
             runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c + .d\", \".e ~ .f\")}\n"),
             "a {\
-         \n  b: .e ~ .c + .d.f, .c.e + .d.f;\
+         \n  b: .e ~ .c + .d.f, .e.c + .d.f;\
          \n}\n"
         );
     }
@@ -119,7 +119,7 @@ mod and_sibling {
              \na {b: selector.unify(\".c.s1-1 + .s1-2\", \".c.s2-1 ~ .s2-2\")}\n"
         ),
         "a {\
-         \n  b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s1-1.s2-1 + .s1-2.s2-2;\
+         \n  b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2;\
          \n}\n"
     );
     }

--- a/rsass/tests/spec/core_functions/selector/unify/complex/combinators/sibling.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/complex/combinators/sibling.rs
@@ -47,7 +47,7 @@ mod and_next_sibling {
             runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c ~ .d\", \".e + .f\")}\n"),
             "a {\
-         \n  b: .c ~ .e + .d.f, .e.c + .d.f;\
+         \n  b: .c ~ .e + .d.f, .c.e + .d.f;\
          \n}\n"
         );
     }
@@ -69,7 +69,7 @@ mod and_next_sibling {
              \na {b: selector.unify(\".c.s1-1 ~ .s1-2\", \".c.s2-1 + .s2-2\")}\n"
         ),
         "a {\
-         \n  b: .c.s1-1 ~ .c.s2-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2;\
+         \n  b: .c.s1-1 ~ .c.s2-1 + .s1-2.s2-2, .c.s1-1.s2-1 + .s1-2.s2-2;\
          \n}\n"
     );
     }
@@ -106,7 +106,7 @@ mod and_sibling {
             runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c ~ .d\", \".e ~ .f\")}\n"),
             "a {\
-         \n  b: .c ~ .e ~ .d.f, .e ~ .c ~ .d.f, .e.c ~ .d.f;\
+         \n  b: .c ~ .e ~ .d.f, .e ~ .c ~ .d.f, .c.e ~ .d.f;\
          \n}\n"
         );
     }
@@ -128,7 +128,7 @@ mod and_sibling {
              \na {b: selector.unify(\".c.s1-1 ~ .s1-2\", \".c.s2-1 ~ .s2-2\")}\n"
         ),
         "a {\
-         \n  b: .c.s1-1 ~ .c.s2-1 ~ .s1-2.s2-2, .c.s2-1 ~ .c.s1-1 ~ .s1-2.s2-2, .c.s2-1.s1-1 ~ .s1-2.s2-2;\
+         \n  b: .c.s1-1 ~ .c.s2-1 ~ .s1-2.s2-2, .c.s2-1 ~ .c.s1-1 ~ .s1-2.s2-2, .c.s1-1.s2-1 ~ .s1-2.s2-2;\
          \n}\n"
     );
     }

--- a/rsass/tests/spec/core_functions/selector/unify/complex/rootish.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/complex/rootish.rs
@@ -34,7 +34,7 @@ fn mixed() {
         runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\":root .c .d\", \":scope .e .f\")}\n"),
         "a {\
-         \n  b: :scope:root .c .e .d.f, :scope:root .e .c .d.f;\
+         \n  b: :root:scope .c .e .d.f, :root:scope .e .c .d.f;\
          \n}\n"
     );
 }
@@ -52,7 +52,7 @@ mod root {
                 runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c:root .d\", \".e:root .f\")}\n"),
                 "a {\
-         \n  b: .e.c:root .d.f;\
+         \n  b: .c.e:root .d.f;\
          \n}\n"
             );
         }

--- a/rsass/tests/spec/core_functions/selector/unify/compound.rs
+++ b/rsass/tests/spec/core_functions/selector/unify/compound.rs
@@ -5,15 +5,50 @@ fn runner() -> crate::TestRunner {
     super::runner().with_cwd("compound")
 }
 
-#[test]
-fn full_overlap() {
-    assert_eq!(
-        runner().ok("@use \"sass:selector\";\
+mod full_overlap {
+    #[allow(unused)]
+    use super::runner;
+
+    #[test]
+    fn class() {
+        assert_eq!(
+            runner().ok("@use \"sass:selector\";\
              \na {b: selector.unify(\".c.d\", \".c.d\")}\n"),
-        "a {\
+            "a {\
          \n  b: .c.d;\
          \n}\n"
-    );
+        );
+    }
+    #[test]
+    fn pseudo_class() {
+        assert_eq!(
+            runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\".c:d\", \".c:d\")}\n"),
+            "a {\
+         \n  b: .c:d;\
+         \n}\n"
+        );
+    }
+    #[test]
+    fn pseudo_element() {
+        assert_eq!(
+            runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\".c::d\", \".c::d\")}\n"),
+            "a {\
+         \n  b: .c::d;\
+         \n}\n"
+        );
+    }
+    #[test]
+    fn pseudo_selector_and_class() {
+        assert_eq!(
+            runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\".c:d::e\", \".c:d::e\")}\n"),
+            "a {\
+         \n  b: .c:d::e;\
+         \n}\n"
+        );
+    }
 }
 #[test]
 fn no_overlap() {
@@ -29,6 +64,93 @@ mod order {
     #[allow(unused)]
     use super::runner;
 
+    mod do_not_cross_pseudo_element {
+        #[allow(unused)]
+        use super::runner;
+
+        mod pseudo_class_and_element {
+            #[allow(unused)]
+            use super::runner;
+
+            #[test]
+            fn into_different_pseudo_element_and_different_pseudo_class() {
+                assert_eq!(
+                    runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\"::foo:bar\", \"::other:baz\")}\n"),
+                    ""
+                );
+            }
+            #[test]
+            #[ignore] // wrong result
+            fn into_pseudo_element() {
+                assert_eq!(
+                    runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\"::bar:baz\", \":foo\")}\n"),
+                    "a {\
+         \n  b: :foo::bar:baz;\
+         \n}\n"
+                );
+            }
+            #[test]
+            #[ignore] // wrong result
+            fn into_same_pseudo_element_and_different_pseudo_class() {
+                assert_eq!(
+                    runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\"::foo:bar\", \"::foo:baz\")}\n"),
+                    "a {\
+         \n  b: ::foo:bar:baz;\
+         \n}\n"
+                );
+            }
+            #[test]
+            #[ignore] // wrong result
+            fn into_simple() {
+                assert_eq!(
+                    runner().ok(
+                        "@use \"sass:selector\";\
+             \na {b: selector.unify(\".x::scrollbar:horizontal\", \".y\")}\n"
+                    ),
+                    "a {\
+         \n  b: .x.y::scrollbar:horizontal;\
+         \n}\n"
+                );
+            }
+        }
+        mod pseudo_element {
+            #[allow(unused)]
+            use super::runner;
+
+            #[test]
+            #[ignore] // wrong result
+            fn into_pseudo_class_and_element() {
+                assert_eq!(
+                    runner().ok("@use \"sass:selector\";\
+             \na {b: selector.unify(\":foo\", \"::bar:baz\")}\n"),
+                    "a {\
+         \n  b: :foo::bar:baz;\
+         \n}\n"
+                );
+            }
+        }
+        mod simple {
+            #[allow(unused)]
+            use super::runner;
+
+            #[test]
+            #[ignore] // wrong result
+            fn into_pseudo_class_and_element() {
+                assert_eq!(
+                    runner().ok(
+                        "@use \"sass:selector\";\
+             \na {b: selector.unify(\".x\", \".y::scrollbar:horizontal\")}\n"
+                    ),
+                    "a {\
+         \n  b: .x.y::scrollbar:horizontal;\
+         \n}\n"
+                );
+            }
+        }
+    }
     #[test]
     fn element_at_start() {
         assert_eq!(

--- a/rsass/tests/spec/main.rs
+++ b/rsass/tests/spec/main.rs
@@ -1,5 +1,5 @@
 //! Tests auto-converted from "sass-spec/spec"
-//! version ddf4b0999, 2024-09-20 20:55:56 +0000.
+//! version 83bd49982, 2024-09-30 17:39:23 -0700.
 //! See <https://github.com/sass/sass-spec> for source material.\n
 //! The following tests are excluded from conversion:
 //! ["directives/extend", "libsass-todo-issues/issue_221260.hrx", "libsass-todo-issues/issue_221262.hrx", "libsass-todo-issues/issue_221264.hrx", "libsass-todo-issues/issue_221292.hrx", "libsass/unicode-bom/utf-16-big", "libsass/unicode-bom/utf-16-little", "non_conformant/scss/huge.hrx", "non_conformant/scss/multiline-var.hrx"]

--- a/rsass/tests/spec/non_conformant/extend_tests/t127_test_nested_extender_with_early_child_selector.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t127_test_nested_extender_with_early_child_selector.rs
@@ -12,7 +12,7 @@ fn test() {
     assert_eq!(
         runner().ok(".foo > .bar {a: b}\
              \n.bip > .baz {@extend .bar}\n"),
-        ".foo > .bar, .bip.foo > .baz {\
+        ".foo > .bar, .foo.bip > .baz {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t142_test_combinator_unification_double_tilde.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t142_test_combinator_unification_double_tilde.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\
              \n.b ~ y {@extend x}\n"),
-        ".a ~ x, .a ~ .b ~ y, .b ~ .a ~ y, .b.a ~ y {\
+        ".a ~ x, .a ~ .b ~ y, .b ~ .a ~ y, .a.b ~ y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t146_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t146_test_combinator_unification_tilde_plus.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\
              \n.b ~ y {@extend x}\n"),
-        ".a + x, .b ~ .a + y, .a.b + y {\
+        ".a + x, .b ~ .a + y, .b.a + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t150_test_combinator_unification_tilde_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t150_test_combinator_unification_tilde_plus.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a ~ x {a: b}\
              \n.b + y {@extend x}\n"),
-        ".a ~ x, .a ~ .b + y, .b.a + y {\
+        ".a ~ x, .a ~ .b + y, .a.b + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t156_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t156_test_combinator_unification_double_angle.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a.b > x {a: b}\
              \n.b > y {@extend x}\n"),
-        ".a.b > x, .b.a > y {\
+        ".a.b > x, .a.b > y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t158_test_combinator_unification_double_angle.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t158_test_combinator_unification_double_angle.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a > x {a: b}\
              \n.b > y {@extend x}\n"),
-        ".a > x, .b.a > y {\
+        ".a > x, .a.b > y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t160_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t160_test_combinator_unification_double_plus.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a.b + x {a: b}\
              \n.b + y {@extend x}\n"),
-        ".a.b + x, .b.a + y {\
+        ".a.b + x, .a.b + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t162_test_combinator_unification_double_plus.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t162_test_combinator_unification_double_plus.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a + x {a: b}\
              \n.b + y {@extend x}\n"),
-        ".a + x, .b.a + y {\
+        ".a + x, .a.b + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t176_test_combinator_unification_nested.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t176_test_combinator_unification_nested.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a > .b + x {a: b}\
              \n.c > .d + y {@extend x}\n"),
-        ".a > .b + x, .c.a > .d.b + y {\
+        ".a > .b + x, .a.c > .b.d + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t177_test_combinator_unification_nested.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t177_test_combinator_unification_nested.rs
@@ -11,7 +11,7 @@ fn test() {
     assert_eq!(
         runner().ok(".a > .b + x {a: b}\
              \n.c > y {@extend x}\n"),
-        ".a > .b + x, .c.a > .b + y {\
+        ".a > .b + x, .a.c > .b + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t178_test_combinator_unification_with_newlines.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t178_test_combinator_unification_with_newlines.rs
@@ -15,7 +15,7 @@ fn test() {
              \n.c\
              \n> .d +\
              \ny {@extend x}\n"),
-        ".a > .b + x, .c.a > .d.b + y {\
+        ".a > .b + x, .a.c > .b.d + y {\
          \n  a: b;\
          \n}\n"
     );

--- a/rsass/tests/spec/non_conformant/extend_tests/t238_unify_root_pseudoelement.rs
+++ b/rsass/tests/spec/non_conformant/extend_tests/t238_unify_root_pseudoelement.rs
@@ -26,13 +26,13 @@ fn test() {
         ":root .foo-1, :root .bar-1 .baz-1 {\
          \n  test: 1;\
          \n}\
-         \n.foo-2:root .bar-2, .baz-2.foo-2:root .bang-2 {\
+         \n.foo-2:root .bar-2, .foo-2.baz-2:root .bang-2 {\
          \n  test: 2;\
          \n}\
          \nhtml:root .bar-3 {\
          \n  test: 3;\
          \n}\
-         \n.foo-4:root > .bar-4 .x-4, .baz-4.foo-4:root > .bar-4 .bang-4 .y-4 {\
+         \n.foo-4:root > .bar-4 .x-4, .foo-4.baz-4:root > .bar-4 .bang-4 .y-4 {\
          \n  test: 4;\
          \n}\n"
     );


### PR DESCRIPTION
Some order of unified selectors was cleaned up in dart sass, and can now be cleaned up in rsass.