### PR TITLE
Fix regression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to
 * Avoid an unnecessary proc macro, making rsass the library
   [free of syn](https://github.com/fasterthanlime/free-of-syn)
   (Note; the cli and the proc macro still uses syn).
+* Fixed a regression where one but not all selectors in a selectorset
+  contained a backref (PR #212).
 * Updated sass-spec test suite to 2025-03-17.
 
 

--- a/rsass/src/css/selectors/context.rs
+++ b/rsass/src/css/selectors/context.rs
@@ -26,13 +26,7 @@ impl SelectorCtx {
 
     /// Evaluate selectors inside this context.
     pub(crate) fn nest(&self, selectors: SelectorSet) -> CssSelectorSet {
-        if selectors.has_backref() {
-            CssSelectorSet {
-                s: selectors.resolve_ref(self.get_backref()),
-            }
-        } else {
-            self.s.nest(selectors)
-        }
+        self.s.nest(selectors, self.get_backref())
     }
     pub(crate) fn at_root(&self, selectors: SelectorSet) -> Self {
         let backref = self.get_backref();

--- a/rsass/src/css/selectors/cssselectorset.rs
+++ b/rsass/src/css/selectors/cssselectorset.rs
@@ -103,13 +103,17 @@ impl CssSelectorSet {
 
     /// Nest `other` selectors inside this as though they were nested
     /// within one another in the stylesheet.
-    pub(crate) fn nest(&self, other: SelectorSet) -> Self {
+    pub(crate) fn nest(
+        &self,
+        other: SelectorSet,
+        backref: &CssSelectorSet,
+    ) -> Self {
         let mut parts = other
             .s
             .into_iter()
             .map(|o| {
                 if o.has_backref() {
-                    o.resolve_ref(self)
+                    o.resolve_ref(backref)
                 } else {
                     self.s.s.iter().map(|s| s.nest(&o)).collect()
                 }

--- a/rsass/src/sass/functions/selector.rs
+++ b/rsass/src/sass/functions/selector.rs
@@ -33,7 +33,7 @@ pub fn create_module() -> Scope {
             .ok_or("At least one selector must be passed.")
             .named(name!(selectors))?;
         let first = CssSelectorSet::try_from(first)?;
-        Ok(v.fold(first, |b, e| b.nest(e)).into())
+        Ok(v.fold(first, |b, e| b.nest(e, &b)).into())
     });
     def!(f, parse(selector), |s| {
         CssSelectorSet::parse_value(s.get(name!(selector))?)

--- a/rsass/tests/misc/scss.rs
+++ b/rsass/tests/misc/scss.rs
@@ -1,5 +1,20 @@
-//! Tests from spec/scss
+//! Some scss tests of my own.
 use rsass::compile_scss;
+
+/// This simple test don't seem to exist in the spec suite?
+#[test]
+fn backref_and_comma() {
+    check(
+        "body {\
+         \n  &.simple p, section {\
+         \n    margin: auto 2em;\
+         \n  }\
+         \n}\n",
+        "body.simple p, body section {\
+         \n  margin: auto 2em;\
+         \n}\n",
+    );
+}
 
 /// My own addition
 #[test]


### PR DESCRIPTION
If one but not all selectors in a selectorset contains a backref, the ones that don't should still be evaluated as childs of the parent.

```scss
body {
  &.simple p, section {
    margin: auto 2em;
  }
}
```
Should be evaluated to:

```css
body.simple p, body section {
  margin: auto 2em;
}
```