### PR TITLE
rsass-cli: bump version to match library (0.29.3-PRE)

### DIFF
--- a/rsass-cli/Cargo.toml
+++ b/rsass-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsass-cli"
-version = "0.29.1-PRE"
+version = "0.29.3-PRE"
 authors = ["Rasmus Kaj <rasmus@krats.se>"]
 description = "Commandline interface for rsass, compiles scss to css."
 categories = ["command-line-utilities", "web-programming"]


### PR DESCRIPTION
## Summary

The `rsass-cli` sub-crate's `Cargo.toml` has carried a stale version string (`"0.29.1-PRE"`) through multiple library releases — the root library `Cargo.toml` has advanced `0.29.0` → `0.29.1` → `0.29.2` → `0.29.3-PRE` while `rsass-cli` stayed at `0.29.1-PRE`.

Bump it to `0.29.3-PRE` to match.

## Why it matters

The practical impact is that the `rsass` CLI binary's `--version` output no longer reflects the actual release version. Downstream packagers running version-check tests (e.g. Chainguard's stereo `test/tw/ver-check`) see drift: the binary reports `0.29.1-PRE` while the package was built from the `v0.29.2` (or later) source tag.

```
$ rsass --version
rsass-cli 0.29.1-PRE      # ← what the binary built at v0.29.2 reports
```

## How surfaced

Found by Chainguard's reverse-dependency testing of all 8k+ packages in our distribution

## Suggested follow-up (optional, not in this PR)

Consider using workspace-level version inheritance to prevent recurrence:

```toml
# In rsass-cli/Cargo.toml:
[package]
version.workspace = true

# In workspace root Cargo.toml, define [workspace.package].version
```

This would let `cli` and library version-bump together automatically on each release.

This PR is just the minimal pin-bump to unblock the immediate case. Happy to follow up with the workspace-inheritance refactor if you'd like.